### PR TITLE
Fix RecoveryTestThread undefined and fix radosbench logging

### DIFF
--- a/benchmark/radosbench.py
+++ b/benchmark/radosbench.py
@@ -87,7 +87,7 @@ class Radosbench(Benchmark):
 
         # Run rados bench
         monitoring.start(run_dir)
-        logger.info('Running radosbench read test.')
+        logger.info('Running radosbench %s test.' % mode)
         ps = []
         for i in xrange(self.concurrent_procs):
             out_file = '%s/output.%s' % (run_dir, i)

--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -571,6 +571,7 @@ class RecoveryTestThread(threading.Thread):
         self.inhealthtries = 0
         self.maxhealthtries = 60
         self.health_checklist = ["degraded", "peering", "recovery_wait", "stuck", "inactive", "unclean", "recovery"]
+        self.ceph_cmd = self.cluster.ceph_cmd
 
     def logcmd(self, message):
         return 'echo "[`date`] %s" >> %s/recovery.log' % (message, self.config.get('run_dir'))


### PR DESCRIPTION
RecoveryTestThread: self.ceph_cmd was not defined
radosbench: log correct mode in Running radosbench xxx test message
