### PR TITLE
cosbench changes to support mode==read or mode==mix

### DIFF
--- a/benchmark/cosbench.py
+++ b/benchmark/cosbench.py
@@ -89,11 +89,11 @@ class Cosbench(Benchmark):
                     },{
                         "name": "main",
                         "work": {"rampup":conf["rampup"], "rampdown":conf["rampdown"], "name":conf["obj_size"], "workers":conf["workers"], "runtime":conf["runtime"],
-                            "operation": {
+                            "operation":[ {
                                 "config":"containers=%s;objects=%s;cprefix=%s-%s;sizes=c(%s)%s" % (conf["containers"], conf["objects"], conf["obj_size"], conf["mode"], conf["obj_size_num"], conf["obj_size_unit"]),
                                 "ratio":conf["ratio"],
-                                "type":conf["mode"]
-                            }
+                                "type":("read" if conf["mode"] == "mix" else conf["mode"])
+                            }]
                         }
                     }]
                 }
@@ -147,6 +147,29 @@ class Cosbench(Benchmark):
         if not self.config["template"]:
             self.config["template"] = "default"
         self.config["workload"] = self.choose_template("default", conf)
+
+        # add a "prepare" stage if mode is read or mix
+        if (self.mode != "write"):
+            workstage_prepare= { "name":"prepare",
+                                 "work": {
+                "type":"prepare",
+                "workers":conf["workers"],
+                "config":"containers=r(1,%s);objects=r(1,%s);cprefix=%s-%s;sizes=c(%s)%s" % 
+                (conf["containers_max"], conf["objects_max"], conf["obj_size"], conf["mode"], conf["obj_size_num"], conf["obj_size_unit"])
+             }}
+            self.config["workload"]["workflow"]["workstage"].insert(1, workstage_prepare)
+
+        # add a second (write)operation if mode is "mix"
+        # parameters same as for read except ratio = 100 - read_ratio
+        if (self.mode == "mix"):
+            operation_write = {
+               "config":"containers=%s;objects=%s;cprefix=%s-%s;sizes=c(%s)%s"
+                %(conf["containers"], conf["objects"], conf["obj_size"], conf["mode"], conf["obj_size_num"], conf["obj_size_unit"]),
+                "ratio":(100 - conf["ratio"]),
+                "type":"write"
+            }
+            self.config["workload"]["workflow"]["workstage"][2]["work"]["operation"].append(operation_write)
+
         self.prepare_xml(self.config["workload"])
         return True
 


### PR DESCRIPTION
cosbench: use prepare workstage if mode==read
cosbench: support mix mode
Addresses issues #82

Signed-off-by: Tom Deneau <tom.deneau@amd.com>

Note: The mixed mode support does not give the user much configurability.
If config.mode is set to mix, we simply treat the "ratio" field as the read ratio,
and add a work operation for write with write_ratio = 100-read_ratio.
Also both read and write cover identical ranges for objects and containers.
