### PR TITLE
monitoring: Add a parameter for the perf command

### DIFF
--- a/monitoring.py
+++ b/monitoring.py
@@ -55,6 +55,7 @@ class PerfMonitoring(Monitoring):
         self.pid_dir = settings.cluster.get('pid_dir')
         self.pid_glob = mconfig.get('pid_glob', 'osd.*.pid')
         self.user = settings.cluster.get('user')
+        self.perf_cmd = mconfig.get('perf_cmd', 'sudo perf')
         self.args_template = mconfig.get('args')
         self.perf_runners = []
         self.perf_dir = ''  # we need the output file to extract data
@@ -64,7 +65,7 @@ class PerfMonitoring(Monitoring):
         self.perf_dir = perf_dir
         common.pdsh(self.nodes, 'mkdir -p -m0755 -- %s' % perf_dir).communicate()
 
-        perf_template = 'sudo perf {} &'.format(self.args_template)
+        perf_template = '{} {} &'.format(self.perf_cmd, self.args_template)
         local_node = common.get_localnode(self.nodes)
         if local_node:
             logger.debug("PerfMonitoring: in local_node");


### PR DESCRIPTION
When using perf stat during cbt execution from teuthology, the subprocess may not terminate correctly when os.killpg is used. This issue occurs because sudo is used, and teuthology does not have sudo privileges to run cbt.

To address this problem, we will add a new parameter called perf_cbt. This parameter will enable users to modify the perf command and remove the sudo requirement. Additionally, we will set the default perf command to use sudo.