### PR TITLE
Remove potentially dangerous mkfs option from samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ cluster:
       a: "127.0.0.1:6789"
   osds_per_node: 1
   fs: 'xfs'
-  mkfs_opts: '-f -i size=2048 -n size=64k'
+  mkfs_opts: '-f -i size=2048'
   mount_opts: '-o inode64,noatime,logbsize=256k'
   conf_file: '/home/nhm/src/ceph-tools/cbt/newstore/ceph.conf.1osd'
   iterations: 1

--- a/example/example-3x-radosbench.yaml
+++ b/example/example-3x-radosbench.yaml
@@ -5,7 +5,7 @@ cluster:
   mons: ["ceph@mon"]
   osds_per_node: 1
   fs: xfs
-  mkfs_opts: -f -i size=2048 -n size=64k
+  mkfs_opts: -f -i size=2048
   mount_opts: -o inode64,noatime,logbsize=256k
   conf_file: /home/ceph/ceph-tools/cbt/example/ceph.conf
   ceph.conf: /home/ceph/ceph-tools/cbt/example/ceph.conf

--- a/example/example-ec-radosbench.yaml
+++ b/example/example-ec-radosbench.yaml
@@ -5,7 +5,7 @@ cluster:
   mons: ["ceph@mon"]
   osds_per_node: 1
   fs: xfs
-  mkfs_opts: -f -i size=2048 -n size=64k
+  mkfs_opts: -f -i size=2048
   mount_opts: -o inode64,noatime,logbsize=256k
   conf_file: /home/ceph/ceph-tools/cbt/example/ceph.conf
   ceph.conf: /home/ceph/ceph-tools/cbt/example/ceph.conf

--- a/example/wip-cosbench/cosbench_ex.yaml
+++ b/example/wip-cosbench/cosbench_ex.yaml
@@ -13,7 +13,7 @@ cluster:
   rgws: ["inf1", "inf2", "inf3"]
   osds_per_node: 1
   fs: 'xfs'
-  mkfs_opts: '-f -i size=2048 -n size=64k'
+  mkfs_opts: '-f -i size=2048'
   mount_opts: '-o inode64,noatime,logbsize=256k'
   conf_file: '/home/cbt/cbt/runs/test2.ceph.conf'
   iterations: 1

--- a/example/wip-mark-testing/runtests.xfs.yaml
+++ b/example/wip-mark-testing/runtests.xfs.yaml
@@ -8,7 +8,7 @@ cluster:
       a: "192.168.10.2:6789"
   osds_per_node: 4 
   fs: 'xfs'
-  mkfs_opts: '-f -i size=2048 -n size=64k'
+  mkfs_opts: '-f -i size=2048'
   mount_opts: '-o inode64,noatime,logbsize=256k'
   conf_file: '/home/nhm/src/cbt/example/wip-mark-testing/ceph.conf'
   iterations: 1


### PR DESCRIPTION
As using a large directory block size on XFS can turn out to have pretty
bad effects on systems under load (see [1]), do not suggest using these
as a default in the examples.

[1] http://oss.sgi.com/pipermail/xfs/2016-February/047020.html