### PR TITLE
common: fix join_no_str to join on list vs join on not str

### DIFF
--- a/common.py
+++ b/common.py
@@ -11,7 +11,9 @@ logger = logging.getLogger("cbt")
 
 
 def join_nostr(command):
-    return command if isinstance(command, str) else ' '.join(command)
+    if isinstance(command, list):
+        return ' '.join(command)
+    return command
 
 # this class overrides the communicate() method to check the return code and
 # throw an exception if return code is not OK


### PR DESCRIPTION
In testing on o10, certain commands being passed to join_nostr were of type "unicode" rather than "str".  The existing join_nostr code would put spaces between every character in the unicode string and return it leading to unfortunate errors.  Instead, only execute the join if command is explicitly a list and break up the single line statement so we can easily add other conditions if desired down the road.

Signed-off-by: Mark Nelson <mnelson@redhat.com>