### PR TITLE
tools/crimson/seastore_metrics_analyze: rename segment_cleaner to async_cleaner

### DIFF
--- a/tools/crimson/seastore_metrics_analyze.py
+++ b/tools/crimson/seastore_metrics_analyze.py
@@ -341,20 +341,20 @@ def parse_metric_file(metric_file):
         "memory_allocated_memory",
         "memory_free_memory",
         "memory_total_memory",
-        "segment_cleaner_available_bytes",
-        "segment_cleaner_projected_used_bytes_sum",
-        "segment_cleaner_unavailable_reclaimable_bytes",
-        "segment_cleaner_unavailable_unreclaimable_bytes",
-        "segment_cleaner_unavailable_unused_bytes",
-        "segment_cleaner_used_bytes",
-        "segment_cleaner_reclaimed_bytes",
-        "segment_cleaner_reclaimed_segment_bytes",
-        "segment_cleaner_closed_journal_total_bytes",
-        "segment_cleaner_closed_journal_used_bytes",
-        "segment_cleaner_closed_ool_total_bytes",
-        "segment_cleaner_closed_ool_used_bytes",
-        "segment_cleaner_alloc_journal_bytes",
-        "segment_cleaner_dirty_journal_bytes",
+        "async_cleaner_available_bytes",
+        "async_cleaner_projected_used_bytes_sum",
+        "async_cleaner_unavailable_reclaimable_bytes",
+        "async_cleaner_unavailable_unreclaimable_bytes",
+        "async_cleaner_unavailable_unused_bytes",
+        "async_cleaner_used_bytes",
+        "async_cleaner_reclaimed_bytes",
+        "async_cleaner_reclaimed_segment_bytes",
+        "async_cleaner_closed_journal_total_bytes",
+        "async_cleaner_closed_journal_used_bytes",
+        "async_cleaner_closed_ool_total_bytes",
+        "async_cleaner_closed_ool_used_bytes",
+        "async_cleaner_alloc_journal_bytes",
+        "async_cleaner_dirty_journal_bytes",
         # count
         "segment_manager_data_read_num",
         "segment_manager_data_write_num",
@@ -368,32 +368,32 @@ def parse_metric_file(metric_file):
         "memory_malloc_operations",
         "memory_reclaims_operations",
         "memory_malloc_live_objects",
-        "segment_cleaner_segments_open",
-        "segment_cleaner_segments_closed",
-        "segment_cleaner_segments_empty",
-        "segment_cleaner_segments_in_journal",
-        "segment_cleaner_segments_type_journal",
-        "segment_cleaner_segments_type_ool",
-        "segment_cleaner_segments_count_open_journal",
-        "segment_cleaner_segments_count_close_journal",
-        "segment_cleaner_segments_count_release_journal",
-        "segment_cleaner_segments_count_open_ool",
-        "segment_cleaner_segments_count_close_ool",
-        "segment_cleaner_segments_count_release_ool",
-        "segment_cleaner_projected_count",
-        "segment_cleaner_io_count",
-        "segment_cleaner_io_blocked_count",
-        "segment_cleaner_io_blocked_count_trim",
-        "segment_cleaner_io_blocked_count_reclaim",
-        "segment_cleaner_io_blocked_sum",
+        "async_cleaner_segments_open",
+        "async_cleaner_segments_closed",
+        "async_cleaner_segments_empty",
+        "async_cleaner_segments_in_journal",
+        "async_cleaner_segments_type_journal",
+        "async_cleaner_segments_type_ool",
+        "async_cleaner_segments_count_open_journal",
+        "async_cleaner_segments_count_close_journal",
+        "async_cleaner_segments_count_release_journal",
+        "async_cleaner_segments_count_open_ool",
+        "async_cleaner_segments_count_close_ool",
+        "async_cleaner_segments_count_release_ool",
+        "async_cleaner_projected_count",
+        "async_cleaner_io_count",
+        "async_cleaner_io_blocked_count",
+        "async_cleaner_io_blocked_count_trim",
+        "async_cleaner_io_blocked_count_reclaim",
+        "async_cleaner_io_blocked_sum",
         "cache_version_count_dirty",
         "cache_version_count_reclaim",
         "cache_version_sum_dirty",
         "cache_version_sum_reclaim",
         # ratio
         "reactor_utilization",
