### PR TITLE
crimson/tools: rados bench stress tool

### DIFF
--- a/tools/crimson/README.rst
+++ b/tools/crimson/README.rst
@@ -78,45 +78,36 @@ Finally, run ``seastore_metrics_analyze.py`` to generate plots in png format.
 Rados bench stress tool
 =======================
 
-This is a rados bench stress tool for single client or multiple client crimson
+This is a rados bench stress tool for multiple clients and multiple threads 
 osd writing test to understand how to stress crimson osd. User can set the 
 number of clients and threads, which processors will bench threads execute 
-on(to avoid test threads influence the result), test time, block size, etc.,
-to run the test case. Then the tool will integrate IOPS, Bandwidth, Latency 
-and seastar reactor utilization to help user analyze cimson osd performance.
+on(to avoid test threads influencing the result), test time, block size, etc.
+, to run the test case. Then the tool will integrate IOPS, Bandwidth, Latency 
+seastar reactor utilization or other targets to help user analyze crimson 
+osd performance.
 
-To use this tool, prepare the python3 environment, crimson cluster and a test 
+To use this tool, prepare the python3 environment, osd cluster and a test 
 pool. Put this tool in the ceph build directory. Since we will decide which 
 processors the bench threads execute on, sudo is needed.
 
 Run ``./rados_bench_tools.py --help`` to get the detail parameter information.
 
-Example of single client stress test:
+Example:
 
 .. code-block:: console
     
-    sudo ./rados_bench_tools.py --clean-up=True --client=1 --thread-list=[4,6,8,10,12,14,16,18,20,22,24,26,28,30,32] --time=300
+    sudo ./rados_bench_tools.py --thread-list 1 2 --client-list 2 4 6 --taskset=16-31 --reactor-utilization=True --time=300
 
-The tool will serially run test case with 1 client and 4 threads, 6 threads, 
-8 threads, etc. In every test case, threads run parallel but different cases 
-run serially. 
-
-Example of multiple client stress test:
-
-.. code-block:: console
-
-    sudo ./rados_bench_tools.py --clean-up=True --taskset=16-31 --client-list=[4,6,8,10,12,14,16,18,20,22,24,26,28,30,32] --thread=2
-
-The tool will run test case with 2 threads and 4 clients(parallel), 6 clients, 
-etc. and the test thread will run in processors 16~31. In every test case, 
-clients and threads in every client run parallel.
-In consideration of SeaStore starts in processor 0 by default, please avoid 
-setting --taskset to 0.
+The tool will run test case with the combination of 1 or 2 clients and 2, 4 or
+6 threads. Meanwhile, it will collect the reactor utilization, which is the 
+utilization of the cpu from seastar. The test thread will run in processors 
+16~31. In consideration of SeaStore starts in processor 0 by default, please 
+avoid setting --taskset to 0.
 
 Example of result:
 
 .. code-block:: console
-    
-    CLIENTS  THREADS  IOPS  BANDWIDTCH  LATENCY REACTOR_UTILIZATION
-    3         1        2580.75    10.0838    0.0003851295    12.74903761999997
-    5         1        1728.6666666666667    6.754173333333333    0.0005760875    92.36707335999996
+
+   bandwidth                iops             latency reactor_utilization          thread_num          client_num
+   0.5301985               135.5           0.0073715   2.370669279999993                   1                   2
+   0.4831115               123.5          0.01609335  27.892383860000024                   2                   2

--- a/tools/crimson/rados_bench_tools.py
+++ b/tools/crimson/rados_bench_tools.py
@@ -1,217 +1,207 @@
-#!/usr/bin/env python3
-
+#!/usr/bin/env python3 
 import argparse
 import math
 import os
 import threading
 import time
 
-class ExecRadosBenchThread(threading.Thread):
-    def __init__(self, thread_nums, client_nums, path):
+
+# Divid all test threads into two categories, which should implement
+# ITestCaseBasedThread or ITimePointBasedThread. The test threads that
+# only care of what is the system going on at a time point, such as 
+# reactor utilization are classified as ITimePointBasedThread and the 
+# basic test case threads(such as rados bench) that are only the single 
+# small test case are classified as ITestCaseBasedThread.
+# For developer, you can write the test class you want by implementing
+# the ITestCaseBasedThread or ITimePointBasedThread interfaces and adding 
+# it to to testclient_threadclass_list or timepoint_threadclass_list to 
+# extend this test tools. 
+# set the start_time to decide when will the test start after thread starts.
+# the tast case based threads interface.
+class ITestCaseBasedThread(threading.Thread):
+    def __init__(self, thread_num, args):
         threading.Thread.__init__(self)
