### PR TITLE
tools: Add scripts to visualize fio output

### DIFF
--- a/tools/fio_visualize_data/fio-plot-stats-usage.rst
+++ b/tools/fio_visualize_data/fio-plot-stats-usage.rst
@@ -1,0 +1,69 @@
+====================
+Visualize Fio Output
+====================
+
+Motivation
+==========
+
+Fio generates quite a bit of output that is sometimes hard to decipher
+and understand. This problem is exacerbated further if one is running
+multiple tests with different ceph options to tune ceph performance.
+It would be good to have a tool that decodes the data from the log files
+created by Fio and generate meaningful graphs that provide insight into
+ceph performance.
+
+The attempt here is to start with some basic scripts that parse Fio
+output and generate plots like average client latencies and completion
+latency percentiles.
+
+Going further the idea is to enhance the scripts to generate more meaningful
+graphs, tighter integration with cbt to generate graphs via yaml
+specification as part of the test itself.
+
+Usage
+=====
+.. code-block:: console
+
+
+    $ ./fio-plot-stats.py -h
+    usage: fio-plot-stats.py [-h] -f {json,csv} -s SRCDIR [-d DESTDIR] -o
+                         {read,write}
+
+    Generate plots from fio output
+
+    optional arguments:
+     -h, --help            show this help message and exit
+     -f {json,csv}, --filetype {json,csv}
+                           type of file to parse
+     -s SRCDIR, --source SRCDIR
+                           source directory containing fio output files
+     -d DESTDIR, --destination DESTDIR
+                           destination directory to save generated plots
+     -o {read,write}, --optype {read,write}
+                           plot read or write stats
+
+
+The input file format option ``-f`` is mandatory. Depending on this,
+additonal  options if preferred may be provided to override the default
+behavior. The default behavior is to treat each output file in the source
+directory and generate comparison graphs.
+
+The option ``-o`` tells the script to scan read or write statistcs in the
+Fio files and generate the graphs.
+
+Assumption
+==========
+All fio files in the source directory having 'json'
+string in filename are treated as JSON files. Otherwise, the file is
+assumed to be of type CSV.
+
+Example
+=======
+The following command scans the source directory for files having
+string 'json' in the filenames and scans relevant stats from the files
+to generate one graph per file in the destination folder
+
+.. code-block:: console
+
+     $python3 fio-plot-stats.py -s ~/cbt_logs/json_logs -f json -o write -d ~/cbt_logs/json_logs
+

--- a/tools/fio_visualize_data/fio-plot-stats.py
+++ b/tools/fio_visualize_data/fio-plot-stats.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python3
+#
+# fio-plot-stats.py - script to parse fio workload generation results
+# for interesting statistics and generate PyPlot graphs. Idea is to
+# parse results generated in json and csv by fio and make use of PyPlot
+# module to generate graphs that will provide insights on Ceph performance
+#
+# input parameters:
+# The input to this script can be a directory containing fio log file(s)
+# in either,
+# - JSON format
+# - CSV format
+#
+# The input file format option is mandatory. Depending on this, additonal
+# options if preferred may be provided to override the default behavior.
+# The default behavior is to treat each output file in the source
+# directory and generate comparison graphs.
+
+# assumption: All fio files in the source directory having 'json'
+# string in filename are treated as JSON files. Otherwise, the file is
+# assumed to be of type CSV.
+#
+# Example 1:
+# The following command scans the source directory for files having
+# string 'json' in the filenames and scans relevant stats from the files
+# to generate comparison graphs in the destination folder.
+# python3 fio-plot-stats.py -s ~/cbt_logs/json_logs -f json -o write -d ~/cbt_logs/json_logs
+import os
+import argparse
+from fiostatsparser import Parsejson
+from fioplotter import Barplot
+
+def dir_path(path):
+  if os.path.isdir(path):
+    return path
+  else:
+    raise argparse.ArgumentTypeError(f"{path} is not a valid directory.")
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Generate plots from fio output')
+  parser.add_argument('-f', '--filetype', dest='ftype', required=True, choices=['json', 'csv'], help='type of file to parse')
+  parser.add_argument('-s', '--source', dest='srcdir', required=True, type=dir_path, help='source directory containing fio output files')
+  parser.add_argument('-d', '--destination', dest='destdir', required=False, type=dir_path, help='destination directory to save generated plots')
+  parser.add_argument('-o', '--optype', dest='optype', required=True, choices=['read', 'write'], help='plot read or write stats')
+  args = parser.parse_args()
+
+  return args
+
+if __name__ == '__main__':
+  args = parse_args()
+
+  # Parse data and generate plots
+  if args.ftype == 'json':
+    print("Parsing JSON files...")
+    pj = Parsejson(args)
+    pj.dump_all_stats_in_csv()
+    print("Creating plots...")
+    Barplot(args, pj.get_fio_latdata(), 'lat')
+    Barplot(args, pj.get_fio_pctdata(), 'pct')
+
+  if args.ftype == 'csv':
+    print("Cannot plot CSV data...coming soon")
+

