### PR TITLE
Control loglevel

### DIFF
--- a/log_support.py
+++ b/log_support.py
@@ -1,7 +1,8 @@
 import logging
-
+import os
 import yaml
 
+has_a_tty = os.isatty(1) # test stdout
 
 def load_run_params(run_params_file):
     with open(run_params_file) as fd:
@@ -28,8 +29,9 @@ class ColoredFormatter(logging.Formatter):
     colors = {
         'WARNING': color_me(YELLOW),
         'DEBUG': color_me(BLUE),
-        'CRITICAL': color_me(YELLOW),
-        'ERROR': color_me(RED)
+        'CRITICAL': color_me(RED),
+        'ERROR': color_me(RED),
+        'INFO': color_me(GREEN)
     }
 
     def __init__(self, msg, use_color=True, datefmt=None):
@@ -42,7 +44,7 @@ class ColoredFormatter(logging.Formatter):
         levelname = record.levelname
 
         prn_name = levelname + ' ' * (8 - len(levelname))
-        if levelname in self.colors:
+        if (levelname in self.colors) and has_a_tty:
             record.levelname = self.colors[levelname](prn_name)
         else:
             record.levelname = prn_name

--- a/log_support.py
+++ b/log_support.py
@@ -1,8 +1,7 @@
 import logging
-import os
+
 import yaml
 
-has_a_tty = os.isatty(1) # test stdout
 
 def load_run_params(run_params_file):
     with open(run_params_file) as fd:
@@ -29,9 +28,8 @@ class ColoredFormatter(logging.Formatter):
     colors = {
         'WARNING': color_me(YELLOW),
         'DEBUG': color_me(BLUE),
-        'CRITICAL': color_me(RED),
-        'ERROR': color_me(RED),
-        'INFO': color_me(GREEN)
+        'CRITICAL': color_me(YELLOW),
+        'ERROR': color_me(RED)
     }
 
     def __init__(self, msg, use_color=True, datefmt=None):
@@ -44,7 +42,7 @@ class ColoredFormatter(logging.Formatter):
         levelname = record.levelname
 
         prn_name = levelname + ' ' * (8 - len(levelname))
-        if (levelname in self.colors) and has_a_tty:
+        if levelname in self.colors:
             record.levelname = self.colors[levelname](prn_name)
         else:
             record.levelname = prn_name

--- a/log_support.py
+++ b/log_support.py
@@ -1,5 +1,6 @@
 import logging
-
+import os
+import sys
 import yaml
 
 
@@ -55,12 +56,32 @@ class ColoredFormatter(logging.Formatter):
         record.__dict__ = orig
         return res
 
+# if LOGLEVEL env var not defined, return def_level, 
+# otherwise return user-specified log level
 
-def setup_loggers(def_level=logging.DEBUG, log_fname=None):
+def loglevel_from_env_var(def_level):
+    level = def_level
+    loglevel_env_var = os.getenv('LOGLEVEL')
+    loglevel_choices = { 
+        'INFO':logging.INFO,
+        'DEBUG':logging.DEBUG,
+        'WARN':logging.WARN,
+        'ERROR':logging.ERROR
+    }
+    if loglevel_env_var:
+        try:
+            level = loglevel_choices[loglevel_env_var]
+        except KeyError as e:
+            print('LOGLEVEL env.var. can be one of: INFO, DEBUG, WARN, ERROR')
+            sys.exit(1)
+    return level
+
+def setup_loggers(def_level=logging.INFO, log_fname=None):
     logger = logging.getLogger('cbt')
     logger.setLevel(logging.DEBUG)
     sh = logging.StreamHandler()
-    sh.setLevel(def_level)
+    level = loglevel_from_env_var(def_level)
+    sh.setLevel(level)
 
     log_format = '%(asctime)s - %(levelname)s - %(name)-15s - %(message)s'
     colored_formatter = ColoredFormatter(log_format, datefmt="%H:%M:%S")


### PR DESCRIPTION
This commit lets the user specify logging level using LOGLEVEL environment variable.  If LOGLEVEL is not defined, the default log level of logging.INFO is used instead of logging.DEBUG.

please ignore the first 2 commits, the 2nd one cancels the first commit to the master branch, sorry again.