-        self.thread_nums = thread_nums
-        self.client_nums = client_nums
-        self.path = path
-        self.task_set = args.taskset
-        self.block_size = args.block_size
-        self.time = args.time
-        self.pool = args.pool
-    def creat_rados_bench_write_command(self):
+        self.thread_num = thread_num
+        self.args = args
+        self.start_time = 0 
+        self.result = None
+    # rewrite method create_command() to define the command this class will 
+    # execute
+    def create_command(self):
+        raise NotImplementedError
+    # don't need to rewite this method
+    def run(self):
+        time.sleep(self.start_time)
+        self.result =  os.popen(self.create_command())
+    # rewrite method analyse() to analyse the output from executing the 
+    # command and return a result dict as format {param : result}
+    # and the value type should be float
+    def analyse(self) ->dict:
+        raise NotImplementedError
+
+
+# the time point based threads interface. 
+class ITimePointBasedThread(threading.Thread):
+    def __init__(self, args):
+        threading.Thread.__init__(self)
+        self.args = args
+        self.start_time = 1 
+        self.result = None
+    def create_command(self):
+        raise NotImplementedError
+    def run(self):
+        time.sleep(self.start_time)
+        self.result = os.popen(self.create_command())
+    def analyse(self) ->dict:
+        raise NotImplementedError
+
+
+class ExecRadosBenchThread(ITestCaseBasedThread):
+    def __init__(self, thread_num, args):
+        ITestCaseBasedThread.__init__(self, thread_num, args)
+        self.task_set = self.args.taskset
+        self.block_size = self.args.block_size
+        self.time = self.args.time
+        self.pool = self.args.pool
+    def create_command(self):
         rados_bench_write = "sudo taskset -c " + self.task_set \
             + " bin/rados bench -p " + self.pool + " " \
             + self.time + " write -t " \
