### PR TITLE
tools/crimson: misc improvements and fixes on task control

### DIFF
--- a/tools/crimson/crimson_bench_tool.py
+++ b/tools/crimson/crimson_bench_tool.py
@@ -790,7 +790,7 @@ class TesterExecutor():
         tester_failure_log_path = f"{env.failure_osd_log}/"\
             f"{tester_id}_{retry_count}/"
         os.makedirs(tester_failure_log_path)
-        os.system(f"mv out/osd.* {tester_failure_log_path}")
+        os.system(f"mv out/* {tester_failure_log_path}")
         os.system(f"rm -rf {env.tester_log_path}")
 
         env.general_post_processing()

--- a/tools/crimson/crimson_bench_tool.py
+++ b/tools/crimson/crimson_bench_tool.py
@@ -40,7 +40,17 @@ class Task(threading.Thread):
 
     # don't need to rewite this method
     def run(self):
-        time.sleep(self.start_time)
+        wait_time = 0
+        fail = self.env.check_failure()
+        while not fail:
+            time.sleep(1)
+            wait_time += 1
+            if wait_time >= self.start_time:
+                break
+            fail = self.env.check_failure()
+        if fail:
+            return
+
         command = self.create_command()
         print(command)
 


### PR DESCRIPTION
remove all sudos
move reset_task_done() to a more appropriate position
fix pre write will not reset_task_done()
fix timepoint case will not check tester failed when waitting
fix fio(abnormal exit) not been killed in general preprocess
avoid non client task to set_task_done()