-        "segment_cleaner_available_ratio",
-        "segment_cleaner_reclaim_ratio",
+        "async_cleaner_available_ratio",
+        "async_cleaner_reclaim_ratio",
         # time
         "reactor_cpu_busy_ms",
         "reactor_cpu_steal_time_ms",
@@ -406,7 +406,7 @@ def parse_metric_file(metric_file):
         "journal_io_num",
         "journal_io_depth_num",
         # util -> count
-        "segment_cleaner_segment_utilization_distribution",
+        "async_cleaner_segment_utilization_distribution",
         # srcs -> count
         "cache_trans_srcs_invalidated",
         # scheduler-group -> time
@@ -479,33 +479,33 @@ def parse_metric_file(metric_file):
             set_value("memory_free_KB", value/1024)
         elif name == "memory_total_memory":
             set_value("memory_total_KB", value/1024)
-        elif name == "segment_cleaner_available_bytes":
+        elif name == "async_cleaner_available_bytes":
             set_value("available_KB", value/1024)
-        elif name == "segment_cleaner_projected_used_bytes_sum":
+        elif name == "async_cleaner_projected_used_bytes_sum":
             set_value("projected_used_sum_KB", value/1024)
-        elif name == "segment_cleaner_unavailable_reclaimable_bytes":
+        elif name == "async_cleaner_unavailable_reclaimable_bytes":
             set_value("unavail_reclaimable_KB", value/1024)
-        elif name == "segment_cleaner_unavailable_unreclaimable_bytes":
+        elif name == "async_cleaner_unavailable_unreclaimable_bytes":
             set_value("unavail_unreclaimable_KB", value/1024)
-        elif name == "segment_cleaner_unavailable_unused_bytes":
+        elif name == "async_cleaner_unavailable_unused_bytes":
             set_value("unavail_unused_KB", value/1024)
-        elif name == "segment_cleaner_used_bytes":
+        elif name == "async_cleaner_used_bytes":
             set_value("unavail_used_KB", value/1024)
-        elif name == "segment_cleaner_reclaimed_bytes":
+        elif name == "async_cleaner_reclaimed_bytes":
             set_value("reclaimed_KB", value/1024)
-        elif name == "segment_cleaner_reclaimed_segment_bytes":
+        elif name == "async_cleaner_reclaimed_segment_bytes":
             set_value("reclaimed_segment_KB", value/1024)
-        elif name == "segment_cleaner_closed_journal_total_bytes":
+        elif name == "async_cleaner_closed_journal_total_bytes":
             set_value("closed_journal_total_KB", value/1024)
-        elif name == "segment_cleaner_closed_journal_used_bytes":
+        elif name == "async_cleaner_closed_journal_used_bytes":
             set_value("closed_journal_used_KB", value/1024)
-        elif name == "segment_cleaner_closed_ool_total_bytes":
+        elif name == "async_cleaner_closed_ool_total_bytes":
             set_value("closed_ool_total_KB", value/1024)
-        elif name == "segment_cleaner_closed_ool_used_bytes":
+        elif name == "async_cleaner_closed_ool_used_bytes":
             set_value("closed_ool_used_KB", value/1024)
-        elif name == "segment_cleaner_alloc_journal_bytes":
+        elif name == "async_cleaner_alloc_journal_bytes":
             set_value("alloc_journal_KB", value/1024)
-        elif name == "segment_cleaner_dirty_journal_bytes":
+        elif name == "async_cleaner_dirty_journal_bytes":
             set_value("dirty_journal_KB", value/1024)
 
         # count
@@ -533,41 +533,41 @@ def parse_metric_file(metric_file):
             set_value("memory_reclaims", value)
         elif name == "memory_malloc_live_objects":
             set_value("memory_live_objs", value)
