### PR TITLE
benchmark/fio: add and unify bs (blocksize) options

### DIFF
--- a/benchmark/fio.py
+++ b/benchmark/fio.py
@@ -30,7 +30,10 @@ class Fio(Benchmark):
         self.logging = config.get('logging', True)
         self.log_avg_msec = config.get('log_avg_msec', None)
         self.ioengine = config.get('ioengine', 'libaio')
-        self.op_size = config.get('op_size', 4194304)
+        self.bssplit = config.get('bssplit', None)
+        self.bsrange = config.get('bsrange', None)
+        self.bs = config.get('bs', None)
+        self.op_size = config.get('op_size', 4194304) # Deprecated, please use bs
         self.size = config.get('size', 4096)
         self.procs_per_endpoint = config.get('procs_per_endpoint', 1)
         self.random_distribution = config.get('random_distribution', None)
@@ -145,7 +148,15 @@ class Fio(Benchmark):
         # IO options
         cmd += ' --ioengine=%s' % self.ioengine
         cmd += ' --direct=%s' % self.direct
-        cmd += ' --bs=%dB' % self.op_size
+        if self.bssplit is not None:
+            cmd += ' --bssplit=%s' % self.bssplit
+        if self.bsrange is not None:
+            cmd += ' --bsrange=%s' % self.bsrange
+        if self.bs is not None:
+            cmd += ' --bs=%s' % self.bs
+        elif self.op_size is not None:
+            logger.warn('op_size is deprecated, please use bs in the future')
+            cmd += ' --bs=%s' % self.op_size
         cmd += ' --iodepth=%d' % self.iodepth
         cmd += ' --end_fsync=%d' % self.end_fsync
         cmd += ' --rw=%s' % self.mode


### PR DESCRIPTION
Previously fio used the "op_size" option in an attempt to unify options with the rados bench benchmark.  This was confusing for people who use fio directly given that it's equivalent option is called bs (blocksize) and that it has several other options to specify different ranges and splits for multiple block sizes at the same time.  This PR adds those additional options and also moves toward deprecating the usage of "op_size" in favor of the original fio bs, bssplit, and bsrange verbage.  For now, op_size is still used if bs is not specified.

Signed-off-by: Mark Nelson <mnelson@redhat.com>