### PR TITLE
Use proportionally sized test files for rbdfio

### DIFF
--- a/benchmark/rbdfio.py
+++ b/benchmark/rbdfio.py
@@ -76,7 +76,7 @@ class RbdFio(Benchmark):
 
         # populate the fio files
         logger.info('Attempting to populating fio files...')
-        pre_cmd = 'sudo %s --ioengine=%s --rw=write --numjobs=%s --bs=4M --size %dM %s > /dev/null' % (self.cmd_path, self.ioengine, self.numjobs, self.vol_size*0.9, self.names)
+        pre_cmd = 'sudo %s --ioengine=%s --rw=write --numjobs=%s --bs=4M --size %dM %s > /dev/null' % (self.cmd_path, self.ioengine, self.numjobs, self.vol_size*0.9/self.concurrent_procs, self.names)
         common.pdsh(settings.getnodes('clients'), pre_cmd).communicate()
 
         return True


### PR DESCRIPTION
Results from tests with greater than one concurrent process per volume
are inaccurate because the benchmark uses a test file per process, and
each test file is set to the same size of the volume. This clearly isn't
possible, so we need the size of each test file to equal the volume size
divided by the number of concurrent processes. To be careful, we only use
90% of the volume, to leave plenty of space for filesystem journal and
metadata.