-        elif name == "segment_cleaner_segments_open":
+        elif name == "async_cleaner_segments_open":
             set_value("segments_open", value)
-        elif name == "segment_cleaner_segments_closed":
+        elif name == "async_cleaner_segments_closed":
             set_value("segments_closed", value)
-        elif name == "segment_cleaner_segments_empty":
+        elif name == "async_cleaner_segments_empty":
             set_value("segments_empty", value)
-        elif name == "segment_cleaner_segments_in_journal":
+        elif name == "async_cleaner_segments_in_journal":
             set_value("segments_in_journal", value)
-        elif name == "segment_cleaner_segments_type_journal":
+        elif name == "async_cleaner_segments_type_journal":
             set_value("segments_type_journal", value)
-        elif name == "segment_cleaner_segments_type_ool":
+        elif name == "async_cleaner_segments_type_ool":
             set_value("segments_type_ool", value)
-        elif name == "segment_cleaner_segments_count_open_journal":
+        elif name == "async_cleaner_segments_count_open_journal":
             set_value("segments_count_open_journal", value)
-        elif name == "segment_cleaner_segments_count_close_journal":
+        elif name == "async_cleaner_segments_count_close_journal":
             set_value("segments_count_close_journal", value)
-        elif name == "segment_cleaner_segments_count_release_journal":
+        elif name == "async_cleaner_segments_count_release_journal":
             set_value("segments_count_release_journal", value)
-        elif name == "segment_cleaner_segments_count_open_ool":
+        elif name == "async_cleaner_segments_count_open_ool":
             set_value("segments_count_open_ool", value)
-        elif name == "segment_cleaner_segments_count_close_ool":
+        elif name == "async_cleaner_segments_count_close_ool":
             set_value("segments_count_close_ool", value)
-        elif name == "segment_cleaner_segments_count_release_ool":
+        elif name == "async_cleaner_segments_count_release_ool":
             set_value("segments_count_release_ool", value)
-        elif name == "segment_cleaner_projected_count":
+        elif name == "async_cleaner_projected_count":
             set_value("projected_count", value)
-        elif name == "segment_cleaner_io_count":
+        elif name == "async_cleaner_io_count":
             set_value("io_count", value)
-        elif name == "segment_cleaner_io_blocked_count":
+        elif name == "async_cleaner_io_blocked_count":
             set_value("io_blocked_count", value)
-        elif name == "segment_cleaner_io_blocked_count_trim":
+        elif name == "async_cleaner_io_blocked_count_trim":
             set_value("io_blocked_count_trim", value)
-        elif name == "segment_cleaner_io_blocked_count_reclaim":
+        elif name == "async_cleaner_io_blocked_count_reclaim":
             set_value("io_blocked_count_reclaim", value)
-        elif name == "segment_cleaner_io_blocked_sum":
+        elif name == "async_cleaner_io_blocked_sum":
             set_value("io_blocked_sum", value)
         elif name == "cache_version_count_dirty":
             set_value("version_count_dirty", value)
@@ -581,9 +581,9 @@ def parse_metric_file(metric_file):
         # ratio
         elif name == "reactor_utilization":
             set_value("reactor_util", value/100)
-        elif name == "segment_cleaner_available_ratio":
+        elif name == "async_cleaner_available_ratio":
             set_value("unavailiable_total", 1 - value)
-        elif name == "segment_cleaner_reclaim_ratio":
+        elif name == "async_cleaner_reclaim_ratio":
             set_value("alive_unavailable", 1 - value)
 
         # time
@@ -609,7 +609,7 @@ def parse_metric_file(metric_file):
             set_value("journal_io_depth_num", value, [labels["submitter"]])
 
         # util -> count
-        elif name == "segment_cleaner_segment_utilization_distribution":
+        elif name == "async_cleaner_segment_utilization_distribution":
             set_value("segment_util_distribution", value)
 
         # srcs -> count


### PR DESCRIPTION
Due to https://github.com/ceph/ceph/pull/46885