### PR TITLE
librbdfio: Fix a few incorrect options passed to 'fio' & 'rbd create' command.

### DIFF
--- a/benchmark/librbdfio.py
+++ b/benchmark/librbdfio.py
@@ -23,12 +23,12 @@ class LibrbdFio(Benchmark):
         self.cmd_path = config.get('cmd_path', '/usr/bin/fio')
         self.pool_profile = config.get('pool_profile', 'default')
         self.data_pool_profile = config.get('data_pool_profile', None)
-        self.time =  str(config.get('time', None))
+        self.time =  config.get('time', None)
         self.time_based = bool(config.get('time_based', False))
-        self.ramp = str(config.get('ramp', None))
+        self.ramp = config.get('ramp', None)
         self.iodepth = config.get('iodepth', 16)
         self.numjobs = config.get('numjobs', 1)
-        self.end_fsync = str(config.get('end_fsync', 0))
+        self.end_fsync = config.get('end_fsync', 0)
         self.mode = config.get('mode', 'write')
         self.rwmixread = config.get('rwmixread', 50)
         self.rwmixwrite = 100 - self.rwmixread
@@ -37,7 +37,7 @@ class LibrbdFio(Benchmark):
         self.op_size = config.get('op_size', 4194304)
         self.pgs = config.get('pgs', 2048)
         self.vol_size = config.get('vol_size', 65536)
-        self.vol_object_size = config.get('vol_object_size', '4M')
+        self.vol_object_size = config.get('vol_object_size', 22)
         self.volumes_per_client = config.get('volumes_per_client', 1)
         self.procs_per_volume = config.get('procs_per_volume', 1)
         self.random_distribution = config.get('random_distribution', None)
@@ -147,16 +147,16 @@ class LibrbdFio(Benchmark):
             fio_cmd += ' --rwmixread=%s --rwmixwrite=%s' % (self.rwmixread, self.rwmixwrite)
 #        fio_cmd += ' --ioengine=%s' % self.ioengine
         if self.time is not None:
-            fio_cmd += ' --runtime=%s' % self.time
+            fio_cmd += ' --runtime=%d' % self.time
         if self.time_based is True:
             fio_cmd += ' --time_based'
         if self.ramp is not None:
-            fio_cmd += ' --ramp_time=%s' % self.ramp
+            fio_cmd += ' --ramp_time=%d' % self.ramp
         fio_cmd += ' --numjobs=%s' % self.numjobs
         fio_cmd += ' --direct=1'
         fio_cmd += ' --bs=%dB' % self.op_size
         fio_cmd += ' --iodepth=%d' % self.iodepth
-        fio_cmd += ' --end_fsync=%s' % self.end_fsync
+        fio_cmd += ' --end_fsync=%d' % self.end_fsync
 #        if self.vol_size:
 #            fio_cmd += ' -- size=%dM' % self.vol_size
         if self.norandommap:

--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -762,7 +762,10 @@ class Ceph(Cluster):
         dp_option = ''
         if data_pool:
             dp_option = "--data-pool %s" % data_pool
-        common.pdsh(settings.getnodes('head'), '%s -c %s create %s --size %s --pool %s %s --order %s' % (self.rbd_cmd, self.tmp_conf, name, size, pool, dp_option, order)).communicate()
+        try:
+            common.pdsh(settings.getnodes('head'), '%s -c %s create %s --size %s --pool %s %s --order %s' % (self.rbd_cmd, self.tmp_conf, name, size, pool, dp_option, order), False).communicate()
+        except Exception as e:
+            logger.error(str(e))
 
     def unmount_all(self):
         # Should take care of pretty much everything so long as wierd mnt_dirs aren't used.


### PR DESCRIPTION
Don't convert options like time, ramp and end_fsync to string before
checks as it's possible that they could be set to None value causing fio
script to fail.

Set 'vol_object_size' to 22 instead of '4M' since the option '--order'
is passed to 'rbd create' command. The '--order' is deprecated but will
still work. This option is retained so that testing on older ceph releases
remains unbroken.

Wrap the execution 'rbd create' command within try..catch block to catch
and report actual error for quicker debugging. Also, pass a False value
for 'continue_if_error' in pdsh(..) so that the exception can be caught.

Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>