### PR TITLE
Cosbench integration with CBT

### DIFF
--- a/benchmark/cosbench.py
+++ b/benchmark/cosbench.py
@@ -1,0 +1,223 @@
+import subprocess
+import common
+import settings
+import monitoring
+import os, sys
+import time
+import threading
+import lxml.etree as ET
+import re
+import time
+
+from cluster.ceph import Ceph
+from benchmark import Benchmark
+
+class Cosbench(Benchmark):
+
+    def __init__(self, cluster, config):
+        super(Cosbench, self).__init__(cluster, config)
+
+        config = self.parse_conf(config)
+
+        self.op_size = config["obj_size"]
+        self.total_procs = config["workers"]
+        self.containers = config["containers_max"]
+        self.objects = config["objects_max"]
+        self.mode = config["mode"]
+
+        self.run_dir = '%s/osd_ra-%08d/op_size-%s/concurrent_procs-%03d/containers-%05d/objects-%05d/%s' % (self.run_dir, int(self.osd_ra), self.op_size, int(self.total_procs), int(self.containers),int(self.objects), self.mode)
+        self.out_dir = '%s/osd_ra-%08d/op_size-%s/concurrent_procs-%03d/containers-%05d/objects-%05d/%s' % (self.archive_dir, int(self.osd_ra), self.op_size, int(self.total_procs),  int(self.containers),int(self.objects), self.mode)
+
+    def prerun_check(self):
+        #1. check cosbench
+        if not self.check_workload_status():
+            sys.exit()
+        #2. check rgw
+        cosconf = {}
+        for param in self.config["auth"]["config"].split(';'):
+            try:
+                key, value = param.split('=')
+                cosconf[key] = value
+            except:
+                pass
+        print cosconf
+        if "username" in cosconf and "password" in cosconf and "url" in cosconf:
+            stdout, stderr = common.pdsh(self.config["controller"],"curl -D - -H 'X-Auth-User: %s' -H 'X-Auth-Key: %s' %s" % (cosconf["username"], cosconf["password"], cosconf["url"])).communicate()
+        else:
+            print "[ERROR]Auth Configuration in Yaml file is not in correct format"
+            sys.exit()
+        if re.search('(refused|error)', stderr):
+            print "[ERROR]Cosbench connect to Radosgw Connection Failed"
+            print stderr
+            sys.exit()
+        if re.search("AccessDenied", stdout):
+            print "[ERROR]Cosbench connect to Radosgw Auth Failed"
+            print stdout
+            sys.exit()
+
+    def exists(self):
+        if os.path.exists(self.out_dir):
+            print 'Skipping existing test in %s.' % self.out_dir
+            return True
+        return False
+
+    def choose_template(self, temp_name, conf):
+        template = {
+            "default":{
+                "description": conf["mode"],
+                "name": "%s_%scon_%sobj_%s_%dw" % (conf["mode"], conf["containers_max"], conf["objects_max"], conf["obj_size"], conf["workers"]),
+                "storage": {"type":"swift", "config":"timeout=300000" },
+                "auth": {"type":"swauth", "config":"%s" % (conf["auth"]["config"])},
+                "workflow": {
+                    "workstage": [{
+                        "name": "init",
+                        "work": {"type":"init", "workers":conf["workers"], "config":"containers=r(1,%s);cprefix=%s-%s" % (conf["containers_max"], conf["obj_size"], conf["mode"])}
+                    },{
+                        "name": "main",
+                        "work": {"rampup":conf["rampup"], "rampdown":conf["rampdown"], "name":conf["obj_size"], "workers":conf["workers"], "runtime":conf["runtime"],
+                            "operation": {
+                                "config":"containers=%s;objects=%s;cprefix=%s-%s;sizes=c(%s)%s" % (conf["containers"], conf["objects"], conf["obj_size"], conf["mode"], conf["obj_size_num"], conf["obj_size_unit"]),
+                                "ratio":conf["ratio"],
+                                "type":conf["mode"]
+                            }
+                        }
+                    }]
+                }
+            }
+        }
+        if temp_name in template:
+            return template[temp_name]
+
+    def parse_conf(self, conf):
+        if "containers" in conf:
+            m = re.findall("(\w{1})\((\d+),(\d+)\)", conf["containers"])
+            if m:
+                conf["containers_method"] = m[0][0]
+                conf["containers_min"] = m[0][1]
+                conf["containers_max"] = m[0][2]
+        if "objects" in conf:
+            m = re.findall("(\w{1})\((\d+),(\d+)\)", conf["objects"])
+            if m:
+                conf["objects_method"] = m[0][0]
+                conf["objects_min"] = m[0][1]
+                conf["objects_max"] = m[0][2]
+        if "obj_size" in conf:
+            m = re.findall("(\d+)(\w+)", conf["obj_size"])
+            if m:
+                conf["obj_size_num"] = m[0][0]
+                conf["obj_size_unit"] = m[0][1]
+        return conf
+
+    def initialize(self):
+        super(Cosbench, self).initialize()
+
+        print 'Running cosbench and radosgw check.'
+        self.prerun_check()
+
+        print 'Running scrub monitoring.'
+        monitoring.start("%s/scrub_monitoring" % self.run_dir)
+        self.cluster.check_scrub()
+        monitoring.stop()
+
+        print 'Pausing for 60s for idle monitoring.'
+        monitoring.start("%s/idle_monitoring" % self.run_dir)
+        time.sleep(60)
+        monitoring.stop()
+
+        common.sync_files('%s' % self.run_dir, self.out_dir)
+
+        # Create the run directory
+        common.make_remote_dir(self.run_dir)
+
+        conf = self.config
+        if not self.config["template"]:
+            self.config["template"] = "default"
+        self.config["workload"] = self.choose_template("default", conf)
+        self.prepare_xml(self.config["workload"])
+        return True
+
+    #function use_template, set_leaf and run_content, add_leaf_to_tree all used for generate a cosbench xml.
+    def prepare_xml(self, leaves):
+        conf = self.config
+        root = ET.Element("workload")
+        parent = root
+        self.add_leaf_to_tree(leaves, parent)
+        self.config["xml_name"] = leaves["name"]
+        tree = ET.ElementTree(root)
+        tree.write("%s/%s.xml" % (conf["cosbench_xml_dir"], leaves["name"]),pretty_print=True)
+        print "Write xml conf to %s/%s.xml" % (conf["cosbench_xml_dir"], leaves["name"])
+
+    def add_leaf_to_tree(self, leaves, parent):
+        for leaf, leaf_content in leaves.iteritems():
+            if isinstance(leaf_content, str) or isinstance(leaf_content, int):
+                parent.set(leaf, str(leaf_content))
+            elif isinstance(leaf_content, list):
+                leaves = leaf_content
+                for leaf_content in leaves:
+                    self.add_leaf_to_tree(leaf_content, ET.SubElement(parent, leaf))
+            else:
+                self.add_leaf_to_tree(leaf_content, ET.SubElement(parent, leaf))
+
+    def run(self):
+        super(Cosbench, self).run()
+        self.dropcaches()
+        self.cluster.dump_config(self.run_dir)
+        monitoring.start(self.run_dir)
+
+        # Run cosbench test
+        try:
+            self._run()
+        except KeyboardInterrupt:
+            print "[WARNING] accept keyboard interrupt, cancel this run"
+            conf = self.config
+            stdout, stderr = common.pdsh(conf["controller"],'sh %s/cli.sh cancel %s' % (conf["cosbench_dir"], self.runid)).communicate()
+            print "[LOG]%s" % stdout
+
+        self.check_workload_status()
+
+        time.sleep(5)
+
+        monitoring.stop(self.run_dir)
+        self.cluster.dump_historic_ops(self.run_dir)
+        common.sync_files('%s/*' % self.run_dir, self.out_dir)
+        common.sync_files('%s/archive/%s*' % (self.config["cosbench_dir"], self.runid), self.out_dir)
+
+    def check_workload_status(self):
+        wait = True
+        try:
+            self.runid
+        except:
+            wait = False
+        while wait:
+            stdout, stderr = common.pdsh(self.config["controller"],"sh %s/cli.sh info | grep %s | awk '{print $8}'" % (self.config["cosbench_dir"], self.runid)).communicate()
+            if stderr:
+                print "[ERROR]Cosbench Deamon is not running on %s" % self.config["controller"]
+                return False
+            try:
+                status = stdout.split(':')[1]
+                if status.strip() != 'PROCESSING':
+                    wait = False
+            except:
+                wait = False
+            time.sleep(1)
+        stdout, stderr = common.pdsh(self.config["controller"],"sh %s/cli.sh info " % (self.config["cosbench_dir"])).communicate()
+        print stdout
+        return True
+
+    def _run(self):
+        conf = self.config
+        stdout, stderr = common.pdsh(conf["controller"],'sh %s/cli.sh submit %s/%s.xml' % (conf["cosbench_dir"], conf["cosbench_xml_dir"], conf["xml_name"])).communicate()
+        m = re.findall('Accepted with ID:\s*(\w+)', stdout )
+        if not m:
+            print "[ERROR] cosbench start failing with error: %s" % stderr
+            sys.exit()
+        self.runid = m[0]
+        print "[LOG] cosbench job start, job number %s" % self.runid
+        wait_time = conf["rampup"]+conf["rampdown"]+conf["runtime"] 
+        print "====== cosbench job: %s started ======" % (conf["xml_name"])
+        print "wait %d secs to finish the test" % (wait_time)
+        print "You can monitor the runtime status and results on http://localhost:19088/controller"
+        time.sleep(wait_time)
+
+    def __str__(self):
+        return "%s\n%s\n%s" % (self.run_dir, self.out_dir, super(Cosbench, self).__str__())

