### PR TITLE
benchmark: Use pathlib to generalize benchmark cleanup.

### DIFF
--- a/benchmark/fio.py
+++ b/benchmark/fio.py
@@ -4,6 +4,7 @@ import monitoring
 import os
 import time
 import logging
+import pathlib
 import client_endpoints_factory
 
 from .benchmark import Benchmark
@@ -233,8 +234,12 @@ class Fio(Benchmark):
         common.sync_files('%s/*' % self.run_dir, self.out_dir)
         self.analyze(self.out_dir)
 
+    def cleanup(self):
+        cmd_name = pathlib.PurePath(self.cmd_path).name
+        common.pdsh(settings.getnodes('clients'), 'sudo killall -2 %s' % cmd_name).communicate()
+
     def recovery_callback_blocking(self):
-        common.pdsh(settings.getnodes('clients'), 'sudo killall -2 fio').communicate()
+        self.cleanup()
 
     def recovery_callback_background(self):
         logger.info('Recovery thread completed!')

--- a/benchmark/getput.py
+++ b/benchmark/getput.py
@@ -4,6 +4,7 @@ import monitoring
 import os
 import time
 import logging
+import pathlib
 
 from .benchmark import Benchmark
 
@@ -147,7 +148,8 @@ class Getput(Benchmark):
         self.cleanup()
 
     def cleanup(self):
-        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 getput').communicate()
+        cmd_name = pathlib.PurePath(self.cmd_path).name
+        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 %s' % cmd_name).communicate()
 
     def __str__(self):
         return "%s\n%s\n%s" % (self.run_dir, self.out_dir, super(Getput, self).__str__())

--- a/benchmark/hsbench.py
+++ b/benchmark/hsbench.py
@@ -3,6 +3,7 @@ import settings
 import monitoring
 import os
 import logging
+import pathlib
 import client_endpoints_factory
 
 from .benchmark import Benchmark
@@ -140,7 +141,8 @@ class Hsbench(Benchmark):
         self.cleanup()
 
     def cleanup(self):
-        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 hsbench').communicate()
+        cmd_name = pathlib.PurePath(self.cmd_path).name
+        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 %s' % cmd_name).communicate()
 
     def __str__(self):
         return "%s\n%s\n%s" % (self.run_dir, self.out_dir, super(Hsbench, self).__str__())

--- a/benchmark/radosbench.py
+++ b/benchmark/radosbench.py
@@ -4,6 +4,7 @@ import monitoring
 import os
 import time
 import logging
+import pathlib
 import re
 import json
 
@@ -215,8 +216,13 @@ class Radosbench(Benchmark):
                 self.cluster.rmpool('rados-bench-cbt', self.pool_profile)
                 self.cluster.mkpool('rados-bench-cbt', self.pool_profile, 'radosbench')
 
+
+    def cleanup(self):
+        cmd_name = pathlib.PurePath(self.cmd_path).name
+        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 %s' % cmd_name).communicate()
+
     def recovery_callback(self):
-        common.pdsh(settings.getnodes('clients'), 'sudo killall -9 rados').communicate()
+        cleanup();
 
     def parse(self, out_dir):
         for client in settings.getnodes('clients').split(','):


### PR DESCRIPTION
Start using pathlib to generalize benchmark cleanup since the supplied command name may not match the current hardcoded executable names we currently use.

Signed-off-by: Mark Nelson <mnelson@redhat.com>