-            + str(self.thread_nums) + " -b " + self.block_size + " "
-        output = ">> " + self.path + "/" + "client_" + str(self.client_nums) \
-            + "_rados_bench_thread_" + str(self.thread_nums) + ".txt"
-        return rados_bench_write + output
-    def run(self):
-        print("client nums:%d, thread nums:%d testing"
-                %(self.client_nums, self.thread_nums))
-        os.system(self.creat_rados_bench_write_command())
-
-class ReactorUtilizationCollectorThread(threading.Thread):
-    def __init__(self, thread_nums, client_nums, path, start_time):
-        threading.Thread.__init__(self)
-        self.start_time = start_time
-        self.thread_nums = thread_nums
-        self.client_nums = client_nums
-        self.path = path
-        self.osd = "osd.0"
-    def create_ceph_metrix_command(self):
-        command = "sudo bin/ceph tell " \
-            + self.osd + " dump_metrics reactor_utilization"
-        output = ">> " + self.path + "/" + "client_" + str(self.client_nums) \
-            + "_seastar_bench_thread_" + str(self.thread_nums) + ".txt"
-        return command + output
-    def run(self):
-        time.sleep(self.start_time)
-        os.system(self.create_ceph_metrix_command()) 
-
-def single_client_bench(lis, rados_bench_path, seastar_bench_path):
-    for thread_nums in lis:
-        client_thread = ExecRadosBenchThread(thread_nums, 1, rados_bench_path)
-        ceph_metrix_thread = ReactorUtilizationCollectorThread(
-            thread_nums, 1, seastar_bench_path, int(args.time)/2)
-        client_thread.start()
-        ceph_metrix_thread.start()
-        client_thread.join()
-        ceph_metrix_thread.join()
-    print("Done.")
-
-def multi_client_bench(n, thread_nums, client_bench_path, client_seastar_path):
-    client_list = list()
-    seastar_list = list()
-    for client_nums in range(n):
-        client_thread = ExecRadosBenchThread( 
-            thread_nums,client_nums, client_bench_path)
-        ceph_metrix_thread = ReactorUtilizationCollectorThread(
-            thread_nums, client_nums, client_seastar_path, int(args.time)/2)
-        client_list.append(client_thread)
-        seastar_list.append(ceph_metrix_thread)
-    for index in range(n):
-        client_list[index].start()
-        seastar_list[index].start()
-    for index in range(n):
-        client_list[index].join()
-        seastar_list[index].join()
-    print("Done.")
-
-
-def multi_group_multi_client_bench( 
-    lis, thread_nums, rados_bench_path, seastar_bench_path): 
-    for n in lis:
-        client_bench_path = rados_bench_path + "/" + str(n)
-        client_seastar_path = seastar_bench_path + "/" + str(n)
-        os.makedirs(client_bench_path)
-        os.makedirs(client_seastar_path)
-        multi_client_bench(n, thread_nums, client_bench_path, client_seastar_path)
-
-def result_sort_rule_thread(tupl):
-    return int(tupl[1])
-
-def result_sort_rule_client(tupl):
-    return int(tupl[0])
-    
-def append_result_to_file(f, result):
-    f.write("CLIENTS  THREADS  IOPS  BANDWIDTCH  LATENCY REACTOR_UTILIZATION\n")
-    for tupl in result:
-        line = str(tupl[0]) + "         " + str(tupl[1]) + "        " \
-            + str(tupl[2]) + "    " + str(tupl[3]) + "    " + str(tupl[4]) \
-            + "    " + str(tupl[5]) + "\n"
-        f.write(line)
-
-def transform_ceph_seastar_bench_filename(rados_bench_filename):
-    return  rados_bench_filename.replace("rados","seastar")
-    
-
-def get_reactor_utilization_value_by_ceph_seastar_bench_filename(
-    seastar_bench_path, seastar_bench_filename):
-    file_path = seastar_bench_path + "/" + seastar_bench_filename
-    f = open(file_path)
-    line = f.readline()
-    while line:
-        temp_lis = line.split()
-        if temp_lis[0] == "\"value\":":
-            f.close()
-            return temp_lis[1]
-        line = f.readline()
-
-def get_rados_bench_result(rados_bench_path, seastar_bench_path):
-    result = list()
-    file_names = os.listdir(rados_bench_path)
-    for result_file in file_names:
-        client_nums = result_file.split('_')[1]
-        thread_nums = result_file.split('_')[5].split('.')[0]
-        result_file_path = rados_bench_path + "/" + result_file
-        iops = latency = bandwidth = None
-        f = open(result_file_path)
-        line = f.readline()
+            + str(self.thread_num) + " -b " + self.block_size + " "
+        return rados_bench_write
+    def analyse(self):
+        result_dic = {} #iops, lantency, bandwidth
+        line = self.result.readline()
         while line:
             if line[0] == 'A':
                 element = line.split()
                 if element[1]=="IOPS:":
-                    iops = element[2]
+                    result_dic['iops'] = float(element[2])
                 if element[1]=="Latency(s):":
-                    latency = element[2]
+                    result_dic['latency'] = float(element[2])
             if line[0] == 'B':
                 element = line.split()
-                bandwidth = element[2] 
-            line = f.readline()
-        f.close()
+                result_dic['bandwidth'] = float(element[2])
+            line = self.result.readline()
+        self.result.close()
+        return result_dic
 
-        #reactor_utilization
-        reactor_utilization = \
-            get_reactor_utilization_value_by_ceph_seastar_bench_filename(
-                seastar_bench_path, 
-                transform_ceph_seastar_bench_filename(result_file))
-        result.append((client_nums, thread_nums, iops, 
-                bandwidth, latency, reactor_utilization))
-    
-    result.sort(key=result_sort_rule_thread)
-    result.sort(key=result_sort_rule_client)
-    append_result_to_file(f_result,result)
-    print(result)
-    return result
 
-def analyse_rados_bench_result(result):
-    sum_iops = sum_bandwith = sum_latency = sum_reactor_utilization = 0
-    length = len(result)
-    for data in result:
-        sum_iops += int(data[2])
-        sum_bandwith += float(data[3])
-        sum_latency += float(data[4])
-        sum_reactor_utilization += float(data[5])
-    return (result[-1][0], 
-            result[-1][1], 
-            sum_iops/length,
-            sum_bandwith/length, sum_latency/length, 
-            sum_reactor_utilization/length)
+class ReactorUtilizationCollectorThread(ITimePointBasedThread):
+    def __init__(self, args):
+        ITimePointBasedThread.__init__(self, args)
+        self.start_time = int(self.args.time)/2
+        self.osd = "osd.0"
+    def create_command(self):
+        command = "sudo bin/ceph tell " \
+            + self.osd + " dump_metrics reactor_utilization"
+        return command
+    def analyse(self):
+        result_dic = {} #reactor_utilization
+        line = self.result.readline()
+        while line:
+            temp_lis = line.split()
+            if temp_lis[0] == "\"value\":":
+                result_dic['reactor_utilization'] = float(temp_lis[1])
+                break
+            line = self.result.readline()
+        self.result.close()
+        return result_dic
 
