### PR TITLE
common: Allow pdsh command pass-through

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -8,6 +8,7 @@ import logging
 
 logger = logging.getLogger("cbt")
 
+common = {}
 cluster = {}
 client_endpoints = {}
 benchmarks = {}
@@ -25,7 +26,7 @@ def _handle_monitoring_legacy():
 
 
 def initialize(ctx):
-    global cluster, client_endpoints, benchmarks, monitoring_profiles
+    global common, cluster, client_endpoints, benchmarks, monitoring_profiles
 
     config = {}
     try:
@@ -34,6 +35,7 @@ def initialize(ctx):
     except IOError as e:
         raise argparse.ArgumentTypeError(str(e))
 
+    common = config.get('common', {})
     cluster = config.get('cluster', {})
     client_endpoints = config.get('client_endpoints', {})
     benchmarks = config.get('benchmarks', {})


### PR DESCRIPTION
The goal here is two-fold:
1) Allow direct path to pdsh commands
2) Allow pdsh environment variables to be set for things like credential pass-through (ie this will enable cbt to run on Red Hat's gibba cluster).  For example, the following can now be added to cbt yaml files:

```
common:
  pdsh_ssh_args: "-A"
  pdsh_cmd: "/usr/local/bin/pdsh"
  pdcp_cmd: "/usr/local/bin/pdcp"
  rpdcp_cmd: "/usr/local/bin/rpdcp"
```

Signed-off-by: Mark Nelson <mnelson@redhat.com>