### PR TITLE
cluster/ceph: fix bug in setting crush_profile

### DIFF
--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -756,13 +756,6 @@ class Ceph(Cluster):
                         continue_if_error=False).communicate()
 
         if crush_profile:
-            try:
-                rule_index = int(crush_profile)
-                # set crush profile using the integer 0-based index of crush rule
-                # displayed by: ceph osd crush rule ls
-                ruleset = crush_profile
-            except ValueError:
-                ruleset = self.get_ruleset(crush_profile)
             common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s crush_rule %s' % (self.ceph_cmd, self.tmp_conf, name, crush_profile),
                         continue_if_error=False).communicate()
 

--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -763,7 +763,7 @@ class Ceph(Cluster):
                 ruleset = crush_profile
             except ValueError:
                 ruleset = self.get_ruleset(crush_profile)
-            common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s crush_ruleset %s' % (self.ceph_cmd, self.tmp_conf, name, crush_profile),
+            common.pdsh(settings.getnodes('head'), 'sudo %s -c %s osd pool set %s crush_rule %s' % (self.ceph_cmd, self.tmp_conf, name, crush_profile),
                         continue_if_error=False).communicate()
 
         logger.info('Checking Health after pool creation.')

--- a/example/example-kvmrbdfio.yaml
+++ b/example/example-kvmrbdfio.yaml
@@ -21,7 +21,7 @@ cluster:
       pg_size: 64
       pgp_size: 64
       replication: 3
-      crush_profile: 1
+      crush_profile: replicated_rule
 benchmarks:
   kvmrbdfio:
     fio_cmd: /usr/local/bin/fio


### PR DESCRIPTION
- Ceph doesn't support pool `crush_rule` based on indexes
- `crush_ruleset` is deprecated and replaced with `crush_rule`