### PR TITLE
Add sudo permission when make_remote_dir

### DIFF
--- a/common.py
+++ b/common.py
@@ -116,7 +116,7 @@ def clean_remote_dir (remote_dir):
 
 def make_remote_dir(remote_dir):
     nodes = settings.getnodes('clients', 'osds', 'mons', 'rgws', 'mds')
-    pdsh(nodes, 'mkdir -p -m0755 -- %s' % remote_dir,
+    pdsh(nodes, 'sudo mkdir -p -m0755 -- %s' % remote_dir,
          continue_if_error=False).communicate()
 
 


### PR DESCRIPTION
[root@admin cbt]# pdsh -S -f 5 -R ssh -w root@node1,root@node2,root@node3,root@client,root@admin
pdsh> ^C
[root@admin cbt]# ./cbt.py --archive=/tmp ./nhanhoa.yaml 
15:39:25 - DEBUG    - cbt      - Settings.cluster:
    {'archive_dir': '/tmp',
     'clients': ['admin', 'node1', 'node2', 'node3', 'client'],
     'clusterid': 'ceph',
     'conf_file': 'nhanhoa.conf.1osd',
     'fs': 'xfs',
     'head': 'admin',
     'iterations': 1,
     'mkfs_opts': '-f -i size=2048',
     'mons': ['node2', 'node2', 'node3'],
     'mount_opts': '-o inode64,noatime,logbsize=256k',
     'osds': ['node2', 'node2', 'node3'],
     'osds_per_node': 2,
     'pool_profiles': {'rbd': {'pg_size': 256, 'pgp_size': 256, 'replication': 1}},
     'tmp_dir': '/tmp/ceph',
     'use_existing': True,
     'user': 'cephuser'}
15:39:25 - DEBUG    - cbt      - Nodes : cephuser@node3,cephuser@node2
15:39:25 - DEBUG    - cbt      - Nodes : cephuser@node3,cephuser@node2,cephuser@admin,cephuser@node1,cephuser@client
15:39:25 - DEBUG    - cbt      - Nodes : cephuser@node3,cephuser@node2,cephuser@admin,cephuser@node1,cephuser@client
15:39:25 - INFO     - cbt      - Deleting /tmp/ceph/ceph
15:39:25 - DEBUG    - cbt      - CheckedPopen continue_if_error=True args=pdsh -f 5 -R ssh -w cephuser@node3,cephuser@node2,cephuser@admin,cephuser@node1,cephuser@client sudo rm -rf /tmp/ceph/ceph
cleaning remote dir /tmp/ceph/00000000/LibrbdFio/osd_ra-00004096/op_size-04194304/concurrent_procs-005/iodepth-064/read
15:39:25 - DEBUG    - cbt      - Nodes : cephuser@node3,cephuser@node2,cephuser@admin,cephuser@node1,cephuser@client
15:39:25 - DEBUG    - cbt      - CheckedPopen continue_if_error=False args=pdsh -S -f 5 -R ssh -w cephuser@node3,cephuser@node2,cephuser@admin,cephuser@node1,cephuser@client if [ -d "/tmp/ceph/00000000/LibrbdFio/osd_ra-00004096/op_size-04194304/concurrent_procs-005/iodepth-064/read" ]; then rm -rf /tmp/ceph/00000000/LibrbdFio/osd_ra-00004096/op_size-04194304/concurrent_procs-005/iodepth-064/read; fi
15:39:26 - DEBUG    - cbt      - Nodes : cephuser@node3,cephuser@node2,cephuser@admin,cephuser@node1,cephuser@client
15:39:26 - DEBUG    - cbt      - CheckedPopen continue_if_error=False args=pdsh -S -f 5 -R ssh -w cephuser@node3,cephuser@node2,cephuser@admin,cephuser@node1,cephuser@client mkdir -p -m0755 -- /tmp/ceph/00000000/LibrbdFio/osd_ra-00004096/op_size-04194304/concurrent_procs-005/iodepth-064/read
15:39:26 - ERROR    - cbt      - During tests
Traceback (most recent call last):
  File "./cbt.py", line 64, in main
    b.initialize()
  File "/root/cbt/benchmark/librbdfio.py", line 72, in initialize
    common.make_remote_dir(self.run_dir)
  File "/root/cbt/common.py", line 120, in make_remote_dir
    continue_if_error=False).communicate()
  File "/root/cbt/common.py", line 33, in communicate
    raise Exception(str(self)+'\nstdout:\n'+stdoutdata+'\nstderr\n'+stderrdata)
Exception: checked_Popen args=['pdsh', '-S', '-f', '5', '-R', 'ssh', '-w', 'cephuser@node3,cephuser@node2,cephuser@admin,cephuser@node1,cephuser@client', 'mkdir -p -m0755 -- /tmp/ceph/00000000/LibrbdFio/osd_ra-00004096/op_size-04194304/concurrent_procs-005/iodepth-064/read'] continue_if_error=False rtncode=1
stdout:

stderr
admin: mkdir: cannot create directory ‘/tmp/ceph/00000000/LibrbdFio/osd_ra-00004096/op_size-04194304/concurrent_procs-005/iodepth-064/read’: Permission denied
pdsh@admin: admin: ssh exited with exit code 1

[root@admin cbt]#