### PR TITLE
conservative error-checking feature for CBT subprocesses

### DIFF
--- a/common.py
+++ b/common.py
@@ -7,42 +7,80 @@ import settings
 
 logger = logging.getLogger("cbt")
 
+# this class overrides the communicate() method to check the return code and
+# throw an exception if return code is not OK
 
-def popen(args):
-    logger.debug('%s', " ".join(args))
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+class CheckedPopen:
+    UNINIT=-720
+    OK=0
+    def __init__(self, args, continue_if_error=False):
+        self.args = args[:]
+        self.myrtncode = self.UNINIT
+        self.continue_if_error = continue_if_error
+        self.popen_obj = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+        logger.debug('CheckedPopen continue_if_error=%s args=%s'%(str(continue_if_error), ' '.join(args)))
 
+    def __str__(self):
+       return 'checked_Popen args=%s continue_if_error=%s rtncode=%d'%(str(self.args), str(self.continue_if_error), self.myrtncode)
 
-def pdsh(nodes, command):
-    return popen(['pdsh', '-R', 'ssh', '-w', nodes, command])
+    # we transparently check return codes for this method now so callers don't have to
 
+    def communicate(self, input=None, continue_if_error=True):
+        (stdoutdata, stderrdata) = self.popen_obj.communicate(input=input)
+        self.myrtncode = self.popen_obj.returncode  # THIS is the thing we couldn't do before
+        if self.myrtncode != self.OK:
+            if not self.continue_if_error:
+                raise Exception(str(self)+'\nstdout:\n'+stdoutdata+'\nstderr\n'+stderrdata)
+            else:
+                logger.warning(' '.join(self.args))
+                logger.warning('error %d seen, continuing anyway...'%self.myrtncode)
+        return (stdoutdata, stderrdata)
+
+    def wait(self):
+        self.communicate(continue_if_error=True)
+        return self.myrtncode
+
+# by default, do NOT abort if pdsh returns error status
+# this policy results in minimal code change to CBT while allowing
+# us to strengthen error checking where it's needed.
+
+def pdsh(nodes, command, continue_if_error=True):
+    args = ['pdsh', '-R', 'ssh', '-w', nodes, command]
+    # -S means pdsh fails if any host fails 
+    if not continue_if_error: args.insert(1, '-S')
+    return CheckedPopen(args,continue_if_error=continue_if_error)
+ 
 
 def pdcp(nodes, flags, localfile, remotefile):
     args = ['pdcp', '-f', '1', '-R', 'ssh', '-w', nodes]
     if flags:
         args += [flags]
-    return popen(args + [localfile, remotefile])
+    return CheckedPopen(args + [localfile, remotefile], 
+                        continue_if_error=False)
 
 
 def rpdcp(nodes, flags, remotefile, localfile):
     args = ['rpdcp', '-f', '1', '-R', 'ssh', '-w', nodes]
     if flags:
         args += [flags]
-    return popen(args + [remotefile, localfile])
+    return CheckedPopen(args + [remotefile, localfile], 
+                        continue_if_error=False)
 
 
 def scp(node, localfile, remotefile):
-    return popen(['scp', localfile, '%s:%s' % (node, remotefile)])
+    return CheckedPopen(['scp', localfile, '%s:%s' % (node, remotefile)], 
+                        continue_if_error=False)
 
 
 def rscp(node, remotefile, localfile):
-    return popen(['scp', '%s:%s' % (node, remotefile), localfile])
+    return CheckedPopen(['scp', '%s:%s' % (node, remotefile), localfile],
+                        continue_if_error=False)
 
 
 def make_remote_dir(remote_dir):
-    logger.info('Making remote directory: %s', remote_dir)
     nodes = settings.getnodes('clients', 'osds', 'mons', 'rgws', 'mds')
-    pdsh(nodes, 'mkdir -p -m0755 -- %s' % remote_dir).communicate()
+    pdsh(nodes, 'mkdir -p -m0755 -- %s' % remote_dir,
+         continue_if_error=False).communicate()
 
 
 def sync_files(remote_dir, local_dir):
@@ -52,7 +90,9 @@ def sync_files(remote_dir, local_dir):
         os.makedirs(local_dir)
 
     if 'user' in settings.cluster:
-        pdsh(nodes, 'sudo chown -R {0}.{0} {1}'.format(settings.cluster['user'], remote_dir)).communicate()
+        pdsh(nodes, 
+             'sudo chown -R {0}.{0} {1}'.format(settings.cluster['user'], remote_dir),
+             continue_if_error=False).communicate()
     rpdcp(nodes, '-r', remote_dir, local_dir).communicate()
 
 


### PR DESCRIPTION
CBT has not been checking subprocess return codes.  This makes CBT hard to use - if the user incorrectly edits the yaml file or the system is incorrectly configured, CBT will not tell the user that there is a problem immediately.  

This incarnation of error checking adds the ability to error check and throw an exception when a subprocess fails, without FORCING every command to do that (unlike my previous attempt).  Specifically pdsh() method calls default to NOT throwing an exception on an error.  This minimizes initial code change to CBT while allowing us to gradually harden it for key error cases (example: initial fio write to populate RBD device).    Be careful not to throw exceptions on cleanup commands such as process kills, or else you will get into a configuration where CBT cannot (automatically) recover.  Specifically benchmark/benchmark.py initialize() calls cleanup() method, so cleanup() code must be idempotent (doing it twice same as doing it once).