### PR TITLE
error-check CBT subprocess return status

### DIFF
--- a/benchmark/cephtestrados.py
+++ b/benchmark/cephtestrados.py
@@ -124,7 +124,7 @@ class CephTestRados(Benchmark):
         monitoring.stop()
 
     def recovery_callback(self): 
-        common.pdsh(settings.getnodes('clients'), 'sudo pkill -f ceph_test_rados').communicate()
+        common.pdsh(settings.getnodes('clients'), 'sudo pkill -f ceph_test_rados', continue_if_error=True).communicate()
 
     def __str__(self):
         return "%s\n%s\n%s" % (self.run_dir, self.out_dir, super(CephTestRados, self).__str__())

--- a/benchmark/librbdfio.py
+++ b/benchmark/librbdfio.py
@@ -84,7 +84,7 @@ class LibrbdFio(Benchmark):
             p = common.pdsh(settings.getnodes('clients'), pre_cmd)
             ps.append(p)
         for p in ps:
-            p.wait()
+            p.communicate()
         return True
 
     def run(self):
@@ -112,7 +112,7 @@ class LibrbdFio(Benchmark):
             p = common.pdsh(settings.getnodes('clients'), fio_cmd)
             ps.append(p)
         for p in ps:
-            p.wait()
+            p.communicate()
         # If we were doing recovery, wait until it's done.
         if 'recovery_test' in self.cluster.config:
             self.cluster.wait_recovery_done()

--- a/benchmark/radosbench.py
+++ b/benchmark/radosbench.py
@@ -93,7 +93,7 @@ class Radosbench(Benchmark):
             p = common.pdsh(settings.getnodes('clients'), '%s -c %s -p rados-bench-`hostname -s`-%s %s bench %s %s %s --no-cleanup 2> %s > %s' % (self.cmd_path_full, self.tmp_conf, i, op_size_str, self.time, mode, concurrent_ops_str, objecter_log, out_file))
             ps.append(p)
         for p in ps:
-            p.wait()
+            p.communicate()
         monitoring.stop(run_dir)
 
         # If we were doing recovery, wait until it's done.

--- a/common.py
+++ b/common.py
@@ -7,37 +7,74 @@ import logging
 
 logger = logging.getLogger("cbt")
 
-def pdsh(nodes, command):
+# this class overrides the communicate() method to check the return code and
+# throw an exception if return code is not OK
+
+class CheckedPopen:
+    UNINIT=-720
+    OK=0
+    # if you really don't care and want old unchecked behavior, set this to True, 
+    # but consider setting "continue_if_error=True" in individual common.pdsh call instead
+    turn_off_checking=False  
+    def __init__(self, args, continue_if_error=False):
+        self.args = args[:]
+        self.myrtncode = self.UNINIT
+        self.continue_if_error = continue_if_error
+        self.popen_obj = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+        logger.debug('CheckedPopen continue_if_error=%s args=%s'%(str(continue_if_error), ' '.join(args)))
+
+    def __str__(self):
+       return 'checked_Popen args=%s continue_if_error=%s rtncode=%d'%(str(self.args), str(self.continue_if_error), self.myrtncode)
+
+    # we transparently check return codes for this method now so callers don't have to
+
+    def communicate(self):
+       (stdoutdata, stderrdata) = self.popen_obj.communicate()
+       self.myrtncode = self.popen_obj.returncode  # THIS is the thing we couldn't do before
+       if (self.myrtncode != self.OK) and (not self.turn_off_checking):
+           if not self.continue_if_error:
+               raise Exception(str(self)+'\nstdout:\n'+stdoutdata+'\nstderr\n'+stderrdata)
+           else:
+               logger.warning(' '.join(self.args))
+               logger.warning('error %d seen, continuing anyway...'%self.myrtncode)
+       return (stdoutdata, stderrdata)
+
+def pdsh(nodes, command, continue_if_error=False):
     args = ['pdsh', '-R', 'ssh', '-w', nodes, command]
-    logger.debug('pdsh: %s' % args)
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    # -S means pdsh fails if any host fails 
+    if not continue_if_error: args.insert(1, '-S')
+    return CheckedPopen(args,continue_if_error=continue_if_error)
 
 def pdcp(nodes, flags, localfile, remotefile):
     args = ['pdcp', '-f', '1', '-R', 'ssh', '-w', nodes, localfile, remotefile]
     if flags:
         args = ['pdcp', '-f', '1', '-R', 'ssh', '-w', nodes, flags, localfile, remotefile]
-    logger.debug('pdcp: %s', args)
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    return CheckedPopen(args)
 
 def rpdcp(nodes, flags, remotefile, localfile):
     args = ['rpdcp', '-f', '1', '-R', 'ssh', '-w', nodes, remotefile, localfile]
     if flags:
         args = ['rpdcp', '-f', '1', '-R', 'ssh', '-w', nodes, flags, remotefile, localfile]
