### PR TITLE
Remove osd_ra requirement for use_existing

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -36,9 +36,12 @@ class Benchmark(object):
         common.make_remote_dir(self.run_dir)
 
     def run(self):
-        logger.info('Setting OSD Read Ahead to: %s', self.osd_ra)
         if self.osd_ra:
+            logger.info('Setting OSD Read Ahead to: %s', self.osd_ra)
             self.cluster.set_osd_param('read_ahead_kb', self.osd_ra)
+        else
+            self.osd_ra = 'na'
+
         logger.debug('Cleaning existing temporary run directory: %s', self.run_dir)
         common.pdsh(settings.getnodes('clients', 'osds', 'mons', 'rgws'), 'sudo rm -rf %s' % self.run_dir).communicate()
         if self.valgrind is not None:


### PR DESCRIPTION
When someone is using use_existing, we don't set the read ahead
on the OSD devices because we want to leave the cluster "as is".
In this case, we need to set osd_ra to something, so that the
archive directory structure is preserved.