### PR TITLE
suppress loglevel colors unless logging to a tty

### DIFF
--- a/log_support.py
+++ b/log_support.py
@@ -1,7 +1,8 @@
 import logging
-
+import os
 import yaml
 
+has_a_tty = os.isatty(1) # test stdout
 
 def load_run_params(run_params_file):
     with open(run_params_file) as fd:
@@ -28,8 +29,9 @@ class ColoredFormatter(logging.Formatter):
     colors = {
         'WARNING': color_me(YELLOW),
         'DEBUG': color_me(BLUE),
-        'CRITICAL': color_me(YELLOW),
-        'ERROR': color_me(RED)
+        'CRITICAL': color_me(RED),
+        'ERROR': color_me(RED),
+        'INFO': color_me(GREEN)
     }
 
     def __init__(self, msg, use_color=True, datefmt=None):
@@ -42,7 +44,7 @@ class ColoredFormatter(logging.Formatter):
         levelname = record.levelname
 
         prn_name = levelname + ' ' * (8 - len(levelname))
-        if levelname in self.colors:
+        if (levelname in self.colors) and has_a_tty:
             record.levelname = self.colors[levelname](prn_name)
         else:
             record.levelname = prn_name


### PR DESCRIPTION
This just makes it a little easier to look at log files generated by CBT, since they won't have the color escape sequences embedded in them.  But if you run CBT from a tty, you'll still see the coloration.