### PR TITLE
Crush rule

### DIFF
--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -496,8 +496,14 @@ class Ceph(Cluster):
             common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s min_size %d' % (self.ceph_cmd, self.tmp_conf, name, pool_repl_size-1)).communicate()
 
         if crush_profile:
-            ruleset = self.get_ruleset(crush_profile)
-            common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s crush_ruleset %s' % (self.ceph_cmd, self.tmp_conf, name, ruleset)).communicate()
+            try:
+              rule_index = int(crush_profile)
+              # set crush profile using the integer 0-based index of crush rule
+              # displayed by: ceph osd crush rule ls
+              ruleset = crush_profile
+            except ValueError as e:
+              ruleset = self.get_ruleset(crush_profile)
+            common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s crush_ruleset %s' % (self.ceph_cmd, self.tmp_conf, name, crush_profile)).communicate()
 
         logger.info('Checking Healh after pool creation.')
         self.check_health()

--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -495,6 +495,10 @@ class Ceph(Cluster):
             common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s size %s' % (self.ceph_cmd, self.tmp_conf, name, replication)).communicate()
             common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s min_size %d' % (self.ceph_cmd, self.tmp_conf, name, pool_repl_size-1)).communicate()
 
+        if crush_profile:
+            ruleset = self.get_ruleset(crush_profile)
+            common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s crush_ruleset %s' % (self.ceph_cmd, self.tmp_conf, name, ruleset)).communicate()
+
         logger.info('Checking Healh after pool creation.')
         self.check_health()
 
@@ -509,9 +513,6 @@ class Ceph(Cluster):
             common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd tier cache-mode %s %s' % (self.ceph_cmd, self.tmp_conf, name, cache_mode)).communicate()
             common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd tier set-overlay %s %s' % (self.ceph_cmd, self.tmp_conf, base_name, name)).communicate()
 
-        if crush_profile:
-            ruleset = self.get_ruleset(crush_profile)
-            common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s crush_ruleset %s' % (self.ceph_cmd, self.tmp_conf, name, ruleset)).communicate()
         if hit_set_type:
             common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s hit_set_type %s' % (self.ceph_cmd, self.tmp_conf, name, hit_set_type)).communicate()
         if hit_set_count:


### PR DESCRIPTION
this change is useful if you are testing with replication/EC on a single host and want to alter the crush rule used for the storage pool, with use_existing: true . 

The first commit puts setting the crush rule ahead of the health check, which otherwise never passes.

The 2nd change allows you to specify the crush rule with an integer.  It is assumed here that the crush rule has been created and you merely want to use an existing rule, not have CBT create it.  The integer index to use is the 0-based index of the rule when you do "ceph osd crush rule ls", I think.