### PR TITLE
monitoring.py: revert to old regex

### DIFF
--- a/monitoring.py
+++ b/monitoring.py
@@ -9,7 +9,7 @@ def start(directory):
     # blktrace_dir = '%s/blktrace' % directory
 
     # collectl
-    rawdskfilt = '\+cciss/c\d+d\d+ |hd[ab] | sd[a-z]+ |dm-\d+ |xvd[a-z] |fio[a-z]+ | vd[a-z]+ |emcpower[a-z]+ |psv\d+ |nvme[0-9]n[0-9]+p[0-9]+ '
+    rawdskfilt = '+cciss/c\d+d\d+ |hd[ab] | sd[a-z]+ |dm-\d+ |xvd[a-z] |fio[a-z]+ | vd[a-z]+ |emcpower[a-z]+ |psv\d+ |nvme[0-9]n[0-9]+p[0-9]+ '
     common.pdsh(nodes, 'mkdir -p -m0755 -- %s' % collectl_dir)
     common.pdsh(nodes, 'collectl -s+mYZ -i 1:10 --rawdskfilt "%s" -F0 -f %s' % (rawdskfilt, collectl_dir))
 


### PR DESCRIPTION
On ubuntu, collectl V3.6.9-1 (zlib:2.06,HiRes:1.9725) required an escape character in the beginning of the regex. However, collectl V4.0.4-1 (zlib:2.068,HiRes:1.9726) does not require this.

Signed-off-by: Neha Ojha <nojha@redhat.com>