### PR TITLE
Added hotfix for benchmarks breaking if osd_ra is not set in the yaml config file

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -20,6 +20,9 @@ class Benchmark(object):
         self.cmd_path_full = '' 
         if self.valgrind is not None:
             self.cmd_path_full = common.setup_valgrind(self.valgrind, self.getclass(), self.run_dir)
+        if self.osd_ra is None:
+            self.osd_ra = common.get_osd_ra()
+            self.osd_ra_changed = False
 
 
     def getclass(self):
@@ -37,7 +40,7 @@ class Benchmark(object):
 
     def run(self):
         logger.info('Setting OSD Read Ahead to: %s', self.osd_ra)
-        if self.osd_ra:
+        if self.osd_ra and self.osd_ra_changed is not False:
             self.cluster.set_osd_param('read_ahead_kb', self.osd_ra)
         logger.debug('Cleaning existing temporary run directory: %s', self.run_dir)
         common.pdsh(settings.getnodes('clients', 'osds', 'mons', 'rgws'), 'sudo rm -rf %s' % self.run_dir).communicate()

--- a/common.py
+++ b/common.py
@@ -82,3 +82,14 @@ def setup_valgrind(mode, name, tmp_dir):
 
     logger.warning('valgrind mode: %s is not supported.', mode)
     return ''
+
+def get_osd_ra():
+    for root, directories, files in os.walk('/sys'):
+        for filename in files:
+            if 'block' in root and 'read_ahead_kb' in filename:
+                filename = os.path.join(root, filename)
+                try:
+                    osd_ra = int(open(filename, 'r').read())
+                    return osd_ra
+                except ValueError:
+                    continue


### PR DESCRIPTION
If the osd_ra parameter is not set in the yaml config file, the default value given to osd_ra is None. When not specified, the benchmark classes will break when trying to parse an int from None. For example, the following line is in the KvmRbdFio class (as well as in most other benchmark classes):
`self.run_dir = '%s/osd_ra-%08d/client_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.run_dir, int(self.osd_ra), int(self.client_ra), int(self.op_size), int(self.total_procs), int(self.iodepth), self.mode)`

Once the above line is executed, it will attempt to parse an int from `None` and CBT will break with a `TypeError`. This hotfix checks for a `read_ahead_kb` value in the cluster and uses that value for osd_ra if not specified.