-def analyse_multi_rados_bench_result(rados_bench_path, seastar_bench_path):
-    result = list()
-    client_dir = os.listdir(rados_bench_path)
-    for client in client_dir:
-        client_result = get_rados_bench_result(
-            rados_bench_path + "/" + client, seastar_bench_path + "/" + client) 
-        client_result_avg = analyse_rados_bench_result(client_result) 
-        result.append(client_result_avg)
-    result.sort(key = result_sort_rule_client)
-    f_result.write("=Every client average results:\n")
-    append_result_to_file(f_result,result)
-    print('every client avg results:')
-    print(result)
-    return result        
 
-def clean_up(path_list):
-    for path in path_list:
-        os.system("sudo rm -rf " + path)
+class TesterMetrix():
+    def __init__(self, args \
+            , testclient_threadclass_list, timepoint_threadclass_list):
+        self.thread_list = args.thread_list
+        self.client_list = args.client_list
+        self.testclient_threadclass_list = testclient_threadclass_list
+        self.timepoint_threadclass_list = timepoint_threadclass_list
+        self.metrix = list() #[[ITestCaseBasedThread or ITimePointBasedThread]]
+        self.desc_metrix = list() #[[(thread_num, client_num)]]
+        self.init_metrix()
+    def init_metrix(self):
+        for thread_num in self.thread_list:
+            row = list()
+            desc_row = list()
+            for client_num in self.client_list:
+                test_case_threads = list()
+                for thread in self.testclient_threadclass_list:
+                    for n in range(client_num):
+                        test_case_threads.append(thread(thread_num, args))
+                for thread in self.timepoint_threadclass_list:
+                    test_case_threads.append(thread(args)) 
+                row.append(test_case_threads)
+                desc_row.append((thread_num, client_num))
+            self.metrix.append(row)
+            self.desc_metrix.append(desc_row)
+    def get_tester_metrix(self):
+        return self.metrix
+    def get_desc_metrix(self):
+        return self.desc_metrix
+
+
+class TesterExecutor():
+    def __init__(self, tester_metrix, desc_metrix):
+        self.result_list = list() #[dict] 
+        for row_index in range(len(tester_metrix)):
+            for test_case_threads_index in range(len(tester_metrix[row_index])):
+                test_case_threads = tester_metrix[row_index][test_case_threads_index]
+                
+                desc = desc_metrix[row_index][test_case_threads_index]
+                thread_num = desc[0]
+                client_num = desc[1]
+                print("client num:%d, thread num:%d testing"
+                            %(client_num, thread_num))
+                for thread in test_case_threads:
+                    thread.start()
+                for thread in test_case_threads:
+                    thread.join()
+                test_case_result = dict()
+                for thread_index in range(client_num):
+                    base_test_case_result = test_case_threads[thread_index].analyse()
+                    for key in base_test_case_result:
+                        if key not in test_case_result:
+                            test_case_result[key] = base_test_case_result[key]
+                        else:
+                            test_case_result[key] += base_test_case_result[key]
+                for key in test_case_result:
+                    test_case_result[key] /= client_num
+                for thread_index in range(client_num, len(test_case_threads)):
+                    timepoint_thread_result = test_case_threads[thread_index].analyse()
+                    for key in timepoint_thread_result:
+                        if key not in test_case_result:
+                            test_case_result[key] =  timepoint_thread_result[key]
+
+                test_case_result['thread_num'] = thread_num
+                test_case_result['client_num'] = client_num
+                self.result_list.append(test_case_result)
+    def output(self, output):
+        f_result = open(output,"w")
+        for key in self.result_list[0]:
+            print('%20s'%(key), end ='')
+            f_result.write('%20s'%(key))
+        print('\n')
+        f_result.write('\n')
+        for result in self.result_list:
+            for key in result:
+                print('%20s'%(str(result[key])), end = '')
+                f_result.write('%20s'%(str(result[key])))
+            print('\n')
+            f_result.write('\n')
+           
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=
-            'For single client stress case, please set --client=1 and --thread-list. \
-            In this case, parameter --client-list and --thread will be invalid. \
-            In multiple client stress case, please set --thread and --client-list. \
-            In this case, parameter --client and --thread-list will be invalid.')
-    parser.add_argument('--clean-up',
-            type = bool,
-            default = False,
-            help = 'clean up all intermediate results')
-    parser.add_argument('--client',
-            type = int,
-            default = 0,
-            help = 'the number of clients in all test case')
-    parser.add_argument('--thread',
-            type = int,
-            default = 16,
-            help = 'the number of threads in all test case')
+    parser = argparse.ArgumentParser(description='')
     parser.add_argument('--thread-list',
-            type = str,
-            default = "[10]",
-            help = 'the number of threads in each test case')
+            nargs = '+',
+            type = int,
+            required = True,
+            help = 'threads list')
     parser.add_argument('--client-list',
-            type = str,
-            default = "[1]",
-            help = 'the number of clients in each test case')
+            nargs = '+',
+            type = int,
+            required = True,
+            help = 'clients list')
     parser.add_argument('--taskset',
             type = str,
             default = "1-32",
@@ -223,52 +213,31 @@ if __name__ == "__main__":
     parser.add_argument('--time',
             type = str,
             default = "10",
-            help = 'test time')
+            help = 'test time for every test case')
     parser.add_argument('--pool',
             type = str,
             default = "benchtest",
             help = 'pool')
