### PR TITLE
Documentation Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Note that pdsh is not packaged for RHEL7 and CentOS 7 based distributations
 at this time, though the rawhide pdsh packages install and are usable.  The
 RPMs for these packages are available here:
 
- - ftp://rpmfind.net/linux/fedora/linux/development/rawhide/x86_64/os/Packages/p/pdsh-2.31-4.fc23.x86_64.rpm 
- - ftp://rpmfind.net/linux/fedora/linux/development/rawhide/x86_64/os/Packages/p/pdsh-rcmd-rsh-2.31-4.fc23.x86_64.rpm
- - ftp://rpmfind.net/linux/fedora/linux/development/rawhide/x86_64/os/Packages/p/pdsh-rcmd-ssh-2.31-4.fc23.x86_64.rpm
+ - ftp://rpmfind.net/linux/fedora/linux/releases/23/Everything/x86_64/os/Packages/p/pdsh-2.31-4.fc23.x86_64.rpm
+ - ftp://rpmfind.net/linux/fedora/linux/releases/23/Everything/x86_64/os/Packages/p/pdsh-rcmd-rsh-2.31-4.fc23.x86_64.rpm
+ - ftp://rpmfind.net/linux/fedora/linux/releases/23/Everything/x86_64/os/Packages/p/pdsh-rcmd-ssh-2.31-4.fc23.x86_64.rpm
 
 Optional tools and benchmarks can be used if desired:
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ CBT uses several libraries and tools to run:
 
  1. python-yaml - A YAML library for python used for reading 
     configuration files.
- 2. ssh (and scp) - remote secure command executation and data 
+ 2. python-lxml - Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API
+ 3. ssh (and scp) - remote secure command executation and data 
     transfer
- 3. pdsh (and pdcp) - a parallel ssh and scp implementation
- 4. ceph - A scalable distributed storage system
+ 4. pdsh (and pdcp) - a parallel ssh and scp implementation
+ 5. ceph - A scalable distributed storage system
 
 Note that pdsh is not packaged for RHEL7 and CentOS 7 based distributations 
 at this time, though the rawhide pdsh packages install and are usable.  The


### PR DESCRIPTION
Under PREREQUISITES section the links for pdsh packages were broken
With this fix i have added the correct working links for pdsh packages

Signed-off-by: ksingh7 <karan.singh731987@gmail.com>