### PR TITLE
Fix perf failure to collect stats from CPU due to permission issues

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -64,6 +64,14 @@ class Benchmark(object):
                 logger.info('CPU Cycles Per Operation metric is not configured for this benchmark')
                 continue
             self_analyzer_res[name] = self_getter()
+            if self_analyzer_res[name] is None:
+                paranoid_path = "/proc/sys/kernel/perf_event_paranoid"
+                with open(paranoid_path) as f:
+                    paranoid_level = int(f.read())
+                    if paranoid_level >= 1:
+                        msg = '''Perf must be run by user with CAP_SYS_ADMIN to extract CPU related metrics. Or you could set %s to 0, which is %d now'''
+                        logger.warning('%s. %s is %d', msg, paranoid_path, paranoid_level)
+                continue
             baseline_getter = getattr(baseline_analyzer, 'get_' + alias)
             baseline_analyzer_res[name] = baseline_getter()
         res_outputs.append(self_analyzer_res)

--- a/monitoring.py
+++ b/monitoring.py
@@ -94,7 +94,11 @@ class PerfMonitoring(Monitoring):
         perf_stat_fnames = os.listdir(perf_dir_name)
         for perf_out_fname in perf_stat_fnames:
             perf_output_file = open(perf_dir_name +"/"+ perf_out_fname, "rt")
-            cpu_cycles = ((re.search(r'(.*) cycles(.*?) .*', perf_output_file.read(), re.M|re.I)).group(1)).strip()
+            match = re.search(r'(.*) cycles(.*?) .*', perf_output_file.read(), re.M|re.I)
+            if match:
+                cpu_cycles = match.group(1).strip()
+            else:
+                return None
             total_cpu_cycles = total_cpu_cycles + int(cpu_cycles.replace(',' , ''))
         return total_cpu_cycles
            


### PR DESCRIPTION
@tchaikov brought to my attention a failure when running CBT and trying to extract CPU metrics using perf without the correct privilege levels: https://github.com/ceph/ceph/pull/35750#issuecomment-650573878
This PR fixes it by:
1. Splitting the regex responsible for extracting CPU cycles so that we can handle NoneType.
2. Adding a warning for the user in case perf failed to collect CPU stats due to permission issues.