### PR TITLE
benchmark: remove directory hierarchy structure of CBT results

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -61,7 +61,7 @@ class Benchmark(object):
         self.cmd_path_full += self.cmd_path
 
         # Store the parameters of the test run
-        config_file = os.path.join(self.archive_dir, 'cbt_config.yaml')
+        config_file = os.path.join(self.archive_dir, 'benchmark_config.yaml')
         if not os.path.exists(self.archive_dir):
             os.makedirs(self.archive_dir)
         if not os.path.exists(config_file):

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -12,7 +12,7 @@ class Benchmark(object):
         self.config = config
         self.cluster = cluster
 #        self.cluster = Ceph(settings.cluster)
-        self.archive_dir = "%s/%08d/%s" % (settings.cluster.get('archive_dir'), config.get('iteration'), self.getclass())
+        self.archive_dir = "%s/%08d" % (settings.cluster.get('archive_dir'), config.get('iteration'))
         self.run_dir = "%s/%08d/%s" % (settings.cluster.get('tmp_dir'), config.get('iteration'), self.getclass())
         self.osd_ra = config.get('osd_ra', None)
         self.cmd_path = ''

--- a/benchmark/librbdfio.py
+++ b/benchmark/librbdfio.py
@@ -49,7 +49,7 @@ class LibrbdFio(Benchmark):
 
 	self.total_procs = self.procs_per_volume * self.volumes_per_client * len(settings.getnodes('clients').split(','))
         self.run_dir = '%s/osd_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.run_dir, int(self.osd_ra), int(self.op_size), int(self.total_procs), int(self.iodepth), self.mode)
-        self.out_dir = '%s/osd_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.archive_dir, int(self.osd_ra), int(self.op_size), int(self.total_procs), int(self.iodepth), self.mode)
+        self.out_dir = self.archive_dir
 
         self.norandommap = config.get("norandommap", False)
         # Make the file names string (repeated across volumes)

--- a/benchmark/radosbench.py
+++ b/benchmark/radosbench.py
@@ -68,10 +68,10 @@ class Radosbench(Benchmark):
         self.mkpools()
 
         # Run write test
-        self._run('write', '%s/write' % self.run_dir, self.out_dir)
+        self._run('write', '%s/write' % self.run_dir, '%s/write' % self.out_dir)
         # Run read test unless write_only
         if self.write_only: return
-        self._run(self.readmode, '%s/%s' % (self.run_dir, self.readmode), self.out_dir)
+        self._run(self.readmode, '%s/%s' % (self.run_dir, self.readmode), '%s/%s' % (self.out_dir, self.readmode))
 
     def _run(self, mode, run_dir, out_dir):
         # We'll always drop caches for rados bench

--- a/benchmark/radosbench.py
+++ b/benchmark/radosbench.py
@@ -29,7 +29,7 @@ class Radosbench(Benchmark):
         self.op_size = config.get('op_size', 4194304)
         self.object_set_id = config.get('object_set_id', '')
         self.run_dir = '%s/osd_ra-%08d/op_size-%08d/concurrent_ops-%08d' % (self.run_dir, int(self.osd_ra), int(self.op_size), int(self.concurrent_ops))
-        self.out_dir = '%s/osd_ra-%08d/op_size-%08d/concurrent_ops-%08d' % (self.archive_dir, int(self.osd_ra), int(self.op_size), int(self.concurrent_ops))
+        self.out_dir = self.archive_dir
         self.pool_profile = config.get('pool_profile', 'default')
         self.cmd_path = config.get('cmd_path', self.cluster.rados_cmd)
         self.pool = config.get('target_pool', 'rados-bench-cbt')
@@ -68,10 +68,10 @@ class Radosbench(Benchmark):
         self.mkpools()
 
         # Run write test
-        self._run('write', '%s/write' % self.run_dir, '%s/write' % self.out_dir)
+        self._run('write', '%s/write' % self.run_dir, self.out_dir)
         # Run read test unless write_only
         if self.write_only: return
-        self._run(self.readmode, '%s/%s' % (self.run_dir, self.readmode), '%s/%s' % (self.out_dir, self.readmode))
+        self._run(self.readmode, '%s/%s' % (self.run_dir, self.readmode), self.out_dir)
 
     def _run(self, mode, run_dir, out_dir):
         # We'll always drop caches for rados bench

--- a/settings.py
+++ b/settings.py
@@ -31,9 +31,12 @@ def initialize(ctx):
         shutdown('No benchmarks section found in config file, bailing.')
 
     # store cbt configuration in the archive directory
-    config_file = os.path.join(ctx.archive, 'cbt_config.yaml')
+    cbt_results = os.path.join(ctx.archive, 'results')
+    config_file = os.path.join(cbt_results, 'cbt_config.yaml')
     if not os.path.exists(ctx.archive):
         os.makedirs(ctx.archive)
+    if not os.path.exists(cbt_results):
+        os.makedirs(cbt_results)
     if not os.path.exists(config_file):
         config_dict = dict(cluster=cluster, benchmarks=benchmarks)
         with open(config_file, 'w') as fd:

--- a/settings.py
+++ b/settings.py
@@ -30,6 +30,15 @@ def initialize(ctx):
     if not benchmarks:
         shutdown('No benchmarks section found in config file, bailing.')
 
+    # store cbt configuration in the archive directory
+    config_file = os.path.join(ctx.archive, 'cbt_config.yaml')
+    if not os.path.exists(ctx.archive):
+        os.makedirs(ctx.archive)
+    if not os.path.exists(config_file):
+        config_dict = dict(cluster=cluster, benchmarks=benchmarks)
+        with open(config_file, 'w') as fd:
+            yaml.dump(config_dict, fd, default_flow_style=False)
+
     # set the tmp_dir if not set.
     if 'tmp_dir' not in cluster:
         cluster['tmp_dir'] = '/tmp/cbt.%s' % os.getpid()


### PR DESCRIPTION
This PR is aimed at eliminating the directory hierarchy approach of cbt to archive results.
Currently, we have an implementation for the following benchmarks:

- radosbench

- librbdfio
 
We also store the parameters of the cbt run in yaml format inside the archive directory.