### PR TITLE
tools/crimson: collect and parse metrics incrementally

### DIFF
--- a/tools/crimson/README.rst
+++ b/tools/crimson/README.rst
@@ -11,7 +11,7 @@ To start the test envionment:
 
 .. code-block:: console
 
-     $ MGR=0 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x -d --without-dashboard --seastore --crimson --nodaemon --redirect-output
+     $ MGR=0 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x --without-dashboard --seastore --crimson --nodaemon --redirect-output
      $ ./bin/ceph osd pool create test-pool 5 5
      $ ./bin/ceph osd pool set test-pool size 1 --yes-i-really-mean-it
 

--- a/tools/crimson/seastore_radosbench_run.sh
+++ b/tools/crimson/seastore_radosbench_run.sh
@@ -6,24 +6,30 @@ TOP_DIR=$(cd $(dirname "$0") && pwd)
 RESULT_DIR="$TOP_DIR/results"
 BUILD_DIR="~/ceph/build/"
 POOL_NAME="test-pool"
-START_ROUND=1
-TOTAL_ROUND=5
+TOTAL_ROUND=10
+BENCH_SECONDS=1
 
 # Note: currently only support single OSD to measure write amplification
 # correctly.
+if [ -e $RESULT_DIR ]; then
+  echo "'$RESULT_DIR' dir already exists, remove it or select a different one"
+  exit 1
+fi
+
 mkdir -p $RESULT_DIR
 cd $BUILD_DIR
-CURRENT_ROUND=$START_ROUND
+CURRENT_ROUND=0
 TARGET_ROUND=$(( CURRENT_ROUND + TOTAL_ROUND ))
+
+CEPH_DEV=1 ./bin/ceph tell osd.0 dump_metrics 2>&1 | tee $RESULT_DIR/result_${CURRENT_ROUND}_metrics.log
 while [ $CURRENT_ROUND -lt $TARGET_ROUND ]
 do
+  (( ++CURRENT_ROUND ))
   echo "start round $CURRENT_ROUND ..."
-  CEPH_DEV=1 ./bin/ceph tell osd.0 dump_metrics 2>&1 | tee $RESULT_DIR/result_${CURRENT_ROUND}_metrics_start.log
-  CEPH_DEV=1 ./bin/rados bench -p $POOL_NAME 5 write -b 4096 --no-cleanup 2>&1 | tee $RESULT_DIR/result_${CURRENT_ROUND}_bench.log
-  CEPH_DEV=1 ./bin/ceph tell osd.0 dump_metrics 2>&1 | tee $RESULT_DIR/result_${CURRENT_ROUND}_metrics_end.log
+  CEPH_DEV=1 ./bin/rados bench -p $POOL_NAME $BENCH_SECONDS write -b 4096 --no-cleanup 2>&1 | tee $RESULT_DIR/result_${CURRENT_ROUND}_bench.log
+  CEPH_DEV=1 ./bin/ceph tell osd.0 dump_metrics 2>&1 | tee $RESULT_DIR/result_${CURRENT_ROUND}_metrics.log
   echo "finish round $CURRENT_ROUND"
   echo
-  (( ++CURRENT_ROUND ))
   sleep 2
 done
 echo "done!"


### PR DESCRIPTION
Reuse the previous metric file as the starting point, so we don't need
to collect result_metrics_start.log for each rados bench round.

Signed-off-by: Yingxin Cheng <yingxin.cheng@intel.com>