-    parser.add_argument('--path-radosbench',
-            type = str,
-            default = "rados_bench_result",
-            help = 'path of every rados bench test results')
-    parser.add_argument('--path-seastar',
-            type = str,
-            default = "rados_seastar_result",
-            help = 'path of every seastar performance data results')
     parser.add_argument('--output',
             type = str,
             default = "result.txt",
             help = 'path of all output result after integrating')
+    parser.add_argument('--reactor-utilization',
+        type = bool,
+        default = False,
+        help = 'set True to collect the reactor utilization')
     args = parser.parse_args()
 
-    f_result = open(args.output,"w")
+    # add the test thread class to the lists below.
+    testclient_threadclass_list = [ExecRadosBenchThread]
+    timepoint_threadclass_list = []
+    if args.reactor_utilization:
+        timepoint_threadclass_list.append(ReactorUtilizationCollectorThread)
+    # init the tester metrix
+    tester_metrix = TesterMetrix(args \
+            , testclient_threadclass_list, timepoint_threadclass_list)
+    # execute the tester in the tester metrix
+    tester_executor = TesterExecutor(tester_metrix.get_tester_metrix() \
+            , tester_metrix.get_desc_metrix())
+    tester_executor.output(args.output)
 
-    rados_bench_path = args.path_radosbench
-    seastar_bench_path = args.path_seastar
-    if not os.path.exists(rados_bench_path):
-        os.makedirs(rados_bench_path)
-    else:
-        if len(os.listdir(rados_bench_path)) != 0:
-            clean_up([rados_bench_path])
-            os.makedirs(rados_bench_path)
-    if not os.path.exists(seastar_bench_path):
-        os.makedirs(seastar_bench_path)
-    else:
-        if len(os.listdir(seastar_bench_path)) != 0:
-            clean_up([seastar_bench_path])
-            os.makedirs(seastar_bench_path)
-
-    if args.client == 1:
-        single_client_bench(eval(args.thread_list), 
-                rados_bench_path, seastar_bench_path)
-        get_rados_bench_result(rados_bench_path, seastar_bench_path)
-    else:
-        multi_group_multi_client_bench(eval(args.client_list),
-                args.thread, rados_bench_path, seastar_bench_path)
-        analyse_multi_rados_bench_result(rados_bench_path, seastar_bench_path)
-
-    if args.clean_up is True:
-        clean_up([rados_bench_path, seastar_bench_path])
-
-    f_result.close()


### PR DESCRIPTION
Rewrite the structure of the code for future extending.

Support multiple clients and mutliple threads test in the same time.

Support stopping collecting the reactor utilization for the bluestore
comparison testing.

Make it easier to use.

Signed-off-by: Xinyu Huang <xinyu.huang@intel.com>