### PR TITLE
Add ability to use block size splits

### DIFF
--- a/benchmark/kvmrbdfio.py
+++ b/benchmark/kvmrbdfio.py
@@ -26,7 +26,11 @@ class KvmRbdFio(Benchmark):
         self.rwmixread = config.get('rwmixread', 50)
         self.rwmixwrite = 100 - self.rwmixread
         self.ioengine = config.get('ioengine', 'libaio')
-        self.op_size = config.get('op_size', 4194304)
+        if config.get('bssplit'):
+          self.bssplit = config.get('bssplit')
+          self.op_size = 'bssplit'
+        else:
+          self.op_size = config.get('op_size', 4194304)
         self.pgs = config.get('pgs', 2048)
         self.vol_size = config.get('vol_size', 65536) * 0.9
         self.rep_size = config.get('rep_size', 1)
@@ -93,7 +97,10 @@ class KvmRbdFio(Benchmark):
         fio_cmd += ' --ramp_time=%s' % self.ramp
         fio_cmd += ' --numjobs=%s' % self.numjobs
         fio_cmd += ' --direct=1'
-        fio_cmd += ' --bs=%dB' % self.op_size
+        if self.bssplit:
+          fio_cmd += ' --bssplit=%s' % self.bssplit
+        else:
+          fio_cmd += ' --bs=%dB' % self.op_size
         fio_cmd += ' --iodepth=%d' % self.iodepth
         fio_cmd += ' --size=%dM' % self.vol_size 
         fio_cmd += ' --write_iops_log=%s' % out_file 

--- a/benchmark/librbdfio.py
+++ b/benchmark/librbdfio.py
@@ -31,7 +31,11 @@ class LibrbdFio(Benchmark):
         self.rwmixwrite = 100 - self.rwmixread
         self.log_avg_msec = config.get('log_avg_msec', None)
 #        self.ioengine = config.get('ioengine', 'libaio')
-        self.op_size = config.get('op_size', 4194304)
+        if config.get('bssplit'):
+          self.bssplit = config.get('bssplit')
+          self.op_size = 'bssplit'
+        else:
+          self.op_size = config.get('op_size', 4194304)
         self.pgs = config.get('pgs', 2048)
         self.vol_size = config.get('vol_size', 65536)
         self.vol_order = config.get('vol_order', 22)
@@ -140,7 +144,10 @@ class LibrbdFio(Benchmark):
             fio_cmd += ' --ramp_time=%s' % self.ramp
         fio_cmd += ' --numjobs=%s' % self.numjobs
         fio_cmd += ' --direct=1'
-        fio_cmd += ' --bs=%dB' % self.op_size
+        if self.bssplit:
+          fio_cmd += ' --bssplit=%s' % self.bssplit
+        else:
+          fio_cmd += ' --bs=%dB' % self.op_size
         fio_cmd += ' --iodepth=%d' % self.iodepth
         fio_cmd += ' --end_fsync=%s' % self.end_fsync
 #        if self.vol_size:

--- a/benchmark/rbdfio.py
+++ b/benchmark/rbdfio.py
@@ -31,7 +31,11 @@ class RbdFio(Benchmark):
         self.rwmixwrite = 100 - self.rwmixread
         self.log_avg_msec = config.get('log_avg_msec', None)
         self.ioengine = config.get('ioengine', 'libaio')
-        self.op_size = config.get('op_size', 4194304)
+        if config.get('bssplit'):
+          self.bssplit = config.get('bssplit')
+          self.op_size = 'bssplit'
+        else:
+          self.op_size = config.get('op_size', 4194304)
         self.vol_size = config.get('vol_size', 65536)
         self.vol_order = config.get('vol_order', 22)
         self.random_distribution = config.get('random_distribution', None)
@@ -113,7 +117,10 @@ class RbdFio(Benchmark):
             fio_cmd += ' --ramp_time=%s' % self.ramp
         fio_cmd += ' --numjobs=%s' % self.numjobs
         fio_cmd += ' --direct=%s' % self.direct
-        fio_cmd += ' --bs=%dB' % self.op_size
+        if self.bssplit:
+          fio_cmd += ' --bssplit=%s' % self.bssplit
+        else:
+          fio_cmd += ' --bs=%dB' % self.op_size
         fio_cmd += ' --iodepth=%d' % self.iodepth
         if self.vol_size:
             fio_cmd += ' --size=%dM' % (int(self.vol_size) * 0.9)


### PR DESCRIPTION
Currently CBT can only instruct fio to run workloads that consist
of a single block size. This introduces a way to craft mixed
workloads composed of multiple block sizes by using the bssplit
fio option.