### PR TITLE
cluster/ceph: Allow string/list representation for mons/osds/clients

### DIFF
--- a/benchmark/fio.py
+++ b/benchmark/fio.py
@@ -224,11 +224,12 @@ class Fio(Benchmark):
 
     def analyze(self, out_dir):
         logger.info('Convert results to json format.')
-        for client in settings.cluster.get('clients'):
+        for client in settings.getnodes('clients').split(','):
+            host = settings.host_info(client)["host"]
             for i in xrange(self.endpoints_per_client):
                 found = 0
-                out_file = '%s/output.%d.%s' % (out_dir, i, client)
-                json_out_file = '%s/json_output.%d.%s' % (out_dir, i, client)
+                out_file = '%s/output.%d.%s' % (out_dir, i, host)
+                json_out_file = '%s/json_output.%d.%s' % (out_dir, i, host)
                 with open(out_file) as fd:
                     with open(json_out_file, 'w') as json_fd:
                         for line in fd.readlines():

--- a/benchmark/librbdfio.py
+++ b/benchmark/librbdfio.py
@@ -200,11 +200,12 @@ class LibrbdFio(Benchmark):
         common.pdsh(settings.getnodes('clients'), 'sudo killall -2 fio').communicate()
 
     def parse(self, out_dir):
-        for client in settings.cluster.get('clients'):
+        for client in settings.getnodes('clients').split(','):
+            host = settings.host_info(client)["host"]
             for i in xrange(self.volumes_per_client):
                 found = 0
-                out_file = '%s/output.%d.%s' % (out_dir, i, client)
-                json_out_file = '%s/json_output.%d.%s' % (out_dir, i, client)
+                out_file = '%s/output.%d.%s' % (out_dir, i, host)
+                json_out_file = '%s/json_output.%d.%s' % (out_dir, i, host)
                 with open(out_file) as fd:
                     with open(json_out_file, 'w') as json_fd:
                         for line in fd.readlines():

--- a/benchmark/radosbench.py
+++ b/benchmark/radosbench.py
@@ -167,12 +167,13 @@ class Radosbench(Benchmark):
         common.pdsh(settings.getnodes('clients'), 'sudo killall -9 rados').communicate()
 
     def parse(self, out_dir):
-        for client in settings.cluster.get('clients'):
+        for client in settings.getnodes('clients').split(','):
+            host = settings.host_info(client)["host"]
             for i in xrange(self.concurrent_procs):
                 result = {}
                 found = 0
-                out_file = '%s/output.%s.%s' % (out_dir, i, client)
-                json_out_file = '%s/json_output.%s.%s' % (out_dir, i, client)
+                out_file = '%s/output.%s.%s' % (out_dir, i, host)
+                json_out_file = '%s/json_output.%s.%s' % (out_dir, i, host)
                 with open(out_file) as fd:
                     for line in fd.readlines():
                         if found == 0:

--- a/client_endpoints/ceph_client_endpoints.py
+++ b/client_endpoints/ceph_client_endpoints.py
@@ -25,7 +25,7 @@ class CephClientEndpoints(ClientEndpoints):
 
         # get the list of mons
         self.mon_addrs  = []
-        mon_hosts = self.cluster.config.get('mons')
+        mon_hosts = self.cluster.get_mon_hosts()
         for mon_host, mons in mon_hosts.iteritems():
             for mon, addr in mons.iteritems():
                  self.mon_addrs.append(addr)


### PR DESCRIPTION
This PR allows string and list representation of mons in the yaml to work when building a cluster and using client endpoints.

String representation: 
```yaml
mons: "localhost"
```
or
```yaml
mons: "127.0.0.1"
```
List representation:

```yaml
mons: ["localhost"]
```
or
```yaml
mons:["127.0.0.1"]
```
Dict representation:
```yaml
mons:
  localhost:
    a: "127.0.0.1:6789"
```

usernames for ssh/pdsh can also now be specified on a per-host basis that override the global user setting:

```yaml
mons: "user@localhost"
```
```yaml
mons: ["user@localhost"]
```
```yaml
mons:
  user@localhost:
    a: "127.0.0.1:6789"
```

Currently the string and list representation will assume that mon ids are listed starting with "a" and ending with "z".  dns resolution is used to find the ip to use when creating the monitor which should match what is configured in ceph (via the ceph.conf file or other means).  In the string and list representation it assumed that a single monitor is running on given host on the default port.  If the monitor is running on an alternate ip address, port, uses a different id convention, or multiple monitors are running on a single host, the dict representation should be used.

Signed-off-by: Mark Nelson <mnelson@redhat.com>