### PR TITLE
monitoring: kill local "perf" processes by their pids

### DIFF
--- a/monitoring.py
+++ b/monitoring.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from glob import glob
 import os.path
 
@@ -126,4 +127,14 @@ def start(directory):
 
 def stop(directory=None):
     for m in Monitoring._get_all():
+        m.stop(directory)
+
+@contextmanager
+def monitor(directory):
+    monitors = []
+    for m in Monitoring._get_all():
+        m.start(directory)
+        monitors.append(m)
+    yield
+    for m in monitors:
         m.stop(directory)


### PR DESCRIPTION
as on some distro, `perf` actuall execv another `perf_*` to do its job,
so we cannot use `pkill` to kill `perf`

Signed-off-by: Kefu Chai <kchai@redhat.com>