### PR TITLE
benchmark: Generalize prefill and add hsbench support

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -116,13 +116,12 @@ class Benchmark(object):
         return self.__class__.__name__
 
     def initialize(self):
-        self.cluster.cleanup()
-        use_existing = settings.cluster.get('use_existing', True)
-        if not use_existing:
-            self.cluster.initialize()
-        self.cleanup()
+        pass
 
     def initialize_endpoints(self):
+        pass
+
+    def prefill(self):
         pass
 
     def run(self):

--- a/benchmark/fio.py
+++ b/benchmark/fio.py
@@ -36,7 +36,7 @@ class Fio(Benchmark):
         self.random_distribution = config.get('random_distribution', None)
         self.rate_iops = config.get('rate_iops', None)
         self.fio_out_format = "json,normal"
-        self.prefill = config.get('prefill', True)
+        self.prefill_flag = config.get('prefill', True)
         self.norandommap = config.get("norandommap", False)
         self.out_dir = self.archive_dir
         self.client_endpoints = config.get("client_endpoints", None)
@@ -69,7 +69,6 @@ class Fio(Benchmark):
         self.create_endpoints()
 
     def create_endpoints(self):
-        new_ep = False
         if not self.client_endpoints_object.get_initialized():
             self.client_endpoints_object.initialize()
             new_ep = True
@@ -90,10 +89,6 @@ class Fio(Benchmark):
         if self.endpoint_type == 'rbd' and self.direct != '1':
             logger.warn('rbd endpoints must use O_DIRECT. Setting direct=1')
             self.direct = '1'
-
-        # Prefill Data
-        if new_ep and self.prefill:
-            self.prefill_data()
 
     def fio_command_extra(self, ep_num):
         cmd = ''
@@ -126,10 +121,13 @@ class Fio(Benchmark):
         cmd += self.fio_command_extra(ep_num)
         return cmd
 
-    def prefill_data(self):
+    def prefill(self):
+        super(Fio, self).prefill()
+        if not self.prefill_flag:
+            return
         # populate the fio files
         ps = []
-        logger.info('Attempting to populating fio files...')
+        logger.info('Attempting to prefill fio files...')
         for ep_num in range(self.endpoints_per_client):
             p = common.pdsh(settings.getnodes('clients'), self.prefill_command(ep_num))
             ps.append(p)


### PR DESCRIPTION
Currently only the fio based benchmarks in CBT support the concept of prefill.  When a benchmark is run, they will optionally prefill the volume before running benchmarks.  The problem is that this is local and only happens when the first invocation of an fio benchmark is run.

IE if you are running an hsbench benchmark and then an fio benchmark you would:

1) run first hsbench benchmarks (no prefill for hsbench now)
2) prefill rbd
3) run first rbd benchmarks
4) run second hsbenchmarks (no prefill, so recreate data)
5) run second rbd bencharks (using the prefilled data from the first run)

This PR makes the concept of prefill generic for all benchmarks and prefills all benchmark data (when possible/desired) before tests are run.  Now you can do things like:

1) prefill hsbench
2) prefill fio
3) run first hsbench benchmarks
4) run first fio benchmarks
5) run second hsbench benchmarks
6) run second fio benchmarks

This is desirable because it allows us to simulate environments where there is pre-existing block and object data and we want to observe cache behavior during alternating workloads.  This PR was used for example to perform these tests for cache age binning:

https://docs.google.com/spreadsheets/d/1lSp2cLzYmRfPILDCyLMXciIfdf0OvSFngwXukQFXIqQ/edit#gid=1873901060

Signed-off-by: Mark Nelson <mnelson@redhat.com>