### PR TITLE
fio_objectstore_tools: utilities for tracing fio_ceph_objectstore

### DIFF
--- a/tools/fio_objectstore_tools/analyze.py
+++ b/tools/fio_objectstore_tools/analyze.py
@@ -1,0 +1,124 @@
+#!env python3
+
+import json
+import os
+import sys
+import itertools
+import argparse
+import sys
+import subprocess
+import numpy as np
+
+from summarize import dump_target, generate_summary
+from traces import open_trace, iterate_structured_trace
+from graph import graph, Scatter, Histogram
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    'target', metavar='T', type=str, help='target results directory')
+parser.add_argument(
+    '--match', type=str, help='json for matching', default='{}')
+parser.add_argument(
+    '--output', type=str, help='output directory')
+parser.add_argument(
+    '--generate-graphs', action='store_true', help='generate graphs')
+parser.add_argument(
+    '--detailed', action='store_true',
+    help='generate more detailed graphs')
+parser.add_argument(
+    '--drop-first', type=float,
+    help='drop', default=10.0)
+parser.add_argument(
+    '--drop-after', type=float,
+    help='drop')
+parser.add_argument(
+    '--filter-latency-above', type=float,
+    help='filter out latency above given percentile')
+parser.add_argument(
+    '--filter-latency-below', type=float,
+    help='filter out latency below given percentile')
+
+
+def get_targets(directory):
+    contents = os.listdir(directory)
+    if 'ceph.conf' in contents:
+        return [(os.path.basename(directory), directory)]
+    else:
+        return [(x, os.path.join(directory, x)) for x in contents]
+
+
+args = parser.parse_args()
+
+match = json.loads(args.match)
+targets = get_targets(args.target)
+projected = [dump_target(name, target) for name, target in targets]
+
+def do_filter(match, input):
+    def cond(x):
+        return all(x[1]['config'].get(k) == v for k, v in match.items())
+    return filter(cond, input)
+
+filtered_targets, filtered = zip(*do_filter(match, zip(targets, projected)))
+
+summary = generate_summary(filtered, match)
+
+graph_filename = lambda x: None
+if args.output:
+    subprocess.run(['mkdir', '-p', args.output], check=False)
+    graph_filename = lambda x: os.path.join(args.output, x + '.png')
+
+def do_mask(above, below):
+    def f(lat):
+        l, u = np.percentile(
+            lat,
+            [below if below else 0.0,
+             above if above else 100.0],
+            interpolation='linear')
+
+        return (lat > l) & (lat < u)
+    return f
+
+masker = None
+mask_params = None
+
+if args.filter_latency_above or args.filter_latency_below:
+    mask_params = ['latency']
+    masker = do_mask(args.filter_latency_above, args.filter_latency_below)
+
+TO_GRAPH_SMALL = [
+    [Scatter(x, 'commit_latency_no_throttle', ymax=0.99) for x in
+     ['current_kv_throttle_cost', 'current_deferred_throttle_cost']],
+    [Scatter(x, 'throughput', ymax=0.99) for x in
+     ['current_kv_throttle_cost', 'current_deferred_throttle_cost']]
+]
+
+TO_GRAPH_LARGE = [
+    [Scatter(*x, ymax=0.99) for x in
+     [('current_kv_throttle_cost', 'commit_latency_no_throttle'),
+      ('current_deferred_throttle_cost', 'commit_latency_no_throttle'),
+      ('total_throttle', 'commit_latency_no_throttle')]],
+    [Scatter(*x, ymax=0.99) for x in
+     [('current_kv_throttle_cost', 'throughput'),
+      ('current_deferred_throttle_cost', 'throughput'),
+      ('total_throttle', 'throughput')]],
+    [Histogram(x) for x in
+     ['current_kv_throttle_cost', 'current_deferred_throttle_cost', 'total_throttle']]
+]
+
+if args.generate_graphs:
+    for name, path in filtered_targets:
+        print("Generating graph for {}, path: {}".format(name, path))
+        events = iterate_structured_trace(open_trace(path))
+        if args.drop_first:
+            events = itertools.dropwhile(
+                lambda x: x.get_start() < args.drop_first, events)
+        if args.drop_after:
+            events = itertools.takewhile(
+                lambda x: x.get_start() < args.drop_after, events)
+
+        graph(
+            events, name, graph_filename(name),
+            TO_GRAPH_LARGE if args.detailed else TO_GRAPH_SMALL,
+            mask_params, masker)
+
+json.dump(summary, sys.stdout, sort_keys=True, indent=2)

--- a/tools/fio_objectstore_tools/bluestore_throttle_tuning.rst
+++ b/tools/fio_objectstore_tools/bluestore_throttle_tuning.rst
@@ -1,0 +1,62 @@
+=========================
+BlueStore Throttle Tuning
+=========================
+
+Motivation
+==========
+
+BlueStore has a throttling mechanism in order to ensure that queued IO doesn't
+increase without bound.  If this throttle is set too low, osd throughput will
+suffer.  If it's set too high, we'll see unnecessary increases in latency at
+the objectstore level preventing the OSD queues from performing QoS.  If
+latency at the objectstore level is 1s due to the current queue length, the
+best possible latency for an incoming high priority IO would be 1s.
+
+Generally, we'd expect the relationship between latency and throttle value (or
+queue depth) to have two behavior types.  When the store is sub-saturated, we'd
+expect increases in queued IO to increase throughput with little corresponding
+increase in latency.  As the store saturates, we'd expect throughput to become
+relatively insensitive to throttle, but latency would begin to increase
+linearly.
+
+In choosing these throttle limits, a user would want first to understand the
+latency/throughput/throttle relationships for their hardware as well as their
+workload/application's preference for latency vs throughput.  One could choose
+to deliberately sacrafice some amount of max throughput in exchange for better
+qos, or one might choose to capture as much throughput as possible at the
+expense of higher average and especially tail latency.
+
+Usage
+=====
+
+There is a backend for fio (src/test/fio/fio_ceph_objectstore.cc) which backs
+fio with a single objectstore instance.  This instance has an option which will
+at configurable intervals alter the throttle values among the configured
+options online as the fio test runs.  By capturing a trace of ios performed via
+lttng, we can get an idea of the throttle/latency/throughput relationship for a
+particular workload and device.
+
+First, ceph needs to be built with fio and lttng:
+
+::
+   ./do_cmake.sh --verbose -DWITH_FIO=on -DWITH_LTTNG=on -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+Next, there are a few scripts in the cbt.git repository to ease running fio
+with the right backend and graphing the results under fio_objectstore_tools/.
+Create a copy of runs.json updating configs as needed (particularly device
+paths).  You can then do a run by running:
+
+::
+   ./run.py --initialize runs <path_to_json>
+   ./run.py --run <path_to_json>
+
+Results will appear in dated subdirs under ~/output by default.
+
+In order to generate graphs from these results, run:
+
+::
+   ./analyze.py --generate-graphs --output <path_for_generated_pdfs> <path_to_output_dir>
+
+The resulting graphs will plot latency and throughput for each traced IO (with
+curves for median (green) and 99pct (red)) against the kv throttle and deferred
+throttle values when the IO was released from the throttle.

