### PR TITLE
check pool health after replication size has been set

### DIFF
--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -392,13 +392,13 @@ class Ceph(Cluster):
         else:
             common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool create %s %d %d' % (self.ceph_cmd, self.tmp_conf, name, pg_size, pgp_size)).communicate()
 
+        if replication and replication.isdigit():
+            pool_repl_size = int(replication)
+            common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s size %s' % (self.ceph_cmd, self.tmp_conf, name, replication)).communicate()
+            common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s min_size %d' % (self.ceph_cmd, self.tmp_conf, name, pool_repl_size-1)).communicate()
+
         logger.info('Checking Healh after pool creation.')
         self.check_health()
-
-        if replication and replication.isdigit():
-            common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s size %s' % (self.ceph_cmd, self.tmp_conf, name, replication)).communicate()
-            logger.info('Checking Health after setting pool replication level.')
-            self.check_health()
 
         if base_name and cache_mode:
             logger.info("Adding %s as cache tier for %s.", name, base_name)


### PR DESCRIPTION
This helps with small test configs using 2 OSD hosts or less where there aren't enough hosts to achieve a healthy pool with default of 3-way replication.  In  this case, check_health() hangs waiting for HEALTH_OK because pool size wasn't set beforehand.