### PR TITLE
A few fixes to CBT setup.sh file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 *.pyc
 *.pyo
+collectl*
+pdsh*
+iperf*
+iftop*
+fio
+FlameGraph
+pmu-tools

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ sudo yum check-update
 sudo yum -y update
 sudo yum install -y psmisc util-linux coreutils xfsprogs e2fsprogs findutils \
   git wget bzip2 make automake gcc gcc-c++ kernel-devel perf blktrace lsof \
-  redhat-lsb sysstat screen python-yaml ipmitool dstat zlib-devel ntp
+  redhat-lsb sysstat screen python-lxml python-yaml ipmitool dstat zlib-devel ntp
 
 MIRROR="http://mirror.hmc.edu/fedora/linux/releases/23/Everything/x86_64/os/Packages"
 
@@ -23,9 +23,10 @@ git clone https://github.com/axboe/fio.git
 git clone https://github.com/andikleen/pmu-tools.git
 git clone https://github.com/brendangregg/FlameGraph
 
-cd ${HOME}/fio
-./configure
-make
+cd fio 
+sudo sh configure
+sudo make
+sudo make install
 
 # wget < Red Hat Ceph Storage ISO URL >
 # sudo mount -o loop Ceph-*-dvd.iso /mnt

--- a/setup.sh
+++ b/setup.sh
@@ -11,12 +11,11 @@ sudo yum install -y psmisc util-linux coreutils xfsprogs e2fsprogs findutils \
 
 MIRROR="http://mirror.hmc.edu/fedora/linux/releases/23/Everything/x86_64/os/Packages"
 
-wget ${MIRROR}/p/pdsh-2.31-3.fc22.x86_64.rpm
-wget ${MIRROR}/p/pdsh-2.31-3.fc22.x86_64.rpm
-wget ${MIRROR}/p/pdsh-rcmd-ssh-2.31-3.fc22.x86_64.rpm
-wget ${MIRROR}/c/collectl-4.0.0-1.fc22.noarch.rpm
-wget ${MIRROR}/i/iftop-1.0-0.9.pre4.fc22.x86_64.rpm
-wget ${MIRROR}/i/iperf3-3.0.10-1.fc22.x86_64.rpm
+wget ${MIRROR}/p/pdsh-2.31-4.fc23.x86_64.rpm
+wget ${MIRROR}/p/pdsh-rcmd-ssh-2.31-4.fc23.x86_64.rpm
+wget ${MIRROR}/c/collectl-4.0.2-2.fc23.noarch.rpm
+wget ${MIRROR}/i/iftop-1.0-0.10.pre4.fc23.x86_64.rpm
+wget ${MIRROR}/i/iperf3-3.0.11-2.fc23.x86_64.rpm
 
 sudo yum localinstall -y *.rpm
 

--- a/setup.sh
+++ b/setup.sh
@@ -9,7 +9,7 @@ sudo yum install -y psmisc util-linux coreutils xfsprogs e2fsprogs findutils \
   git wget bzip2 make automake gcc gcc-c++ kernel-devel perf blktrace lsof \
   redhat-lsb sysstat screen python-yaml ipmitool dstat zlib-devel ntp
 
-MIRROR="http://mirror.hmc.edu/fedora/linux/releases/22/Everything/x86_64/os/Packages"
+MIRROR="http://mirror.hmc.edu/fedora/linux/releases/23/Everything/x86_64/os/Packages"
 
 wget ${MIRROR}/p/pdsh-2.31-3.fc22.x86_64.rpm
 wget ${MIRROR}/p/pdsh-2.31-3.fc22.x86_64.rpm


### PR DESCRIPTION
Hello Guys 

With this pull request i am submitting a few fixes to setup.sh, they are :
- Get dependent packages from FC23 repository rather than FC22
- Updated package names for FC23
- FIO installation from source is a 3 step process , configure , make and make install this needs to be done as sudo. 
- updated .gitignore

Changes has been tested and working fine.