### PR TITLE
tools/fio_visualize_data: Sort fio results based on output filenames

### DIFF
--- a/tools/fio_visualize_data/fioplotcommon.py
+++ b/tools/fio_visualize_data/fioplotcommon.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python3
+
+import re
+
+def sort_map_data_by_key(data):
+    sorteddata = {}
+    # Sort data dictionary based on key
+    convert = lambda text: int(text) if text.isdigit() else text
+    alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
+    sorted_keys = sorted(data.keys(), key=alphanum_key)
+    for key in sorted_keys:
+      sorteddata[key] = data[key]
+    return sorteddata
+

--- a/tools/fio_visualize_data/fioplotter.py
+++ b/tools/fio_visualize_data/fioplotter.py
@@ -3,8 +3,8 @@
 import json
 import time
 import numpy as np
+import fioplotcommon as common
 from matplotlib import pyplot as plt
-from collections import OrderedDict
 
 class Fioplotter():
   def __init__(self, ctx):
@@ -24,7 +24,7 @@ class Barplot(Fioplotter):
   def __init__(self, ctx, data, stat):
     super().__init__(ctx)
     self.ctx = ctx
-    self.plotdata = OrderedDict(sorted(data.items()))
+    self.plotdata = common.sort_map_data_by_key(data)
     self.stattype = stat
 
     # Initialize generic plot information


### PR DESCRIPTION
Implement a simpler mechanism using regular expression module to sort
keys of plot data. Filenames containing fio data form the keys of a plot
data dictionary. The keys may be text, numeric or alphanumeric. Use the
inbuilt python function 'sorted()' and provide a custom key function that
sorts the keys in natural order. Factor out this sorting function to a
common library.