--- a/tools/fio_visualize_data/fioplotter.py
+++ b/tools/fio_visualize_data/fioplotter.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python3
+
+import json
+import time
+import numpy as np
+from matplotlib import pyplot as plt
+
+class Fioplotter():
+  def __init__(self, ctx):
+    # Initialize basic parameters
+    self.destination = ctx.destdir
+    self.basefile = '/client_stats_plot_'
+    self.baseplotfilename = self.destination + self.basefile
+
+  def get_plot_filename(self):
+    date = time.strftime("%m-%d-%Y", time.localtime())
+    ltime = time.strftime("%I:%M-%S%p", time.localtime())
+    timestamp = date + "_" + ltime
+    plotfilename = self.baseplotfilename + self.stattype + "_" + timestamp + ".pdf"
+    return plotfilename
+
+class Barplot(Fioplotter):
+  def __init__(self, ctx, data, stat):
+    super().__init__(ctx)
+    self.ctx = ctx
+    self.plotdata = data
+    self.stattype = stat
+
+    # Initialize generic plot information
+    self.ylabel = ''
+    self.xlabel = ''
+    self.title = ''
+    self.xticklabels = []
+    self.yticklabels = []
+    self.bar_width = 0.2
+    self.index = 0
+    if stat == 'lat':
+      self.set_avg_clt_lat_metadata()
+    elif stat == 'pct':
+      self.set_pct_clt_lat_metadata()
+    self.generate_bar_plot()
+
+  def set_avg_clt_lat_metadata(self):
+    self.ylabel = 'latency (msec)'
+    self.xlabel = 'latency type'
+    self.title = self.ctx.optype + '-avg client latencies'
+    # TODO: Extract from plot data
+    self.xticklabels = ['slat', 'clat', 'lat']
+    self.index = np.arange(len(self.xticklabels))
+
+  def set_pct_clt_lat_metadata(self):
+    self.ylabel = 'latency (msec)'
+    self.xlabel = 'clat percentiles'
+    self.title = self.ctx.optype + '-clat client percentiles'
+    # TODO: Extract from plot data
+    self.xticklabels = ['95th', '99th', '99.50th', '99.90th', '99.95th', '99.99th']
+    self.index = np.arange(len(self.xticklabels))
+
+  def generate_bar_plot(self):
+    width = 0
+
+    # Create subplot
+    fig, ax = plt.subplots()
+
+    for f in self.plotdata.keys():
+      y = list(self.plotdata[f].values())
+      ax.bar(self.index + width, y, self.bar_width, label=f)
+      width += self.bar_width
+
+    ax.set_ylabel(self.ylabel)
+    ax.set_xlabel(self.xlabel)
+    ax.set_title(self.title)
+    ax.set_xticks(self.index)
+    if len(self.xticklabels):
+      ax.set_xticklabels(self.xticklabels)
+    if len(self.yticklabels):
+      ax.set_yticklabels(self.yticklabels)
+    ax.legend()
+    fig.tight_layout()
+
+    plt.grid(b=True, which='major', color='#666666', linestyle='-', alpha=0.5)
+    plt.minorticks_on()
+    plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
+
+    plotfilename = self.get_plot_filename()
+    plt.savefig(plotfilename)
+    print("Created plot: ", plotfilename, "\n")
+

