### PR TITLE
Add use_existing_rbds param to avoid having to refill rbds

### DIFF
--- a/benchmark/librbdfio.py
+++ b/benchmark/librbdfio.py
@@ -40,7 +40,7 @@ class LibrbdFio(Benchmark):
         self.random_distribution = config.get('random_distribution', None)
         self.rate_iops = config.get('rate_iops', None)
         self.poolname = "cbt-librbdfio"
-        self.use_existing_rbds = config.get('use_existing_rbds', False)
+        self.use_existing_volumes = config.get('use_existing_volumes', False)
 
 	self.total_procs = self.procs_per_volume * self.volumes_per_client * len(settings.getnodes('clients').split(','))
         self.run_dir = '%s/osd_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.run_dir, int(self.osd_ra), int(self.op_size), int(self.total_procs), int(self.iodepth), self.mode)
@@ -80,7 +80,7 @@ class LibrbdFio(Benchmark):
         # populate the fio files
         ps = []
         logger.info('Attempting to populating fio files...')
-        if (self.use_existing_rbds == False):
+        if (self.use_existing_volumes == False):
           for i in xrange(self.volumes_per_client):
               pre_cmd = 'sudo %s --ioengine=rbd --clientname=admin --pool=%s --rbdname=cbt-librbdfio-`hostname -s`-%d --invalidate=0  --rw=write --numjobs=%s --bs=4M --size %dM %s > /dev/null' % (self.cmd_path, self.poolname, i, self.numjobs, self.vol_size, self.names)
               p = common.pdsh(settings.getnodes('clients'), pre_cmd)
@@ -163,7 +163,7 @@ class LibrbdFio(Benchmark):
 
     def mkimages(self):
         monitoring.start("%s/pool_monitoring" % self.run_dir)
-        if (self.use_existing_rbds == False):
+        if (self.use_existing_volumes == False):
           self.cluster.rmpool(self.poolname, self.pool_profile)
           self.cluster.mkpool(self.poolname, self.pool_profile)
           for node in settings.getnodes('clients').split(','):


### PR DESCRIPTION
If several benchmarks are being ran in conjunction with use_existing
filling rbd volumes can take up a considerable amount of time between
tests, especially if using many clients with several volumes/fio
processes each. For example, 12 clients, with 10x 64GB volumes takes
1.185 hours at 1800 MB/s. This change applies to the librbdfio
benchmark only.

Resolves #48 