--- a/tools/fio_objectstore_tools/graph.py
+++ b/tools/fio_objectstore_tools/graph.py
@@ -1,0 +1,319 @@
+#!env python3
+
+import numpy as np
+import matplotlib
+import matplotlib.figure
+from traces import Write
+import matplotlib.backends
+import matplotlib.backends.backend_pdf as backend
+from scipy import interpolate
+
+FEATURES = Write.get_features()
+
+def weighted_quantile(values, quantiles, sample_weight=None,
+                      values_sorted=False):
+    """
+    Adapted from: https://stackoverflow.com/questions/21844024/weighted-percentile-using-numpy
+    Very close to numpy.percentile, but supports weights.
+    NOTE: quantiles should be in [0, 1]!
+    :param values: numpy.array with data
+    :param quantiles: array-like with many quantiles needed
+    :param sample_weight: array-like of the same length as `array`
+    :param values_sorted: bool, if True, then will avoid sorting of
+        initial array
+    :return: numpy.array with computed quantiles.
+    """
+    values = np.array(values)
+    quantiles = np.array(quantiles)
+    if sample_weight is None:
+        sample_weight = np.ones(len(values))
+    sample_weight = np.array(sample_weight)
+    assert np.all(quantiles >= 0) and np.all(quantiles <= 1), \
+        'quantiles should be in [0, 1]'
+
+    if not values_sorted:
+        sorter = np.argsort(values)
+        values = values[sorter]
+        sample_weight = sample_weight[sorter]
+
+    weighted_quantiles = np.cumsum(sample_weight) - 0.5 * sample_weight
+    weighted_quantiles -= weighted_quantiles[0]
+    weighted_quantiles /= weighted_quantiles[-1]
+    return np.interp(quantiles, weighted_quantiles, values)
+
+def generate_throughput(start, ios):
+    P = 1.0
+    tp = np.empty_like(start)
+    for i in range(len(start)):
+        limit = i
+        count = 0
+        while limit < len(start) and start[limit] - start[i] < P:
+            count += ios[limit]
+            limit += 1
+
+        if start[limit - 1] - start[i] < (P/4):
+            tp[i] = 0
+        else:
+            tp[i] = count / (start[limit - 1] - start[i])
+    return tp
+
+SECONDARY_FEATURES = {
+    'prepare_kv_queued_and_submitted': (
+        ('state_prepare_duration', 'state_kv_submitted_duration', 'state_kv_queued_duration'),
+        's',
+        float,
+        lambda x, y, z: x + y + z),
+    'kv_sync_size': (
+        ('kv_batch_size', 'deferred_done_batch_size', 'deferred_stable_batch_size'),
+        'n',
+        int,
+        lambda x, y, z: x + y + z),
+    'deferred_batch_size': (
+        ('deferred_done_batch_size', 'deferred_stable_batch_size'),
+        'n',
+        int,
+        lambda x, y: x + y),
+    'incomplete_ios': (
+        ('total_pending_ios', 'total_pending_deferred_ios'),
+        'n',
+        int,
+        lambda x, y: x + y),
+    'committing_state': (
+        ('state_prepare_duration', 'state_kv_queued_duration', 'state_kv_submitted_duration'),
+        's',
+        int,
+        lambda x, y, z: x + y + z),
+    'commit_latency_no_throttle': (
+        ('commit_latency', 'throttle_time'),
+        's',
+        int,
+        lambda x, y: x - y),
+    'throughput': (
+        ('time', 'ios_completed_since_last_traced_io'),
+        'iops',
+        float,
+        lambda t, ios: generate_throughput(t, ios)),
+    'weight': (
+        ('ios_started_since_last_traced_io',),
+        'ratio',
+        float,
+        lambda x: x.astype(float)),
+    'total_throttle': (
+        ('current_kv_throttle_cost', 'current_deferred_throttle_cost'),
+        'bytes',
+        float,
+        lambda x, y: x + y),
+}
+
+def get_unit(feat):
+    if feat in FEATURES:
+        return FEATURES[feat][2]
+    elif feat in SECONDARY_FEATURES:
+        return SECONDARY_FEATURES[feat][1]
+    else:
+        assert False, "{} isn't a valid feature".format(feat)
+
+def get_dtype(feat):
+    if feat in FEATURES:
+        return FEATURES[feat][1]
+    elif feat in SECONDARY_FEATURES:
+        return SECONDARY_FEATURES[feat][2]
+    else:
+        assert False, "{} isn't a valid feature".format(feat)
+
+def get_features(features):
+    s = set()
+    gmap = {}
+    for ax in features:
+        if ax in FEATURES:
+            s.add(ax)
+            gmap[ax] = (lambda name: (lambda x: x[name]))(ax)
+        elif ax in SECONDARY_FEATURES:
+            pfeat = list(SECONDARY_FEATURES[ax][0])
+            for f in pfeat:
+                s.add(f)
+            gmap[ax] = (lambda name, pf: lambda x: SECONDARY_FEATURES[name][3](
+                *[x[feat] for feat in pf]))(ax, pfeat)
+        else:
+            assert False, "Invalid feature {}".format(ax)
+    return s, gmap
+
+def to_arrays(pfeats, events):
+    arrays = [(pfeat, FEATURES[pfeat][0], FEATURES[pfeat][1], [])
+              for pfeat in pfeats]
+
+    count = 0
+    SIZE = 4096
+
+    for event in events:
+        if (count % SIZE == 0):
+            for pfeat, _, dtype, l in arrays:
+                l.append(np.zeros(SIZE, dtype=dtype))
+
+        offset = count % SIZE
+        for name, f, _, l in arrays:
+            l[-1][offset] = f(event)
+
+        count += 1
+
+    last_size = count % SIZE
+    for name, _, _, l in arrays:
+        l[-1] = l[-1][:last_size]
+
+    return dict(((feat, np.concatenate(l).ravel()) for feat, _, _, l in arrays))
+
+class Graph(object):
+    def sources(self):
+        pass
+
+    def graph(self, ax, *sources):
+        pass
+
+    def name(self):
+        pass
+
+class Scatter(Graph):
+    def __init__(self, x, y, ymax=0):
+        self.__sources = [x, y]
+        self.__ymax = ymax
+        self.__xname = x
+        self.__yname = y
+        self.__xunit = get_unit(x)
+        self.__yunit = get_unit(y)
+
+    def sources(self):
+        return ['weight', self.__xname, self.__yname]
+
+    def graph(self, ax, w, x, y):
+        bins, x_e, y_e = np.histogram2d(x, y, bins=1000, weights=w)
+        z = interpolate.interpn(
+            (0.5*(x_e[1:] + x_e[:-1]) , 0.5*(y_e[1:]+y_e[:-1])),
+            bins,
+            np.vstack([x,y]).T,
+            method = "nearest",
+            fill_value = None,
+            bounds_error = False)
+
+        idx = z.argsort()
+
+        ax.set_xlabel(
+            "{name} ({unit})".format(name=self.__xname, unit=self.__xunit),
+            fontsize=FONTSIZE
+        )
+        ax.set_ylabel(
+            "{name} ({unit})".format(name=self.__yname, unit=self.__yunit),
+            fontsize=FONTSIZE)
+        ax.scatter(
+            x[idx], y[idx],
+            c=z[idx],
+            s=1,
+            rasterized=True)
+
+        xsortidx = x.argsort()
+        xs = x[xsortidx]
+        ys = y[xsortidx]
+        ws = w[xsortidx]
+        per_point = max(150, (len(xs)//50))
+        lines = [(t, c, []) for t, c in [(.5, 'green'), (.95, 'red')]]
+        limits = []
+        idx = 0
+        min_per_tick = (xs[-1] - xs[0])/100.0
+
+        if self.__ymax != 0:
+            top = weighted_quantile(ys, [self.__ymax], ws)[0]
+            bottom = weighted_quantile(ys, [1 - self.__ymax], ws)[0]
+            ax.set_ylim(top=top, bottom=bottom - (0.05 * (top - bottom)))
+
+        while idx < len(xs):
+            limit = min(
+                len(xs),
+                max(idx + per_point,
+                    np.searchsorted(xs, xs[idx] + min_per_tick)))
+            limits.append((xs[idx] + xs[limit - 1]) / 2.0)
+            quantiles = weighted_quantile(
+                ys[idx:limit],
+                [t for t, _, _ in lines],
+                ws[idx:limit])
+            for p, d in zip(quantiles, [d for _, _, d in lines]):
+                d.append(p)
+            idx = limit
+        for t, c, d in lines:
+            ax.plot(limits, d, 'go--', linewidth=1, markersize=2, color=c)
+
+    def name(self):
+        return "Scatter({}, {})".format(self.__xname, self.__yname)
+
+
+class Histogram(Graph):
+    def __init__(self, p):
+        self.__param = p
+        self.__unit = get_unit(p)
+
+    def sources(self):
+        return ['weight', self.__param]
+
+    def graph(self, ax, w, p):
+        ax.set_xlabel(
+            "{name} ({unit})".format(name=self.__param, unit=self.__unit),
+            fontsize=FONTSIZE
+        )
+        ax.set_ylabel(
+            "N",
+            fontsize=FONTSIZE)
+        ax.hist(p, weights=w, bins=50)
+
+    def name(self):
+        return "Histogram({})".format(self.__param)
+
+FONTSIZE=4
+matplotlib.rcParams.update({'font.size': FONTSIZE})
+
+def graph(events, name, path, graph_format, mask_params=None, masker=None):
+    if mask_params is None:
+        mask_params = []
+    features = set([ax for row in graph_format for g in row for ax in g.sources()]
+                   + mask_params)
+    pfeat, feat_to_array = get_features(features)
+
+    cols = to_arrays(pfeat, events)
+
+    print("Generated arrays")
+
+    arrays = dict(((feat, t(cols)) for feat, t in feat_to_array.items()))
+
+    if masker is not None:
+        mask = masker(*[arrays[x] for x in mask_params])
+        arrays = dict(((feat, ar[mask]) for feat, ar in arrays.items()))
+
+    fig = matplotlib.figure.Figure()
+    fig.suptitle(name)
+
+    rows = len(graph_format)
+    cols = len(graph_format[0])
+
+    fig.set_figwidth(8)
+    fig.set_figheight(4 * cols)
+
+    for nrow in range(rows):
+        for ncol in range(cols):
+            index = (nrow * cols) + ncol + 1
+            ax = fig.add_subplot(rows, cols, index)
+            grapher = graph_format[nrow][ncol]
+            grapher.graph(
+                ax,
+                *[arrays.get(n) for n in grapher.sources()])
+
+            print("Generated subplot {}".format(grapher.name()))
+
+    fig.subplots_adjust(left=0.08, right=0.98, bottom=0.1, top=0.95)
+
+    if path is not None:
+        fig.set_canvas(backend.FigureCanvas(fig))
+        print("Generating image")
+        fig.savefig(
+            path,
+            dpi=200,
+            format='png')
+    else:
+        import matplotlib.pyplot as plt
+        plt.show()

--- a/tools/fio_objectstore_tools/hdd-runs.json
+++ b/tools/fio_objectstore_tools/hdd-runs.json
@@ -1,0 +1,65 @@
+{
+  "base": {
+    "runtime": 3600,
+    "devices": {
+      "nvme": {
+        "device_type": "ssd",
+        "block_wal_path": "/dev/nvme0n1p2",
+        "block_db_path": "/dev/nvme0n1p3",
+        "block_path": "/dev/nvme0n1p4",
+        "target_dir": "/mnt/sjust/bluestore-nvme"
+      },
+      "nvme_plain": {
+        "device_type": "ssd",
+        "block_path": "/dev/nvme3n1p4",
+        "target_dir": "/mnt/sjust/bluestore-nvme-plain"
+      },
+      "hdd": {
+        "device_type": "hdd",
+        "block_path": "/dev/sdh2",
+        "target_dir": "/mnt/sjust/bluestore-hdd"
+      },
+      "hdd_nvme_db": {
+        "device_type": "hdd",
+        "block_wal_path": "/dev/nvme2n1p2",
+        "block_db_path": "/dev/nvme2n1p3",
+        "block_path": "/dev/sdg2",
+        "target_dir": "/mnt/sjust/bluestore-hdd-nvme-db"
+      }
+    },
+    "size": 512,
+    "filesize": 4,
+    "preextend": "true",
+    "qd": 1024,
+    "numjobs": 32,
+    "tcio_hdd": 1048576,
+    "bluestore_deferred_throttle": [
+      2,
+      4,
+      8,
+      12
+    ],
+    "bluestore_throttle": [
+      8,
+      12,
+      16,
+      20,
+      24
+    ],
+    "vary_bluestore_throttle_period": 30
+  },
+  "runs": {
+    "bs": [
+      4,
+      512
+    ],
+    "target_device": [
+      "nvme",
+      "nvme_plain"
+    ],
+    "run": [
+      0,
+      1
+    ]
+  }
+}

--- a/tools/fio_objectstore_tools/nvme-runs.json
+++ b/tools/fio_objectstore_tools/nvme-runs.json
@@ -1,0 +1,67 @@
+{
+  "base": {
+    "runtime": 3600,
+    "devices": {
+      "nvme": {
+        "device_type": "ssd",
+        "block_wal_path": "/dev/nvme0n1p2",
+        "block_db_path": "/dev/nvme0n1p3",
+        "block_path": "/dev/nvme0n1p4",
+        "target_dir": "/mnt/sjust/bluestore-nvme"
+      },
+      "nvme_plain": {
+        "device_type": "ssd",
+        "block_path": "/dev/nvme3n1p4",
+        "target_dir": "/mnt/sjust/bluestore-nvme-plain"
+      },
+      "hdd": {
+        "device_type": "hdd",
+        "block_path": "/dev/sdh2",
+        "target_dir": "/mnt/sjust/bluestore-hdd"
+      },
+      "hdd_nvme_db": {
+        "device_type": "hdd",
+        "block_wal_path": "/dev/nvme2n1p2",
+        "block_db_path": "/dev/nvme2n1p3",
+        "block_path": "/dev/sdg2",
+        "target_dir": "/mnt/sjust/bluestore-hdd-nvme-db"
+      }
+    },
+    "size": 512,
+    "filesize": 4,
+    "preextend": "true",
+    "qd": 1024,
+    "numjobs": 32,
+    "tcio_hdd": 1048576,
+    "tcio_ssd": 8192,
+    "bluestore_deferred_throttle": [
+      0.25,
+      0.5,
+      1,
+      2,
+      4
+    ],
+    "bluestore_throttle": [
+      0.25,
+      0.5,
+      1,
+      2,
+      4,
+      6,
+      8
+    ],
+    "vary_bluestore_throttle_period": 30
+  },
+  "runs": {
+    "bs": [
+      4,
+      512
+    ],
+    "target_device": [
+      "nvme"
+    ],
+    "run": [
+      0
+    ]
+  }
+}

--- a/tools/fio_objectstore_tools/run.py
+++ b/tools/fio_objectstore_tools/run.py
@@ -1,0 +1,346 @@
+#!env python3
+
+import os
+import subprocess
+import json
+import time
+import sys
+
+BLUESTORE_CONF = """
+[global]
+	debug bluestore = 0/0
+	debug bluefs = 0/0
+	debug bdev = 0/0
+	debug rocksdb = 0/0
+	osd pool default pg num = 8
+	osd op num shards = {numjobs}
+
+[osd]
+	osd objectstore = bluestore
+
+	# use directory= option from fio job file
+	osd data = {target_dir}
+	osd journal = {target_dir}/journal
+
+        #bluestore rocksdb options = compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152,stats_dump_period_sec=10
+
+	# log inside fio_dir
+	log file = {output_dir}/log
+        bluestore_tracing = true
+        bluestore_throttle_trace_rate = 200.0
+        bluestore_throttle_bytes = 0
+        bluestore_throttle_deferred_bytes = 0
+        #rocksdb collect extended stats = true
+        #rocksdb collect memory stats = true
+        #rocksdb collect compaction stats = true
+        #rocksdb perf = true
+        bluefs_preextend_wal_files = {preextend}
+        bluestore_throttle_cost_per_io_hdd = {tcio_hdd}
+        bluestore_throttle_cost_per_io_ssd = {tcio_ssd}
+        bluestore_fsck_on_mkfs = false
+"""
+
+def generate_ceph_conf(conf):
+    ret = BLUESTORE_CONF.format(**conf)
+    for k in ['block_path', 'block_wal_path', 'block_db_path']:
+        v = conf['devices'][conf['target_device']].get(k, None)
+        if v:
+            ret += "        bluestore_" + k + " = " + v + "\n"
+    for k in ['cache_size']:
+        v = conf.get(k, None)
+        if v:
+            ret += "        bluestore_" + k + " = " + v + "\n"
+    return ret
+
+
+BLUESTORE_FIO_BASE = """
+[global]
+ioengine={lib}/libfio_ceph_objectstore.so
+
+conf={output_dir}/ceph.conf
+directory={target_dir}
+
+
+oi_attr_len=320 # specifies OI(aka '_') attribute length range to couple
+                # writes with. Default: 0 (disabled)
+
+snapset_attr_len=35  # specifies snapset attribute length range to couple
+                     # writes with. Default: 0 (disabled)
+_fastinfo_omap_len=186 # specifies _fastinfo omap entry length range to
+                       # couple writes with. Default: 0 (disabled)
+pglog_simulation=1   # couples write and omap generation in OSD PG log manner.
+                     # Ceph's osd_min_pg_log_entries, osd_pg_log_trim_min,
+                     # osd_pg_log_dups_tracked settings control cyclic
+                     # omap keys creation/removal.
+                     # Following additional FIO pglog_ settings to apply too:
+
+pglog_omap_len=173   # specifies PG log entry length range to couple
+                     # writes with. Default: 0 (disabled)
+
+pglog_dup_omap_len=57 # specifies duplicate PG log entry length range
+                      # to couple writes with. Default: 0 (disabled)
+
+perf_output_file={output_dir}/perf_counters.json
+thread=1
+group_reporting=1
+
+nr_files={nr_files}
+size={size}
+filesize={filesize}
+"""
+
+def preprocess_fio_configs(conf):
+    c = conf.copy()
+    for k in ["deferred_", ""]:
+        key = "bluestore_" + k + "throttle"
+        c[key] = ','.join([str(int(x * (1<<20))) for x in c[key]])
+    c['nr_files'] = str((conf['size'] << 30) // (conf['filesize'] << 20) // conf['numjobs'])
+    c['size'] = str((conf['size'] << 30) // conf['numjobs'])
+    c['filesize'] = str(conf['filesize']) + 'm'
+    return c
+
+BLUESTORE_FIO_POPULATE = """
+[write]
+bs=1m
+iodepth=16
+rw=write
+time_based=0
+numjobs={numjobs}
+"""
+
+def generate_fio_populate_conf(conf):
+    c = preprocess_fio_configs(conf)
+    return (BLUESTORE_FIO_BASE + BLUESTORE_FIO_POPULATE).format(**c)
+
+BLUESTORE_FIO = """
+[write]
+preallocate_files=0
+check_files=1
+bluestore_throttle="{bluestore_throttle}"
+bluestore_deferred_throttle="{bluestore_deferred_throttle}"
+vary_bluestore_throttle_period={vary_bluestore_throttle_period}
+rw=randwrite
+iodepth={qd}
+bs={bs}k
+time_based=1
+runtime={runtime}s
+numjobs={numjobs}
+"""
+
+def generate_fio_job_conf(conf):
+    c = preprocess_fio_configs(conf)
+    return (BLUESTORE_FIO_BASE + BLUESTORE_FIO).format(**c)
+
+
+DEFAULT = {
+    'output_dir': os.path.join('../../output',time.strftime('%Y-%m-%d-%H:%M:%S')),
+    'lib': '../../ceph/build/lib',
+    'fio_bin': '../../ceph/build/bin/fio',
+    'qd': 16,
+    'runtime': 10,
+    'bs': 4,
+    'lttng': True,
+    'preextend': 'false',
+    'bluestore_throttle': [],
+    'bluestore_deferred_throttle': [],
+    'vary_bluestore_throttle_period': 0,
+    'tcio_hdd': 670000,
+    'tcio_ssd': 4000,
+    'size': 1,
+    'filesize': 4,
+    'cache_size': None,
+    'tcmalloc': True,
+    'numjobs': 4
+}
+
+def get_fio_fn(base):
+    return os.path.join(base, 'bluestore.fio')
+
+def get_fio_populate_fn(base):
+    return os.path.join(base, 'bluestore_populate.fio')
+
+def get_ceph_fn(base):
+    return os.path.join(base, 'ceph.conf')
+
+def get_fio_output(base):
+    return os.path.join(base, 'fio_output.json')
+
+def get_fio_stdout(base):
+    return os.path.join(base, 'fio.stdout')
+
+def write_conf(conf):
+    fio_fn = get_fio_fn(conf['output_dir'])
+    fio_populate_fn = get_fio_populate_fn(conf['output_dir'])
+    ceph_fn = get_ceph_fn(conf['output_dir'])
+    for fn, func in [(fio_fn, generate_fio_job_conf),
+                     (fio_populate_fn, generate_fio_populate_conf),
+                     (ceph_fn, generate_ceph_conf)]:
+        with open(fn, 'a') as f:
+            f.write(func(conf))
+    return fio_fn, fio_populate_fn
+
+def setup_start_lttng(conf):
+    if not conf.get('lttng', False):
+        return
+    tracedir = os.path.join(conf['output_dir'], 'trace')
+    subprocess.run(['mkdir', tracedir])
+    subprocess.run([
+        'lttng', 'create', 'fio-bluestore',
+        '--output', tracedir
+        ])
+    for event in ['state_duration', 'total_duration',
+                  'initial_state', 'initial_state_rocksdb',
+                  'commit_latency', 'kv_sync_latency', 'kv_submit_latency']:
+        subprocess.run([
+            'lttng', 'enable-event',
+            '--session', 'fio-bluestore',
+            '--userspace', 'bluestore:transaction_' + event
+        ])
+    subprocess.run(['lttng', 'start', 'fio-bluestore'])
+
+def stop_destroy_lttng(conf):
+    if not conf.get('lttng', False):
+        return
+    subprocess.run([
+        'lttng', 'stop', 'fio-bluestore'
+    ], check=False)
+    subprocess.run([
+        'lttng', 'destroy', 'fio-bluestore'
+    ], check=False)
+
+def run_fio(conf, fn):
+    env = {
+        'LD_LIBRARY_PATH': conf['lib']
+    }
+    output_json = get_fio_output(conf['output_dir'])
+    cmd = [
+        conf['fio_bin'],
+        fn,
+        '--alloc-size', '1048576',
+        '--output', output_json,
+        '--output-format', 'json+']
+
+    if conf.get('tcmalloc', False):
+        env['LD_PRELOAD'] = '/usr/lib64/libtcmalloc.so.4'
+        env['TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES'] = '134217728'
+    with open(get_fio_stdout(conf['output_dir']), 'a') as outf:
+        subprocess.run(cmd, env=env, stdout=outf, stderr=outf)
+
+def run_conf(conf):
+    stop_destroy_lttng(conf)
+
+    subprocess.run(['rm', '-rf', conf['output_dir']], check=False)
+    subprocess.run(['mkdir', '-p', conf['output_dir']])
+    fio_conf, fio_populate_conf = write_conf(conf)
+
+    setup_start_lttng(conf)
+    run_fio(conf, fio_conf)
+    stop_destroy_lttng(conf)
+
+def get_all_config_combos(configs):
+    if len(configs) == 0:
+        yield {}
+    else:
+        key = list(configs.keys())[0]
+        vals = configs[key]
+        sub = configs.copy()
+        del sub[key]
+        for val in vals:
+            for subconfig in get_all_config_combos(sub):
+                subconfig.update({key: val})
+                yield subconfig
+
+def generate_name_full_config(base, run):
+    full_config = {}
+    full_config.update(DEFAULT)
+    full_config.update(base)
+    full_config.update(run)
+    if ('devices' in full_config.keys() or
+        'target_device' in full_config.keys()):
+        full_config['target_dir'] = \
+            full_config['devices'][full_config['target_device']]['target_dir']
+    name = "-".join(
+        "{name}({val})".format(name=name, val=val)
+        for name, val in run.items())
+    return name, run, full_config
+
+def get_base_config(base):
+    return os.path.join(base, 'base_config.json')
+
+def get_full_config(base):
+    return os.path.join(base, 'full_config.json')
+
+def write_obj(obj, fn):
+    with open(fn, 'w') as f:
+        json.dump(obj, f, sort_keys=True, indent=2)
+
+def do_run(base, runs):
+    ret = {}
+    orig_output_dir = None
+
+    for name, base_config, full_config in map(
+            lambda x: generate_name_full_config(base, x),
+            get_all_config_combos(runs)):
+        if orig_output_dir is None:
+            orig_output_dir = full_config['output_dir']
+        full_config['output_dir'] = os.path.join(full_config['output_dir'], name)
+        print("Running {name}".format(name=name))
+        run_conf(full_config)
+        write_obj(base_config, get_base_config(full_config['output_dir']))
+        write_obj(full_config, get_full_config(full_config['output_dir']))
+    return orig_output_dir
+
+def do_initialize(base, runs, initialize):
+    devices = set()
+    if initialize == 'runs':
+        devices = set([full_config['target_device'] for _, _, full_config
+                       in [generate_name_full_config(base, x) for x in
+                           get_all_config_combos(runs)]])
+    elif initialize == 'all':
+        devices = set(base['devices'].keys())
+    else:
+        devices = set(initialize.split(','))
+
+    print("Initializing devices {}".format(devices))
+    for name, base_config, full_config in [
+            generate_name_full_config(base, { 'target_device': device })
+            for device in devices]:
+        full_config['output_dir'] = os.path.join(full_config['output_dir'], name)
+        print("Initializing {name}".format(name=name))
+
+        stop_destroy_lttng(full_config)
+
+        for d in [full_config['output_dir'], full_config['target_dir']]:
+            subprocess.run(['rm', '-rf', d], check=False)
+            subprocess.run(['mkdir', '-p', d])
+
+        fio_conf, fio_populate_conf = write_conf(full_config)
+        run_fio(full_config, fio_populate_conf)
+
+        write_obj(base_config, get_base_config(full_config['output_dir']))
+        write_obj(full_config, get_full_config(full_config['output_dir']))
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        '--run', action='store_true',
+        help='execute runs in conf')
+    group.add_argument(
+        '--initialize', type=str,
+        help='comma seperated list of devices or runs or all to be initialized')
+    parser.add_argument('conf', metavar='C', type=str, nargs=1,
+                        help='path to config file')
+    args = parser.parse_args()
+
+    if args.run or args.initialize:
+        conf = {}
+        with open(args.conf[0]) as f:
+            conf = json.load(f)
+            base = DEFAULT
+            base.update(conf.get('base', {}))
+            if args.run:
+                do_run(base, conf['runs'])
+            elif args.initialize:
+                do_initialize(base, conf['runs'], args.initialize)

--- a/tools/fio_objectstore_tools/summarize.py
+++ b/tools/fio_objectstore_tools/summarize.py
@@ -1,0 +1,119 @@
+#!env python3
+
+import os
+import json
+from run import get_fio_output, get_base_config
+
+def populate_args(parser):
+    parser.add_argument('target', metavar='T', type=str, help='target results directory')
+    parser.add_argument('--match', type=str, help='json for matching', default='{}')
+    parser.add_argument('--output', type=str, help='output directory')
+    parser.add_argument('--generate-graphs', type=bool, help='generate graphs')
+    parser.set_default(func=summarize)
+
+def project(name, config, fio_stats, perf_stats):
+    def f(op):
+        return {
+            'iops_min': op['iops_min'],
+            'iops_max': op['iops_max'],
+            'iops': op['iops'],
+            'clat_min_ns': op['clat_ns']['min'],
+            'clat_max_ns': op['clat_ns']['max'],
+            'clat_mean_ns': op['clat_ns']['mean'],
+            'clat_median_ns': op['clat_ns']['percentile']['50.000000'],
+            'clat_99.9_ns': op['clat_ns']['percentile']['99.900000'],
+            'slat_min_ns': op['slat_ns']['min'],
+            'slat_max_ns': op['slat_ns']['max'],
+            'slat_mean_ns': op['slat_ns']['mean'],
+        }
+    fio = dict(((op, f(fio_stats['jobs'][0][op])) for op in ['read', 'write']))
+
+    wanted_perf = [
+        'commit_lat',
+        'kv_commit_lat',
+        'kv_final_lat',
+        'kv_flush_lat',
+        'kv_sync_lat',
+        'state_deferred_aio_wait_lat',
+        'state_deferred_cleanup_lat',
+        'state_deferred_queued_lat',
+        'state_kv_committing_lat'
+        ]
+
+    perf = {
+        k: v['avgtime'] for k, v in
+        filter(lambda x: '_lat' in x[0],
+               perf_stats['perfcounter_collection']['bluestore'].items())
+        }
+
+    return {
+        'fio': fio,
+        'config': config,
+        'name': name,
+        'perf': perf,
+        }
+
+def dump_target(name, directory):
+    fio_output = {}
+    with open(get_fio_output(directory)) as f:
+        decoder = json.JSONDecoder()
+        fio_output, _ = decoder.raw_decode(f.read())
+        #fio_output = json.load(f)
+    perf_output = {}
+    with open(os.path.join(directory, 'perf_counters.json')) as f:
+        perf_output = json.load(f)
+    with open(get_base_config(directory)) as f:
+        base_config = json.load(f)
+    return project(name, base_config, fio_output, perf_output)
+
+def generate_summary(filtered, match):
+    def config_to_frozen(config, match):
+        ret = dict(filter(lambda x: x[0] not in match, config.items()))
+        if 'run' in ret:
+            del ret['run']
+        return frozenset(sorted(ret.items()))
+
+    def group_by_config(input):
+        grouped = {}
+        for run in filtered:
+            key = config_to_frozen(run['config'], match)
+            if key not in grouped:
+                grouped[key] = []
+            grouped[key].append(run)
+        return [{'config': dict(list(k)), 'runs': v} for k, v in grouped.items()]
+
+    grouped = group_by_config(filtered)
+
+    def union_top_n(group):
+        ret = set()
+        for run in group:
+            ret = ret.union(
+                [k for v, k in sorted(((a, b) for b, a in run['perf'].items()))][::-1][:5]
+            )
+        return ret
+
+    def project_run(perfs):
+        def ret(run):
+            return {
+                'tp': run['fio']['write']['iops'],
+                'lat': run['fio']['write']['clat_mean_ns'] / 1000000000.0,
+                'slat': run['fio']['write']['slat_mean_ns'] / 1000000000.0,
+                'perf': dict(filter(lambda x: x[0] in perfs, run['perf'].items()))
+            }
+        return ret
+
+    def sort_by(f, input):
+        return [v for (_, _, v) in sorted(map(lambda x: (f(x[0]), x[1], x[0]), zip(input, range(len(input)))))]
+
+    def project_group(group):
+        perfs = union_top_n(group['runs'])
+        return {
+            'config': group['config'],
+            'runs': sort_by(
+                lambda x: x['tp'],
+                list(map(project_run(perfs), group['runs'])))
+        }
+
+    return sort_by(
+        lambda x: (x['config'].get('bs', 0), x['config'].get('size', 0)),
+        list(map(project_group, grouped)))

--- a/tools/fio_objectstore_tools/traces.py
+++ b/tools/fio_objectstore_tools/traces.py
@@ -1,0 +1,347 @@
+#!env python3
+
+import babeltrace
+import sys
+import json
+import os
+import subprocess
+import re
+import datetime
+import itertools
+
+
+def open_trace(rdir):
+    tdir_prefix = os.path.join(rdir, 'trace/ust/uid')
+    uid = os.listdir(tdir_prefix)[0]
+    ret = babeltrace.TraceCollection()
+    ret.add_trace(os.path.join(tdir_prefix, uid, '64-bit'), 'ctf')
+    return ret.events
+
+class Event(object):
+    @staticmethod
+    def map_name_to_subtype(name):
+        if 'bluestore:transaction_' in name:
+            return TEvent.map_name_to_subtype(name)
+        else:
+            return None
+
+    def __init__(self, name, timestamp, properties):
+        self.name = name
+        self.timestamp = timestamp
+        self.properties = self.filter_properties(properties)
+
+    def __getitem__(self, key):
+        return self.properties.get(key)
+
+    def filter_properties(self, properties):
+        pass
+
+    def __str__(self):
+        return "Event(name: {name}, timestamp: {timestamp}, {properties})".format(
+            name=self.name,
+            timestamp=self.timestamp,
+            properties=self.properties)
+
+
+class TEvent(Event):
+    @staticmethod
+    def get_subtypes():
+        return \
+            { 'bluestore:transaction_state_duration': TStateDuration
+            , 'bluestore:transaction_total_duration': TTotalDuration
+            , 'bluestore:transaction_commit_latency': TCommitLatency
+            , 'bluestore:transaction_kv_submit_latency': TKVSubmitLatency
+            , 'bluestore:transaction_kv_sync_latency': TKVSyncLatency
+            , 'bluestore:transaction_initial_state': TInitial
+            , 'bluestore:transaction_initial_state_rocksdb': TRocksInitial
+            }
+
+    def get_param_map(self):
+        pass
+
+    def filter_properties(self, properties):
+        ret = dict(((v[0], v[1](properties[k])) for k, v
+                    in self.get_param_map().items()))
+        ret.update({
+            'sequencer_id': int(properties['sequencer_id']),
+            'tid': int(properties['tid'])
+        })
+        return ret
+
+    @staticmethod
+    def get_param_types():
+        param_list = itertools.chain(
+            *((t for _, t in v.get_param_map().items())
+              for _, v in TEvent.get_subtypes().items()))
+        return dict(((v[0], tuple(v[1:])) for v in param_list))
+
+    @staticmethod
+    def map_name_to_subtype(name):
+        return TEvent.get_subtypes()[name]
+
+    def get_event_id(self):
+        return (self['sequencer_id'], self['tid'])
+
+    def get_params(self):
+        ret = self.properties.copy()
+        del ret['sequencer_id']
+        del ret['tid']
+        return ret
+
+    def is_final_event(self):
+        return False
+
+
+class TStateDuration(TEvent):
+    STATE_MAP = \
+        { 19: "prepare"
+        , 20: "aio_wait"
+        , 21: "io_done"
+        , 22: "kv_queued"
+        , 23: "kv_submitted"
+        , 24: "kv_done"
+        , 25: "deferred_queued"
+        , 26: "deferred_cleanup"
+        , 27: "deferred_done"
+        , 28: "finishing"
+        , 29: "done"
+        }
+
+    @staticmethod
+    def get_param_map():
+        return dict((v, ('state_' + v + '_duration', float, 's')) for _, v
+                    in TStateDuration.STATE_MAP.items())
+
+    def filter_properties(self, properties):
+        state_name = TStateDuration.STATE_MAP[int(properties['state'])]
+        return {
+            'state_' + state_name + '_duration': float(properties['elapsed']),
+            'sequencer_id': int(properties['sequencer_id']),
+            'tid': int(properties['tid'])
+            }
+
+class TTotalDuration(TEvent):
+    @staticmethod
+    def get_param_map():
+        return { 'elapsed': ('total_duration', float, 's') }
+
+    def is_final_event(self):
+        return True
+
+
+class TCommitLatency(TEvent):
+    @staticmethod
+    def get_param_map():
+        return { 'elapsed': ('commit_latency', float, 's') }
+
+
+class TKVSubmitLatency(TEvent):
+    @staticmethod
+    def get_param_map():
+        return { 'elapsed': ('kv_submit_latency', float, 's') }
+
+
+class TKVSyncLatency(TEvent):
+    @staticmethod
+    def get_param_map():
+        return \
+            { 'elapsed': ('kv_sync_latency', float, 's')
+            , 'kv_batch_size': ('kv_batch_size', int, 'n')
+            , 'deferred_done_batch_size': ('deferred_done_batch_size', int, 'n')
+            , 'deferred_stable_batch_size': ('deferred_stable_batch_size', int, 'n')
+            }
+
+
+class TInitial(TEvent):
+    @staticmethod
+    def get_param_map():
+        return dict(((k, (k, t, u)) for k, t, u in
+            [ ('current_kv_throttle_cost', int, 'bytes')
+            , ('current_deferred_throttle_cost', int, 'bytes')
+            , ('pending_kv_ios', int, 'ios')
+            , ('pending_deferred_ios', int, 'ios')
+            , ('ios_started_since_last_traced_io', int, 'iops')
+            , ('ios_completed_since_last_traced_io', int, 'iops')
+            , ('throttle_time', float, 's')
+            ]))
+
+
+class TRocksInitial(TEvent):
+    @staticmethod
+    def get_param_map():
+        return dict(((k, (k, int, 'n')) for k in [
+	    'rocksdb_base_level',
+	    'rocksdb_estimate_pending_compaction_bytes',
+	    'rocksdb_cur_size_all_mem_tables',
+            'rocksdb_compaction_pending',
+            'rocksdb_mem_table_flush_pending',
+            'rocksdb_num_running_compactions',
+            'rocksdb_num_running_flushes',
+            'rocksdb_actual_delayed_write_rate'
+        ]))
+
+
+DATE = '(\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d\d\d\d\d\d\d\d\d)'
+OFFSET = '\(\+(\?\.\?+|\d\.\d\d\d\d\d\d\d\d\d)\)'
+NAME = 'bluestore:[a-z_]*'
+PAIRS = '{((?: [a-z_]+ = [0-9.e+-]+[ ,])+)}'
+RE = re.compile(
+    '\[' + DATE + '\] [a-z0-9]* (?P<name>' + NAME + '): { \d* }, ' + PAIRS
+    )
+def parse(line):
+    res = RE.match(line)
+    if not res:
+        print(line)
+    assert res
+    groups = res.groups()
+    start = datetime.datetime.strptime(groups[0][:-3], "%Y-%m-%d %H:%M:%S.%f")
+    name = groups[1]
+    props = {}
+    for pair in (x.strip() for x in groups[2].split(',')):
+        k, v = pair.split('=')
+        k = k.strip()
+        props[k] = v.strip()
+    return Event.map_name_to_subtype(name)(name, start.timestamp(), props)
+
+
+def test():
+    test = '[20:01:49.773714486] (+?.?????????) incerta05 bluestore:transaction_initial_state: { 22 }, { sequencer_id = 1, tid = 1, transaction_bytes = 399, transaction_ios = 1, total_pending_bytes = 399, total_pending_ios = 1, total_pending_kv = 1 }'
+    test2 = '[20:01:49.774633030] (+0.000918544) incerta05 bluestore:transaction_state_duration: { 22 }, { sequencer_id = 1, tid = 1, state = 19, elapsed = 4859 }'
+    parse(test)
+    parse(test2)
+
+
+def open_trace(rdir):
+    tdir_prefix = os.path.join(rdir, 'trace/')
+    CMD = ['babeltrace', '--no-delta', '--clock-date', '-n', 'payload',
+           tdir_prefix]
+    proc = subprocess.Popen(
+        CMD,
+        bufsize=524288,
+        stdout=subprocess.PIPE,
+        stderr=sys.stderr)
+    for line in proc.stdout.readlines():
+        yield parse(line.decode("utf-8"))
+
+
+class Write(object):
+    @staticmethod
+    def get_features():
+        ret = {
+            'time': (lambda e: e.get_start(), float, 's')
+        }
+        ret.update(dict(
+            ((k, ((lambda k1: lambda e: e.get_param(k1))(k), v[0], v[1]))
+             for k, v in TEvent.get_param_types().items())
+        ))
+        return ret
+
+    def __init__(self, event_id):
+        self.__id = event_id
+        self.__state_durations = {}
+        self.__start = None
+        self.__duration = None
+        self.__commit_latency = None
+        self.__params = {}
+
+    def consume_event(self, event, start):
+        #assert event_id(event) == self.__id
+        if isinstance(event, TInitial):
+            assert self.__start is None
+            self.__start = event.timestamp - start
+
+        if isinstance(event, TEvent):
+            self.__params.update(event.get_params())
+            return event.is_final_event()
+        else:
+            assert False, "{} not a valid event".format(event)
+            return True
+
+    def to_primitive(self):
+        return {
+            'type': 'write',
+            'id': {
+                'sequencer_id': self.__id[0],
+                'tid': self.__id[1],
+                },
+            'state_durations': self.__state_durations,
+            'start': self.__start,
+            'duration': self.__duration,
+            'params': self.__params
+        }
+
+    def get_start(self):
+        assert self.__start is not None
+        return self.__start
+
+    def get_param(self, param):
+        if param not in self.__params:
+            print("{} not in {}".format(param, self.__params))
+        assert param in self.__params
+        return self.__params[param]
+
+
+class Aggregator(object):
+    def check(self, event):
+        return False
+
+    def consume(self, event, start):
+        return None
+
+
+class WriteAggregator(Aggregator):
+    def __init__(self):
+        self.__live = {}
+        self.__count = 0
+
+    def check(self, event):
+        return issubclass(type(event), TEvent)
+
+    def consume(self, event, start):
+        eid = event.get_event_id()
+        if eid not in self.__live:
+            self.__live[eid] = Write(eid)
+
+        if self.__live[eid].consume_event(event, start):
+            self.__count += 1
+            y = self.__live[eid]
+            del self.__live[eid]
+            return y
+        else:
+            return None
+
+
+def iterate_structured_trace(trace):
+    count = 0
+    last = 0.0
+    start = None
+    aggregators = [
+        WriteAggregator()
+        ]
+    for event in trace:
+        if start is None:
+            start = event.timestamp
+        if event.timestamp > last + 10:
+            last = event.timestamp
+            print("Trace processed up to {}s".format(
+                int(event.timestamp - start)))
+        for agg in aggregators:
+            if agg.check(event):
+                ret = agg.consume(event, start)
+                if ret is not None:
+                    yield ret
+
+
+def dump_structured_trace(tdir, fd):
+    trace = open_trace(tdir)
+    for p in iterate_structured_trace(trace):
+        json.dump(p.to_primitive(), fd, sort_keys=True, indent=2)
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dump-structured-trace', type=str,
+                        help='generate json dump of writes')
+    args = parser.parse_args()
+
+    dump_structured_trace(args.dump_structured_trace, sys.stdout)


### PR DESCRIPTION
This adds a few python scripts for initializing, running, and
analyzing benchmark runs using the fio_ceph_objectstore backend.

The tooling is focused on understanding the
latency/throttle/throughput relationship for a particular
device.

Signed-off-by: Samuel Just <sjust@redhat.com>