--- a/benchmarkfactory.py
+++ b/benchmarkfactory.py
@@ -5,6 +5,7 @@ from benchmark.radosbench import Radosbench
 from benchmark.rbdfio import RbdFio 
 from benchmark.kvmrbdfio import KvmRbdFio
 from benchmark.librbdfio import LibrbdFio
+from benchmark.cosbench import Cosbench
 
 def getAll(cluster, iteration):
     objects = []
@@ -43,3 +44,5 @@ def getObject(cluster, benchmark, bconfig):
         return KvmRbdFio(cluster, bconfig)
     if benchmark == 'librbdfio':
         return LibrbdFio(cluster, bconfig)
+    if benchmark == 'cosbench':
+        return Cosbench(cluster, bconfig)

--- a/docs/cosbench.README
+++ b/docs/cosbench.README
@@ -1,0 +1,190 @@
+--------------
+ Introduction
+--------------
+
+Cosbench is a distributed benchmark tool to test cloud object storage systems, 
+in CBT toolset, cosbench benchmark will use radosgw api to generate workload.
+
+------------
+ Components
+------------
+
+1.  Driver (also referred to as COSBench Driver or Load Generator):
+o  Responsible for workload generation, issuing operations to target cloud object storage,
+and collecting performance statistics.
+o  Can be accessed via http://<driver-host>:18088/driver/index.html.
+
+2.  Controller (also referred to as COSBench Controller):
+o  Responsible for coordinating drivers to collectively execute a workload, collecting and 
+aggregating runtime status or benchmark results from driver instances, and accepting 
+workload submissions.
+o  Can be accessed via http://<controller-host>:19088/controller/index.html. 
+
+---------------------
+ System Requirements
+---------------------
+
+NOTE: The current release of COSBench features Ubuntu* 12.04.1 LTS Desktop, but the COSBench 
+development team assumes that organizations will install using various OSs and contribute related 
+feedback to the community.
+o  Ubuntu 12.04.1 LTS Desktop
+o  Java* Runtime Environment 1.6 or later
+o  Curl 7.22.0 or later
+o  Csvtool if processing generated csv files is required.
+o  Free TCP port (ensure these ports are accessible non-locally):  
+    o  On COSBench controller machine: 19088
+    o  On COSBench driver machines: 18088
+
+------------------
+ Install Cosbench
+------------------
+
+Intel source code for COSBench is being released under the Apache 2.0 license, and hosted at 
+http://github.com/intel-cloud/cosbench/.
+
+1. installing the requirements
+   sudo apt-get install openjdk-7-jre
+   sudo apt-get install curl
+
+2. install cosbench
+    unzip ${cosbench-zip}
+    cd ${cosbench-zip}
+    chmod +x *.sh
+
+    unset http_proxy
+    vim conf/controller.conf 
+    
+****** Edit content like below ******
+    [controller]
+    drivers = 2
+    log_level = INFO
+    log_file = log/system.log
+    archive_dir = archive
+    
+    [driver1]
+    name = driver1
+    url = http://127.0.0.1:18088/driver
+    
+    [driver2]
+    name = driver2
+    url = http://192.168.5.252:18088/driver
+ ************************************
+
+    ssh to all driver nodes
+    vim conf/driver.conf 
+
+ ****** Edit content like below ******
+    [driver]
+    log_level = INFO
+    url=http://192.168.5.251:18088:driver
+ *************************************
+
+    sh start-all.sh
+
+ ****** see output like below ******
+
+    root@client01:~/0.4.1.0# ./start-all.sh 
+    Launching osgi framwork ... 
+    Successfully launched osgi framework!
+    Booting cosbench driver ... 
+    .
+    Starting    cosbench-log_0.4.1    [OK]
+    Starting    cosbench-tomcat_0.4.1    [OK]
+    Starting    cosbench-config_0.4.1    [OK]
+    Starting    cosbench-http_0.4.1    [OK]
+    Starting    cosbench-cdmi-util_0.4.1    [OK]
+    Starting    cosbench-core_0.4.1    [OK]
+    Starting    cosbench-core-web_0.4.1    [OK]
+    Starting    cosbench-api_0.4.1    [OK]
+    Starting    cosbench-mock_0.4.1    [OK]
+    Starting    cosbench-ampli_0.4.1    [OK]
+    Starting    cosbench-swift_0.4.1    [OK]
+    Starting    cosbench-keystone_0.4.1    [OK]
+    Starting    cosbench-httpauth_0.4.1    [OK]
+    Starting    cosbench-s3_0.4.1    [OK]
+    Starting    cosbench-librados_0.4.1    [OK]
+    Starting    cosbench-scality_0.4.1    [OK]
+    Starting    cosbench-cdmi-swift_0.4.1    [OK]
+    Starting    cosbench-cdmi-base_0.4.1    [OK]
+    Starting    cosbench-driver_0.4.1    [OK]
+    Starting    cosbench-driver-web_0.4.1    [OK]
+    Successfully started cosbench driver!
+    Listening on port 0.0.0.0/0.0.0.0:18089 ... 
+    Persistence bundle starting...
+    Persistence bundle started.
+    ----------------------------------------------
+    !!! Service will listen on web port: 18088 !!!
+    ----------------------------------------------
+    
+    ======================================================
+    
+    Launching osgi framwork ... 
+    Successfully launched osgi framework!
+    Booting cosbench controller ... 
+    .
+    Starting    cosbench-log_0.4.1    [OK]
+    Starting    cosbench-tomcat_0.4.1    [OK]
+    Starting    cosbench-config_0.4.1    [OK]
+    Starting    cosbench-core_0.4.1    [OK]
+    Starting    cosbench-core-web_0.4.1    [OK]
+    Starting    cosbench-controller_0.4.1    [OK]
+    Starting    cosbench-controller-web_0.4.1    [OK]
+    Successfully started cosbench controller!
+    Listening on port 0.0.0.0/0.0.0.0:19089 ... 
+    Persistence bundle starting...
+    Persistence bundle started.
+    ----------------------------------------------
+    !!! Service will listen on web port: 19088 !!!
+    ----------------------------------------------
+ 
+3.  Create Radosgw User for cosbench
+    radosgw-admin user create --uid="cosbench" --display-name="cosbench"
+    radosgw-admin subuser create --uid=cosbench --subuser=cosbench:operator --access=full
+    radosgw-admin key create --uid=cosbench --subuser=cosbench:operator --key-type=swift
+    radosgw-admin user modify --uid=cosbench --max-buckets=100000
+    radosgw-admin subuser modify --uid=cosbench --subuser=cosbench:operator --secret=intel2012 --key-type=swift
+
+4.  Check if radosgw can be accessed with cosbench auth
+    curl -D - -H 'X-Auth-User: cosbench:operator' -H 'X-Auth-Key: intel2012' http://${radosgw.server}/auth/v1.0"
+
+******* see output like below ******
+
+    HTTP/1.1 204 No Content
+    Date: Fri, 10 Apr 2015 02:48:58 GMT
+    Server: Apache/2.4.7 (Ubuntu)
+    X-Storage-Url: http://127.0.0.1/swift/v1
+    X-Storage-Token: AUTH_rgwtk11000000636f7362656e63683a6f70657261746f728d2a9e3caa0ce94f9a8b28552070872ef67d9919008df3868dd4a2b09c7ddfed2ce2f7d6
+    X-Auth-Token: AUTH_rgwtk11000000636f7362656e63683a6f70657261746f728d2a9e3caa0ce94f9a8b28552070872ef67d9919008df3868dd4a2b09c7ddfed2ce2f7d6
+    Content-Type: application/json
+************************************
+
+5.  cosbench param config in yaml
+
+benchmarks:
+  cosbench: 
+    cosbench_dir: /root/0.4.1.0
+    cosbench_xml_dir: /home/cephperf/plugin/cbt/conf/cosbench/
+    controller: client01
+    auth:
+      config: username=cosbench:operator;password=intel2012;url=http://192.168.5.251/auth/v1.0;retry=9
+    obj_size: [128KB]
+    template: [default]
+    mode: [write]
+    ratio: [100]
+    rampup: 10
+    runtime: 10
+    rampdown: 10
+    workers: [20]
+    containers: ["u(1,100)"]
+    objects: ["u(1,100)"]
+    
+ ****** Parameter intro ******
+    [cosbench_dir]: where cosbench execute files are
+    [cosbench_xml_dir]: cosbench start a test from xml file, so in cbt, we will translate yaml
+                        to xml, this indicates where cosbench xml files will creat to
+    [controller]: cosbench need a controller node to monitor and submit test jobs, this is where 
+                  cosbench controller daemon runs
+    [auth][config]: specify radosgw username and passwork and radosgw url for cosbench
+    [template]: Cosbench can support multi workstage, so user can design complex workload like 
+                seqwrite in 1st workstage, and randread in 2nd workstage then randwrite in 3rd 
+                workstage, etc. But in CBT toolset, currently we only support 2 workstage template.


### PR DESCRIPTION
1. Add cosbench config field in yaml
2. Add cosbench guidance in docs/cosbench.README
3. Now, adding cosbench field in CBT yaml, cbt can start a cosbench,
   and collect system metrics and cosbench results in the end

Added fields in yaml lists below:

benchmarks:
  cosbench:
    cosbench_dir: /mnt/data/0.4.1.0
    #cosbench_dir: /root/0.4.1.0
    cosbench_xml_dir: /home/cephperf/plugin/cbt/conf/cosbench/
    controller: cceph01
    auth:
      config: username=cosbench:operator;password=intel2012;url=http://192.168.5.251/auth/v1.0;retry=9
    obj_size: [128KB,10MB]
    template: [default]
    mode: [write, read]
    ratio: [100]
    rampup: 30
    runtime: 300
    rampdown: 90
    workers: [10, 20]
    containers: ["u(1,100)", "u(1,10000)"]
    objects: ["u(1,100)", "u(1,10000)"]

Signed-off-by: Chendi.Xue <chendi.xue@intel.com>