### PR TITLE
cluster/ceph: do not specify asok path explicitly

### DIFF
--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -608,7 +608,7 @@ class Ceph(Cluster):
             time.sleep(1)
 
     def dump_config(self, run_dir):
-        common.pdsh(settings.getnodes('osds'), 'sudo %s -c %s --admin-daemon /var/run/ceph/ceph-osd.0.asok config show > %s/ceph_settings.out' % (self.ceph_cmd, self.tmp_conf, run_dir)).communicate()
+        common.pdsh(settings.getnodes('osds'), 'sudo %s -c %s daemon osd.0 config show > %s/ceph_settings.out' % (self.ceph_cmd, self.tmp_conf, run_dir)).communicate()
 
     def dump_historic_ops(self, run_dir):
         common.pdsh(settings.getnodes('osds'), 'find "/var/run/ceph/ceph-osd*.asok" -maxdepth 1 -exec sudo %s --admin-daemon {} dump_historic_ops \; > %s/historic_ops.out' % (self.ceph_cmd, run_dir)).communicate()


### PR DESCRIPTION
there is chance that we run cbt against a vstart cluster which puts the
asok files in $TMPDIR instead of /var/run/ceph. so. in this chance,
use `ceph daemon` instead of `ceph --admin-daemon <path>` to let `ceph`
cli to deduce the path of asock by itself to avoid hardwire the path to
/var/run.

Signed-off-by: Kefu Chai <kchai@redhat.com>