### PR TITLE
cbt: use_existing fixes for #249

### DIFF
--- a/cbt.py
+++ b/cbt.py
@@ -53,7 +53,8 @@ def main(argv):
 
     # Only initialize and prefill upfront if we aren't rebuilding for each test.
     if not rebuild_every_test:
-        cluster.initialize();
+        if not cluster.use_existing:
+            cluster.initialize();
         for iteration in range(settings.cluster.get("iterations", 0)):
             benchmarks = benchmarkfactory.get_all(archive_dir, cluster, iteration)
             for b in benchmarks:

--- a/cluster/ceph.py
+++ b/cluster/ceph.py
@@ -145,7 +145,6 @@ class Ceph(Cluster):
 
         self.urls = []
         self.auth_urls = []
-        self.osd_count = config.get('osds_per_node') * len(settings.getnodes('osds'))
         self.crimson_cpusets = config.get('crimson_cpusets', [])
 
         # Recovery objects prefill info


### PR DESCRIPTION
Fix for use_existing after #249 merged.  Also remove unused osd_count from ceph cluster class that required unnecessary fields in the yaml when use_existing is invoked.

Signed-off-by: Mark Nelson <mnelson@redhat.com>