-    logger.debug('rpdcp: %s', args)
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    return CheckedPopen(args)
 
 def scp(node, localfile, remotefile):
     args = ['scp', localfile, '%s:%s' % (node, remotefile)]
-    logger.debug('scp: %s', args)
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    return CheckedPopen(args)
 
 def rscp(node, remotefile, localfile):
     args = ['scp', '%s:%s' % (node, remotefile), localfile]
-    logger.debug('rscp: %s', args)
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    return CheckedPopen(args)
+
+# we don't want to stop the run if no such process exists, hence continue_if_error
+def killall(nodelist, signalstr, process_name_pattern):
+    pdsh(nodelist, 'sudo killall -s %s -q %s'%(signalstr, process_name_pattern), continue_if_error=True).communicate()
+
+# this is used in some places instead of killall for looser matching
+# again we don't care if there aren't any such processes
+def pkill(nodelist, signalstr, process_name_pattern):
+    pdsh(nodelist, 'sudo pkill --signal %s -f %s'%(signalstr, process_name_pattern), continue_if_error=True).communicate()
 
 def make_remote_dir(remote_dir):
-    logger.info('Making remote directory: %s', remote_dir)
     nodes = settings.getnodes('clients', 'osds', 'mons', 'rgws', 'mds')
     pdsh(nodes, 'mkdir -p -m0755 -- %s' % remote_dir).communicate()
 
@@ -69,5 +106,5 @@ def setup_valgrind(mode, name, tmp_dir):
     if mode == 'memcheck':
         return 'valgrind --tool=memcheck --soname-synonyms=somalloc=*tcmalloc* --log-file=%s ' % (logfile)
 
-    logger.debug('valgrind mode: %s is not supported.', mode)
+    logger.warn('valgrind mode: %s is not supported.' % mode)
     return ''

--- a/monitoring.py
+++ b/monitoring.py
@@ -9,8 +9,9 @@ def start(directory):
     blktrace_dir = '%s/blktrace' % directory
 
     # collectl
-    common.pdsh(nodes, 'mkdir -p -m0755 -- %s' % collectl_dir)
-    common.pdsh(nodes, 'collectl -s+mYZ -i 1:10 -F0 -f %s' % collectl_dir)
+    common.pdsh(nodes, 'mkdir -p -m0755 -- %s' % collectl_dir).communicate()
+    # don't block on this
+    common.pdsh(nodes, 'collectl -s+mYZ -i 1:10 -F0 -f %s' % collectl_dir, continue_if_error=True)
 
     # perf
 #    common.pdsh(nodes), 'mkdir -p -m0755 -- %s' % perf_dir).communicate()
@@ -25,10 +26,8 @@ def start(directory):
 
 def stop(directory=None):
     nodes = settings.getnodes('clients', 'osds', 'mons', 'rgws')
-
-    common.pdsh(nodes, 'pkill -SIGINT -f collectl').communicate()
-    common.pdsh(nodes, 'sudo pkill -SIGINT -f perf_3.6').communicate()
-    common.pdsh(settings.getnodes('osds'), 'sudo pkill -SIGINT -f blktrace').communicate()
+    for pattern in [ 'collectl', 'perf_3.6', 'blktrace' ]:
+        common.pkill(nodes, 'INT', pattern)
     if directory:
         sc = settings.cluster
         common.pdsh(nodes, 'cd %s/perf;sudo chown %s.%s perf.data' % (directory, sc.get('user'), sc.get('user')))
@@ -40,5 +39,5 @@ def make_movies(directory):
     blktrace_dir = '%s/blktrace' % directory
 
     for device in xrange (0,sc.get('osds_per_node')):
-        common.pdsh(settings.getnodes('osds'), 'cd %s;%s -t device%s -o device%s.mpg --movie' % (blktrace_dir,seekwatcher,device,device)).communicate()
+        common.pdsh(settings.getnodes('osds'), 'cd %s;%s -t device%s -o device%s.mpg --movie' % (blktrace_dir,seekwatcher,device,device), continue_if_error=True).communicate()
 


### PR DESCRIPTION
this replaces pull request 27.  It runs with example/wip-mark-testing, with one exception: I can't get all the tests to pass in a single CBT run.  I am working on that separately.

The CheckedPopen class is what the common pdsh,pdcp, and other functions return now, instead of a subprocess.Popen object.  This allows us to override the subprocess.Popen.communicate() method to do error checking, minimizing changes to CBT code.  It throws an exception if the subprocess exit status is not 0.

in a couple of places we change p.wait() to p.communicate() and just ignore the outputs.

In some places we use the optional continue_if_error parameter to the CheckedPopen constructor so that it will avoid stopping CBT if a failure occurs, but it will log a warning message instead.