### PR TITLE
skip sync of archive files on all nodes, the cos log directory will n…

### DIFF
--- a/benchmark/cosbench.py
+++ b/benchmark/cosbench.py
@@ -240,7 +240,6 @@ class Cosbench(Benchmark):
         monitoring.stop(self.run_dir)
         self.cluster.dump_historic_ops(self.run_dir)
         common.sync_files('%s/*' % self.run_dir, self.out_dir)
-        common.sync_files('%s/archive/%s*' % (self.config["cosbench_dir"], self.runid), self.out_dir)
 
     def check_workload_status(self):
         logger.info("Checking workload status")


### PR DESCRIPTION
skip sync of archive files on all nodes, the cos log directory will not be available

on all nodes.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>