### PR TITLE
set_osd_param: add support for use_existing use case

### DIFF
--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -287,7 +287,7 @@ class Ceph(Cluster):
         common.pdsh(settings.getnodes('osds'), 'find /var/run/ceph/*.asok -maxdepth 1 -exec sudo ceph --admin-daemon {} dump_historic_ops \; > %s/historic_ops.out' % run_dir).communicate()
 
     def set_osd_param(self, param, value):
-        common.pdsh(settings.getnodes('osds'), 'find /dev/disk/by-partlabel/osd-device-*data -exec readlink {} \; | cut -d"/" -f 3 | sed "s/[0-9]$//" | xargs -I{} sudo sh -c "echo %s > /sys/block/\'{}\'/queue/%s"' % (value, param))
+        common.pdsh(settings.getnodes('osds'), 'mount|grep "/var/lib/ceph/osd"|sed -e "s/\s.*$//" -e s"/.$//g" -e s"/\/dev\///g" | xargs -I{} sudo sh -c "echo %s > /sys/block/\'{}\'/queue/%s"' % (value, param))
 
 
     def __str__(self):


### PR DESCRIPTION
set_osd_param used a command that required that the OSDs use the CBT
style labels, which is unlikely during a use_existing use case. This
changes the command to modify the device settings based on devices
that have a filesystem mounted in /var/lib/ceph/osd instead of by
label. Closes #25 