### PR TITLE
monitoring.py: add escape character to regex

### DIFF
--- a/monitoring.py
+++ b/monitoring.py
@@ -9,7 +9,7 @@ def start(directory):
     # blktrace_dir = '%s/blktrace' % directory
 
     # collectl
-    rawdskfilt = '+cciss/c\d+d\d+ |hd[ab] | sd[a-z]+ |dm-\d+ |xvd[a-z] |fio[a-z]+ | vd[a-z]+ |emcpower[a-z]+ |psv\d+ |nvme[0-9]n[0-9]+p[0-9]+ '
+    rawdskfilt = '\+cciss/c\d+d\d+ |hd[ab] | sd[a-z]+ |dm-\d+ |xvd[a-z] |fio[a-z]+ | vd[a-z]+ |emcpower[a-z]+ |psv\d+ |nvme[0-9]n[0-9]+p[0-9]+ '
     common.pdsh(nodes, 'mkdir -p -m0755 -- %s' % collectl_dir)
     common.pdsh(nodes, 'collectl -s+mYZ -i 1:10 --rawdskfilt "%s" -F0 -f %s' % (rawdskfilt, collectl_dir))
 


### PR DESCRIPTION
This change seems to be particularly required for Ubuntu. On Fedora and CentOS, collectl works with or without the escape character in the regex.

Here's what we want to avoid in Ubuntu:
`Quantifier follows nothing in regex; marked by <-- HERE in m/+ <-- HERE cciss/c\d+d\d+ |hd[ab] | sd[a-z]+ |dm-\d+ |xvd[a-z] |fio[a-z]+ | vd[a-z]+ |emcpower[a-z]+ |psv\d+ |nvme[0-9]n[0-9]+p[0-9]+ / at /usr/share/collectl/formatit.ph line 235.`

Signed-off-by: Neha Ojha <nojha@redhat.com>