### PR TITLE
Remove problematic health check

### DIFF
--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -380,9 +380,6 @@ class Ceph(Cluster):
         else:
             common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool create %s %d %d' % (self.ceph_cmd, self.tmp_conf, name, pg_size, pgp_size)).communicate()
 
-        logger.info('Checking Healh after pool creation.')
-        self.check_health()
-
         if replication and replication.isdigit():
             common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s size %s' % (self.ceph_cmd, self.tmp_conf, name, replication)).communicate()
             logger.info('Checking Health after setting pool replication level.')


### PR DESCRIPTION
Pools are created by default with a size of 3, if you are testing
with a 2 node cluster then this can be problematic because the pool
will never become healthy until the size is set to 2, which is done
after the health check. Remoing this health check allows the pool's
size to be set to 2 before doing a health check. There is a health
check later in the function, so the removed check was really just
a matter of being over cautious.