### PR TITLE
Eliminate superfluous configuration requirements for use_existing

### DIFF
--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -125,6 +125,9 @@ class Ceph(Cluster):
         common.pdsh(nodes, 'sudo rm -rf %s' % self.tmp_dir).communicate()
 
     def setup_fs(self):
+        use_existing = settings.cluster.get('use_existing', True)
+        if use_existing:
+            return None
         sc = settings.cluster
         fs = sc.get('fs')
         mkfs_opts = sc.get('mkfs_opts', '')

--- a/monitoring.py
+++ b/monitoring.py
@@ -36,6 +36,9 @@ def stop(directory=None):
 
 
 def make_movies(directory):
+    use_existing = settings.cluster.get('use_existing', True)
+    if use_existing:
+        return None
     sc = settings.cluster
     seekwatcher = '/home/%s/bin/seekwatcher' % sc.get('user')
     blktrace_dir = '%s/blktrace' % directory


### PR DESCRIPTION
Check for use_existing before going through code paths that would
require osds_per_node, fs, mkfs_opts, and mount_opts. Previously
absence of these options would cause CBT to crash, even when CBT
isn't handling cluster/OSD setup. This was unintuitive for new
users of CBT.