### PR TITLE
benchmark/radosbench: do not error out if max_objects is not set

### DIFF
--- a/benchmark/radosbench.py
+++ b/benchmark/radosbench.py
@@ -109,10 +109,10 @@ class Radosbench(Benchmark):
         else:
             max_objects = self.max_objects
         max_objects_str = ''
-        if max_objects and rados_version > 9:
+        if max_objects:
+            if rados_version < 10:
+                raise ValueError('max_objects not supported by rados_version < 10')
             max_objects_str = '--max-objects %s' % max_objects
-        else:
-            raise ValueError('max_objects not supported by rados_version < 9')
 
         # Operation type 
         op_type = mode


### PR DESCRIPTION
there is chance that neither "prefill_objects" with "prefill" mode set
nor
"max_objects" is set. in that case, we should not panic.

also the "max-objects" option was introduced by
3ce648d349e1e51b6324a237a665fbd0f54b8996 in ceph/ceph, so the first
release of `rados` cli utilities had this feature was jewel, which is
v10.0:

$ git tag --contains 3ce648d349e | head
v10.0.4
v10.0.5
v10.1.0
v10.1.1
v10.1.2
v10.2.0
v10.2.1
v10.2.10
v10.2.11
v10.2.2

Signed-off-by: Kefu Chai <kchai@redhat.com>