### PR TITLE
settings: better fix for conf and archive dir checks.

### DIFF
--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -120,7 +120,7 @@ class Ceph(Cluster):
         self.tmp_conf = '%s/ceph.conf' % self.tmp_dir
         # If using an existing cluster, defualt to /etc/ceph/ceph.conf
         if self.use_existing:
-            self.tmp_conf = self.config.get('conf_file', '/etc/ceph/ceph.conf')
+            self.tmp_conf = self.config.get('conf_file')
 
         self.osd_valgrind = config.get('osd_valgrind', None)
         self.mon_valgrind = config.get('mon_valgrind', None)


### PR DESCRIPTION
https://github.com/ceph/cbt/pull/182 didn't actually fix the conf file regression seen in teuthology since the conf file was being set improperly in settings.  Revert that change, fix settings.py, and perform error checking for the conf_file and archive_dir.

Edit: Also fix a bug where the command line archive_dir setting was always being used for directory creation.

Signed-off-by: Mark Nelson <mnelson@redhat.com>