### PR TITLE
Added config wizard to easily generate YAML config files

### DIFF
--- a/tools/config_class.py
+++ b/tools/config_class.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python2
+import os
+import sys
+
+MODES = ["randwrite", "randread", "write", "read"]
+
+
+class Config:
+    def __init__(self, out_file, hosts, user, tmp_dir, osds_per_node=1):
+        self.benchmarks = ""
+        self.ceph_conf = "/etc/ceph/ceph.conf"
+        self.hosts = hosts
+        self.iterations = 1
+        self.mkfs_opts = "-f -i size=2048 -n size=64k"
+        self.mount_opts = "-o inode64,noatime,logbsize=256k"
+        self.osds_per_node = osds_per_node
+        self.out_file = "%s/%s" % (os.path.dirname(os.path.realpath(__file__)),
+                                   out_file)
+        self.tmp_dir = tmp_dir
+        self.user = user
+
+    def add_benchmark_settings(self, settings):
+        self.benchmarks += settings
+
+    def get_pgs(self):
+        while True:
+            pgs = 0
+            pgs = get_input("Enter the number of placement groups (PGs): ")
+            try:
+                pgs = int(pgs)
+            except ValueError:
+                print "PGs can only be integer values greater than 0."
+                continue
+            if pgs <= 0:
+                print "PGs must be greater than 0."
+                continue
+            return pgs
+
+    def get_mode(self):
+        modes = ""
+        while True:
+            print "Which of the following modes do you wish to run?"
+            modes = get_input("randwrite, randread, write, read: ")
+            modes = modes.replace(" ", "").split(",")
+            valid = True
+            for mode in modes:
+                if mode.lower() not in MODES:
+                    valid = False
+                    break
+            if valid:
+                break
+        return str(modes).replace("'", "")
+
+    def get_integer_list(self, prompt, example):
+        int_list = ""
+        while True:
+            print prompt
+            int_list = get_input("e.g. %s " % (example)).replace(" ", "")
+            int_list = int_list.replace("[", "").replace("]", "").split(",")
+            valid = True
+            for num in int_list:
+                try:
+                    num = int(num)
+                except ValueError:
+                    print "Only integer values greater than 0 are allowed."
+                    valid = False
+                    break
+                if num <= 0:
+                    print "Value must be greater than 0."
+                    valid = False
+                    break
+            if valid:
+                break
+        return str(int_list).replace("'", "")
+
+    def get_integer(self, prompt, example):
+        int_out = ""
+        while True:
+            print prompt
+            int_out = get_input("e.g. %s: " % (example))
+            valid = True
+            if "," in int_out:
+                print "Only single integer value allowed."
+                valid = False
+            try:
+                int_out = int(int_out)
+            except ValueError:
+                print "Only valid integer values greater than 0 are allowed."
+                valid = False
+            if valid:
+                break
+        return int_out
+
+    def get_time(self):
+        while True:
+            time = 0
+            time = get_input("Enter the desired timeout in seconds: ")
+            try:
+                time = int(time)
+            except ValueError:
+                print "Time must be a valid integer number greater than 0."
+                continue
+            if time <= 0:
+                print "Time must be greater than 0."
+                continue
+            return time
+
+    def get_volume(self):
+        while True:
+            volume = 0
+            volume = get_input("Enter the total number of I/O bytes to operate"
+                               " on: ")
+            try:
+                volume = int(volume)
+            except ValueError:
+                print "Volume must be a valid integer number greater than 0."
+                continue
+            if volume <= 0:
+                print "Volume must be greater than 0."
+                continue
+            return volume
+
+    def get_pgs_per_pool(self):
+        while True:
+            pgs = 0
+            pgs = get_input("Enter the number of placement groups per pool: ")
+            try:
+                pgs = int(pgs)
+            except ValueError:
+                print "Placement groups must be a valid integer number "\
+                      "greater than 0."
+                continue
+            if pgs <= 0:
+                print "Placement groups must be greater than 0."
+                continue
+            return pgs
+
+    def true_or_false(self, prompt):
+        while True:
+            response = get_input("%s [y/n]?: " % (prompt))
+            if response.lower() == "y":
+                return True
+            elif response.lower() == "n":
+                return False
+            else:
+                continue
+
+    def save_file(self):
+        f = open(self.out_file, "w")
+        out_message = ("cluster:\n"
+                       "  head: '%s'\n"
+                       "  clients: %s\n"
+                       "  servers: %s\n"
+                       "  mons: ['%s']\n"
+                       "  user: %s\n"
+                       "  osds_per_node: %s\n"
+                       "  fs: xfs\n"
+                       "  mkfs_opts %s\n"
+                       "  mount_opts: %s\n"
+                       "  ceph.conf: %s\n"
+                       "  iterations: %s\n"
+                       "  tmp_dir: '%s'\n"
+                       "benchmarks: %s\n") % (self.hosts[0], self.hosts[1],
+                                              self.hosts[1], self.hosts[0],
+                                              self.user, self.osds_per_node,
+                                              self.mkfs_opts, self.mount_opts,
+                                              self.ceph_conf, self.iterations,
+                                              self.tmp_dir, self.benchmarks)
+        f.write(out_message)
+
+
+class KvmRbdFio:
+    def __init__(self, default, config):
+        self.iodepth = "[1, 2, 4, 8, 16]"
+        self.mode = "[randwrite, randread, write, read]"
+        self.op_size = "[4096, 131072, 4194304]"
+        self.osd_ra = "128"
+        self.output = ""
+        self.pgs = 8192
+        self.time = 60
+        self.vol_size = 65536
+
+        if not default:
+            self.get_settings(config)
+
+        self.generate_output()
+
+    def generate_output(self):
+        self.output = ("\n  kvmrbdfio:\n"
+                       "    time: %s\n"
+                       "    pgs: %s\n"
+                       "    vol_size: %s\n"
+                       "    mode: %s\n"
+                       "    op_size: %s\n"
+                       "    iodepth: %s\n"
+                       "    osd_ra: %s\n") % (self.time, self.pgs,
+                                              self.vol_size, self.mode,
+                                              self.op_size, self.iodepth,
+                                              self.osd_ra)
+
+    def get_settings(self, config):
+        self.pgs = config.get_pgs()
+        self.mode = config.get_mode()
+        self.iodepth = config.get_integer_list("Enter the desired IO depth",
+                                               "[1, 2, 4, 8, 16]")
+        self.op_size = config.get_integer_list("Enter the desired object"
+                                               " size(s) in bytes",
+                                               "[4096, 131072, 4194304]")
+        self.osd_ra = config.get_integer("Enter the desired OSD read-ahead"
+                                         " in bytes", "128")
+        self.time = config.get_time()
+        self.vol_size = config.get_volume()
+
+
+class Radosbench:
+    def __init__(self, default, config):
+        self.concurrent_ops = "[32]"
+        self.concurrent_procs = 2
+        self.op_size = "[4096, 131072, 4194304]"
+        self.osd_ra = "128"
+        self.output = ""
+        self.pgs_per_pool = 1024
+        self.time = 300
+        self.write_only = False
+
+        if not default:
+            self.get_settings(config)
+
+        self.generate_output()
+
+    def generate_output(self):
+        self.output = ("\n  radosbench:\n"
+                       "    op_size: %s\n"
+                       "    write_only: %s\n"
+                       "    time: %s\n"
+                       "    concurrent_ops: %s\n"
+                       "    concurrent_procs: %s\n"
+                       "    pgs_per_pool: %s\n"
+                       "    osd_ra: %s\n") % (self.op_size, self.write_only,
+                                              self.time, self.concurrent_ops,
+                                              self.concurrent_procs,
+                                              self.pgs_per_pool, self.osd_ra)
+
+    def get_settings(self, config):
+        self.concurrent_ops = config.get_integer_list("Enter the number of"
+                                                      " concurrent operations"
+                                                      " to run", "32")
+        self.concurrent_procs = config.get_integer_list("Enter the number of"
+                                                        " concurrent processes"
+                                                        " to run", "32")
+        self.op_size = config.get_integer_list("Enter the desired object"
+                                               " size(s) in bytes",
+                                               "[4096, 131072, 4194304]")
+        self.osd_ra = config.get_integer("Enter the desired OSD read-ahead"
+                                         " in bytes", "128")
+        self.pgs_per_pool = config.get_pgs_per_pool()
+        self.time = config.get_time()
+        self.write_only = config.true_or_false("Would you like to only perform"
+                                               " write-tests")
+
+
+class RbdFio:
+    def __init__(self, default, config):
+        self.concurrent_procs = "[1, 2, 4, 8, 16]"
+        self.iodepth = "[1, 2, 4, 8, 16]"
+        self.mode = "[randwrite, randread, write, read]"
+        self.op_size = "[4096, 131072, 4194304]"
+        self.osd_ra = "128"
+        self.output = ""
+        self.pgs = 8192
+        self.rbdadd_options = "'noshare'"
+        self.time = 60
+        self.vol_size = 65536
+
+        if not default:
+            self.get_settings(config)
+
+        self.generate_output()
+
+    def generate_output(self):
+        self.output = ("\n  rbdfio:\n"
+                       "    rbdadd_options: %s\n"
+                       "    time: %s\n"
+                       "    pgs: %s\n"
+                       "    vol_size: %s\n"
+                       "    mode: %s\n"
+                       "    op_size: %s\n"
+                       "    concurrent_procs: %s\n"
+                       "    iodepth: %s\n"
+                       "    osd_ra: %s\n") % (self.rbdadd_options, self.time,
+                                              self.pgs, self.vol_size,
+                                              self.mode, self.op_size,
+                                              self.concurrent_procs,
+                                              self.iodepth, self.osd_ra)
+
+    def get_settings(self, config):
+        self.pgs = config.get_pgs()
+        self.mode = config.get_mode()
+        self.concurrent_procs = config.get_integer_list("Enter the number of"
+                                                        " concurrent processes"
+                                                        " you desire to run",
+                                                        "[1, 2, 4, 8, 16]")
+        self.iodepth = config.get_integer_list("Enter the desired IO depth",
+                                               "[1, 2, 4, 8, 16]")
+        self.time = config.get_time()
+        self.op_size = config.get_integer_list("Enter the desired object"
+                                               " size(s) in bytes",
+                                               "[4096, 131072, 4194304]")
+        self.osd_ra = config.get_integer("Enter the desired OSD read-ahead"
+                                         " in bytes", "128")
+        self.vol_size = config.get_volume()
+
+
+def keyboard_input(func):
+    def wrapper(prompt):
+        try:
+            return func(prompt)
+        except KeyboardInterrupt:
+            print "Aborting script. No data will be saved."
+            sys.exit(1)
+    return wrapper
+
+
+@keyboard_input
+def get_input(prompt):
+    return raw_input(prompt)

