### PR TITLE
common: pdsh() accepts list as its command parameter.

### DIFF
--- a/common.py
+++ b/common.py
@@ -102,7 +102,7 @@ def pdsh(nodes, command, continue_if_error=True):
     if local_node:
         return sh(local_node, command, continue_if_error=continue_if_error)
     else:
-        args = ['pdsh', '-f', str(len(expanded_node_list(nodes))), '-R', 'ssh', '-w', nodes, command]
+        args = ['pdsh', '-f', str(len(expanded_node_list(nodes))), '-R', 'ssh', '-w', nodes, join_nostr(command)]
         # -S means pdsh fails if any host fails
         if not continue_if_error: args.insert(1, '-S')
         return CheckedPopen(args,continue_if_error=continue_if_error)


### PR DESCRIPTION
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

------------

The problem this PR tries to deal with can be illustrated with following trackback:

```
2019-08-09T20:25:56.287 INFO:teuthology.orchestra.run.smithi195.stderr:Traceback (most recent call last):
2019-08-09T20:25:56.287 INFO:teuthology.orchestra.run.smithi195.stderr:  File "/home/ubuntu/cephtest/cbt/cbt.py", line 64, in main
2019-08-09T20:25:56.287 INFO:teuthology.orchestra.run.smithi195.stderr:    b.initialize()
2019-08-09T20:25:56.287 INFO:teuthology.orchestra.run.smithi195.stderr:  File "/home/ubuntu/cephtest/cbt/benchmark/radosbench.py", line 57, in initialize
2019-08-09T20:25:56.287 INFO:teuthology.orchestra.run.smithi195.stderr:    monitoring.start("%s/idle_monitoring" % self.run_dir)
2019-08-09T20:25:56.287 INFO:teuthology.orchestra.run.smithi195.stderr:  File "/home/ubuntu/cephtest/cbt/monitoring.py", line 106, in start
2019-08-09T20:25:56.288 INFO:teuthology.orchestra.run.smithi195.stderr:    m.start(directory)
2019-08-09T20:25:56.288 INFO:teuthology.orchestra.run.smithi195.stderr:  File "/home/ubuntu/cephtest/cbt/monitoring.py", line 35, in start
2019-08-09T20:25:56.288 INFO:teuthology.orchestra.run.smithi195.stderr:    common.pdsh(self.nodes, ['collectl', self.args.format(collectl_dir=collectl_dir)])
2019-08-09T20:25:56.288 INFO:teuthology.orchestra.run.smithi195.stderr:  File "/home/ubuntu/cephtest/cbt/common.py", line 108, in pdsh
2019-08-09T20:25:56.288 INFO:teuthology.orchestra.run.smithi195.stderr:    return CheckedPopen(args,continue_if_error=continue_if_error)
2019-08-09T20:25:56.288 INFO:teuthology.orchestra.run.smithi195.stderr:  File "/home/ubuntu/cephtest/cbt/common.py", line 22, in __init__
2019-08-09T20:25:56.288 INFO:teuthology.orchestra.run.smithi195.stderr:    % (str(continue_if_error), str(shell), join_nostr(args)))
2019-08-09T20:25:56.289 INFO:teuthology.orchestra.run.smithi195.stderr:  File "/home/ubuntu/cephtest/cbt/common.py", line 13, in join_nostr
2019-08-09T20:25:56.289 INFO:teuthology.orchestra.run.smithi195.stderr:    return command if isinstance(command, str) else ' '.join(command)
2019-08-09T20:25:56.289 INFO:teuthology.orchestra.run.smithi195.stderr:TypeError: sequence item 7: expected string, list found
```