### PR TITLE
cbt: fix prefill skips

### DIFF
--- a/cbt.py
+++ b/cbt.py
@@ -74,7 +74,7 @@ def main(argv):
         for iteration in range(settings.cluster.get("iterations", 0)):
             benchmarks = benchmarkfactory.get_all(archive_dir, cluster, iteration)
             for b in benchmarks:
-                if b.exists():
+                if b.exists() and not settings.cluster.get('is_teuthology', False):
                     continue
 
                 if rebuild_every_test:


### PR DESCRIPTION
after commit 43b553579f6c36b63027b31c7dbb6d0de7e46bed merge that handle prefill we are checking if folder exist after initialize and it will cause the run to skip the test.
i Added also check to do the test in case it is teuthology run, we will skip all the test since we are using exist cluster.