--- a/tools/config_wizard.py
+++ b/tools/config_wizard.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python2
+# NOTE: Be sure to run script on the main ceph monitor as the desired
+# CBT user if running the script automatically (-a).
+
+import argparse
+import os
+import socket
+import sys
+
+from config_class import Config, KvmRbdFio, Radosbench, RbdFio
+
+BENCHMARKS = ["radosbench", "kvmrbdfio", "rbdfio"]
+TMP_DIR = "/dev/null"
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--automate", help="Automatically create a config"
+                                                 " file with default values for"
+                                                 " Radosbench, RBDFIO and "
+                                                 "KVMRBDFIO.",
+                                                 action="store_true")
+    parser.add_argument("-o", "--output_file", help="Specify filename for "
+                                                    "output config file. "
+                                                    "Defaults to 'cbt_config"
+                                                    ".xfs.yaml'", type=str,
+                                                    nargs="?",
+                                                    default="cbt_config"
+                                                    ".xfs.yaml")
+    return parser.parse_args()
+
+
+def get_hosts(auto):
+    if auto:
+        clients = []
+        monitor = os.popen("hostname -s").read().rstrip()
+        hosts = os.popen("ceph osd tree | grep host").read().split("\n")
+        for host in hosts:
+            if host != "":
+                clients.append(host.rstrip().split(" ")[-1])
+        return (monitor, clients)
+
+    try:
+        monitor = raw_input("Enter the hostname of the monitor: ")
+        clients = raw_input("Enter the hostname(s) of the OSD(s) seperated by"
+                            " comma: ").replace(" ", "").split(",")
+    except KeyboardInterrupt:
+        print "Aborting script. No data will be saved."
+        sys.exit(1)
+    return (monitor, clients)
+
+
+def get_user(auto):
+    if auto:
+        return os.getlogin()
+
+    try:
+        user = raw_input("Enter the username for CBT: ")
+    except KeyboardInterrupt:
+        print "Aborting script. No data will be saved."
+        sys.exit(1)
+    return user
+
+
+def get_tmp_dir(auto):
+    if auto:
+        return TMP_DIR
+
+    try:
+        directory = raw_input("Enter the temporary directory for CBT results: ")
+    except KeyboardInterrupt:
+        print "Aborting script. No data will be saved."
+        sys.exit(1)
+    return directory
+
+
+def select_tests():
+    while True:
+        valid = True
+        print "Which of the following tests would you like to run?\nradosbench"\
+              ", kvmrbdfio, rbdfio"
+        try:
+            tests = raw_input("Enter the test names seperated by comma: ")
+            tests = tests.replace(" ", "").split(",")
+        except KeyboardInterrupt:
+            print "Aborting script. No data will be saved."
+            sys.exit(1)
+        for test in tests:
+            if test.lower() not in BENCHMARKS:
+                print "Unknown test: %s" % (test)
+                print "Please specify only valid tests from the list above\n"
+                valid = False
+                break
+        if valid:
+            return [x.lower() for x in tests]
+
+
+def generate_test_values(test, default, config):
+    if test == "rbdfio":
+        rbdfio = RbdFio(default, config)
+        config.add_benchmark_settings(rbdfio.output)
+    elif test == "kvmrbdfio":
+        kvmrbdfio = KvmRbdFio(default, config)
+        config.add_benchmark_settings(kvmrbdfio.output)
+    else:
+        radosbench = Radosbench(default, config)
+        config.add_benchmark_settings(radosbench.output)
+
+
+def main():
+    args = parse_arguments()
+    hosts = get_hosts(args.automate)
+    user = get_user(args.automate)
+    tmp_dir = get_tmp_dir(args.automate)
+    conf = Config(args.output_file, hosts, user, tmp_dir)
+    if args.automate:
+        rbdfio = RbdFio(True, conf)
+        kvmrbdfio = KvmRbdFio(True, conf)
+        radosbench = Radosbench(True, conf)
+        conf.add_benchmark_settings(rbdfio.output)
+        conf.add_benchmark_settings(kvmrbdfio.output)
+        conf.add_benchmark_settings(radosbench.output)
+    else:
+        tests = select_tests()
+        for test in tests:
+            use_default = False
+            print "\nEntering settings for %s:" % (test)
+            while True:
+                try:
+                    default = raw_input("Would you like to use default"
+                                        " settings for %s [y/n]? " % (test))
+                except KeyboardInterrupt:
+                    print "Aborting script. No data will be saved."
+                    sys.exit(1)
+                if default.lower() == "y":
+                    print "Using default values for %s" % (test)
+                    use_default = True
+                    break
+                elif default.lower() == "n":
+                    use_default = False
+                    break
+            generate_test_values(test, use_default, conf)
+    conf.save_file()
+    print "Output saved to: %s" % (conf.out_file)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This tool is a quick way to generate a YAML config file by stepping the user through the process of specifying values for every CBT setting. Creating a config file manually can be a bit daunting to the first-time user of CBT and this tool aims to solve that issue. In most cases, the user will be given a brief description of the setting and a suggested value. If desired, he or she can also append a '-a' or '--automate' argument to the script to automatically generate a config file without any input, using default values for all settings.

Currently, the tool only supports radosbench, kvmrbdfio and rbdfio, but adding new benchmarks is very straightforward.