### PR TITLE
benchmark/fio: Add prefill specific iodepth

### DIFF
--- a/benchmark/fio.py
+++ b/benchmark/fio.py
@@ -22,6 +22,7 @@ class Fio(Benchmark):
         self.time_based = bool(config.get('time_based', False))
         self.ramp = config.get('ramp', None)
         self.iodepth = config.get('iodepth', 16)
+        self.prefill_iodepth = config.get('prefill_iodepth', 16)
         self.numjobs = config.get('numjobs', 1)
         self.end_fsync = config.get('end_fsync', 0)
         self.mode = config.get('mode', 'write')
@@ -121,6 +122,7 @@ class Fio(Benchmark):
         cmd += ' --rw=write'
         cmd += ' --numjobs=%d' % self.numjobs
         cmd += ' --bs=4M'
+        cmd += ' --iodepth=%d' % self.prefill_iodepth
         cmd += ' --size %dM' % self.size
         cmd += ' --output-format=%s' % self.fio_out_format
         cmd += self.fio_command_extra(ep_num)


### PR DESCRIPTION
Prefilling RBD can be slow when large volumes are used.  This PR provides an fio prefill specific iodepth option with a default value of 16 to ensure that volumes are prefilled quickly by default (with the option to override when desired).  This was separated from the normal iodepth option so that even when testing with low iodepths the prefill stage can be completed quickly.

Long term, we may want to provide a completely separate way to run fio/hsbench/etc in prefill mode with all of the normal options available, but until then this option can help.

Signed-off-by: Mark Nelson <mnelson@redhat.com>