--- a/tools/fio_visualize_data/fiostatsparser.py
+++ b/tools/fio_visualize_data/fiostatsparser.py
@@ -1,0 +1,141 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import json
+import time
+
+class Fiostatsparser():
+  def __init__(self, ctx):
+    self.fiojsonfiles = []
+    self.fiocsvfiles = []
+    self.getfiofiles(ctx.srcdir, ctx.ftype)
+    # Output CSV filea
+    self.basecsvfile = '/client_csv_data_'
+    self.baseopcsvfn = ctx.destdir + self.basecsvfile
+
+  def getfiofiles(self, srcdir, ftype):
+    files = [os.path.join(srcdir, fname) for fname in next(os.walk(srcdir))[2]]
+
+    # Filter files based on passed filetype
+    for f in files:
+      if ftype in os.path.split(f)[1]:
+        self.fiojsonfiles.append(f)
+      else:
+        self.fiocsvfiles.append(f)
+
+  def get_output_csv_filename(self):
+    date = time.strftime("%m-%d-%Y", time.localtime())
+    ltime = time.strftime("%I:%M-%S%p", time.localtime())
+    timestamp = date + "_" + ltime
+    csvfilename = self.baseopcsvfn + timestamp + ".txt"
+    return csvfilename
+
+class Parsejson(Fiostatsparser):
+  def __init__(self, ctx):
+    super().__init__(ctx)
+    self.JOBS = 'jobs'
+    self.BWBYTES = 'bw_bytes'
+    self.IOPS = 'iops'
+    self.SLAT = 'slat_ns'
+    self.CLAT = 'clat_ns'
+    self.LAT = 'lat_ns'
+    self.MEAN = 'mean'
+    self.PERCT = 'percentile'
+    self._95TH = '95.000000'
+    self._99TH = '99.000000'
+    self._995TH = '99.500000'
+    self._999TH = '99.900000'
+    self._9995TH = '99.950000'
+    self._9999TH = '99.990000'
+    self.MILLION = 1000000
+    self.MBYTE = 1024 * 1024
+    self.OPTYPE = ctx.optype
+    self.fiobwdata = {}
+    self.fiolatdata = {}
+    self.fiopctdata = {}
+    self.parse_json_data()
+
+  def parse_json_data(self):
+    for f in self.fiojsonfiles:
+      with open(f, 'r') as json_file:
+        f_info = os.fstat(json_file.fileno())
+        if f_info.st_size == 0:
+          print('JSON input file %s is empty'%f)
+          sys.exit(1)
+
+        # load json data
+        json_data = json.load(json_file)
+        # Extract latency specific data
+        filestats = {}
+        for data in json_data:
+          if data == self.JOBS:
+            op_data = json_data[self.JOBS][0][self.OPTYPE]
+            fn = os.path.split(f)[1]
+            self.fiobwdata[fn] = {}
+            self.fiolatdata[fn] = {}
+            self.fiopctdata[fn] = {}
+
+            # Get bandwidth & iops data
+            bwdata = self.parse_bw_stats(op_data)
+            self.fiobwdata[fn].update(bwdata)
+            # Get latency data
+            latdata = self.parse_latency_stats(op_data)
+            self.fiolatdata[fn].update(latdata)
+            # Get percentile data
+            pctdata = self.parse_percentile_stats(op_data)
+            self.fiopctdata[fn].update(pctdata)
+
+  def parse_bw_stats(self, data):
+    bwstats = {}
+    bwstats[self.BWBYTES] = float(data[self.BWBYTES])/self.MBYTE
+    bwstats[self.IOPS] = float(data[self.IOPS])
+
+    return bwstats
+
+  def parse_latency_stats(self, data):
+    stats = {}
+    keys = [self.SLAT, self.CLAT, self.LAT]
+    for key in keys:
+      stats[key] =  float(data[key][self.MEAN])/self.MILLION
+
+    return stats
+
+  def parse_percentile_stats(self, data):
+    clatpctstats = data[self.CLAT][self.PERCT]
+    pstats = {}
+    keys = [self._95TH, self._99TH, self._995TH, self._999TH, self._9995TH, self._9999TH]
+    for key in keys:
+      pstats[key] = float(clatpctstats[key])/self.MILLION
+
+    return pstats
+
+  def get_fio_bwdata(self):
+    return self.fiobwdata
+
+  def get_fio_latdata(self):
+    return self.fiolatdata
+
+  def get_fio_pctdata(self):
+    return self.fiopctdata
+
+  def dump_all_stats_in_csv(self):
+    separator = ","
+    jsonfiofiles = self.fiobwdata.keys()
+    # Open csv file
+    with open(self.get_output_csv_filename(), "w+") as f:
+      # Build stats to write
+      for fn in jsonfiofiles:
+        csvdata = []
+        csvdata.append(fn)
+        for value in [*self.fiobwdata[fn].values()]:
+          csvdata.append(value)
+        for value in [*self.fiolatdata[fn].values()]:
+          csvdata.append(value)
+        for value in [*self.fiopctdata[fn].values()]:
+          csvdata.append(value)
+        csvstr = [str(data) for data in csvdata]
+        csventry = separator.join(csvstr) + "\n"
+        # Write to csv file
+        f.write(csventry)
+


### PR DESCRIPTION
Tool to parse Fio workload generation results for interesting statistics
and generate PyPlot graphs. The idea is for the script to parse both
json and csv output and create meaningful plots to provide insights into
ceph performance.

The code most certainly needs rework to make it generic. One of the
thoughts is to provide the plot specific metadata in a yaml file so that
a lot of the plot specific items (labeling, legends etc.) in the script are
read from it rather than setting them within the script.

Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>