### PR TITLE
tools/crimson: functions updates and fixes on tool

### DIFF
--- a/tools/crimson/README.rst
+++ b/tools/crimson/README.rst
@@ -200,6 +200,10 @@ the structure of it will be like:
   autobench.20240111.113706/ # one auto bench root directory
   --config.yaml # config file will be copied automatically into this dir
   --failure_log.txt # record all failed tests (exceed retry limits of crimson_bench_tool)
+  --failure_osd_log # store all osd logs when test failed
+  ---0.client-8_thread-128_smp-1_1 # 1 means the first tryment(but failed) of test 0
+  ----osd.0.log
+    ...
   --sys_info.txt # commit, disk, cpu, mem, etc.
   --rep-0 # repeat 0
       # result log from crimson_bench_tool, using the first group of config
@@ -229,8 +233,7 @@ from random test log directory in autobench results directory.
 
 If you want to merge multiple tests' results from one auto bench results, you can use
 --comp, set the index of test you want to merge. e.g. --comp 1,2 means merge the 
-first and second tests into one graphics for comparison. (But the --x target config in 
-config file must be the same when using --comp.)
+first and second tests into one graphics for comparison.
 
 If you want to merge multiple tests' results from multiple auto bench results, you can 
 use param like this: --ana autobench.root1 autobench.root2 --comp 2 1,2 which means 

--- a/tools/crimson/README.rst
+++ b/tools/crimson/README.rst
@@ -201,17 +201,17 @@ the structure of it will be like:
   --config.yaml # config file will be copied automatically into this dir
   --failure_log.txt # record all failed tests (exceed retry limits of crimson_bench_tool)
   --sys_info.txt # commit, disk, cpu, mem, etc.
-  --rep:0 # repeat 0
+  --rep-0 # repeat 0
       # result log from crimson_bench_tool, using the first group of config
       # in config yaml
-  ----test:0_classic_bluestore_osd:1_ps:1
-  ------0.client{8}_thread{128}_smp{1} # first case in first test
+  ----test-0_classic_bluestore_osd-1_ps-1
+  ------0.client-8_thread-128_smp-1 # first case in first test
   --------0.RadosRandWriteThread.0.01
   --------osd.0.log
   --------proc.txt # all osd threads running during the bench
-  ----test:1_crimson_bluestore_osd:1_ps:1
+  ----test-1_crimson_bluestore_osd-1_ps-1
       ...
-  --rep:1
+  --rep-1
     ...
 
 --ana will organize data and draw graphics using these results from auto 

--- a/tools/crimson/README.rst
+++ b/tools/crimson/README.rst
@@ -173,13 +173,13 @@ config yaml file be like:
   rand_write: 1
   client: 1 1
   block_size: 4K
-  smp: 1 2
+  osd_cores: 1 2
   ---
   alias: eg.test.2
   rand_write: 1
   client: 8 8
   block_size: 4K
-  smp: 1 2
+  osd_cores: 1 2
 
 All label in yaml file should be crimson_bench_tool's input param(- changed to be _,
 and delete --)
@@ -201,7 +201,7 @@ the structure of it will be like:
   --config.yaml # config file will be copied automatically into this dir
   --failure_log.txt # record all failed tests (exceed retry limits of crimson_bench_tool)
   --failure_osd_log # store all osd logs when test failed
-  ---0.client-8_thread-128_smp-1_1 # 1 means the first tryment(but failed) of test 0
+  ---0.client-8_thread-128_osd_cores-1_1 # 1 means the first tryment(but failed) of test 0
   ----osd.0.log
     ...
   --sys_info.txt # commit, disk, cpu, mem, etc.
@@ -209,7 +209,7 @@ the structure of it will be like:
       # result log from crimson_bench_tool, using the first group of config
       # in config yaml
   ----test-0_classic_bluestore_osd-1_ps-1
-  ------0.client-8_thread-128_smp-1 # first case in first test
+  ------0.client-8_thread-128_osd_cores-1 # first case in first test
   --------0.RadosRandWriteThread.0.01
   --------osd.0.log
   --------proc.txt # all osd threads running during the bench
@@ -227,7 +227,7 @@ based on. By default, different tests(a test means one run of crimson bench tool
 corresponding to one group of config in yaml file) in autobench results will generate
 graphics dependently.
 
---x must be the label in config file, such as --x smp, and --y must be the output from
+--x must be the label in config file, such as --x osd_cores, and --y must be the output from
 crimson bench tool such as iops, latency. You can check it in result.csv 
 from random test log directory in autobench results directory.
 
@@ -249,20 +249,20 @@ Example:
 .. code-block:: console
 
        # will generate dir autobench.20240111.113705 and autobench.20240111.113705.graphic
-     $ ./crimson_auto_bench.py --run bench_config.yaml --x smp --y iops --repeat 2 --alias ssd
-     $ ./crimson_auto_bench.py --run bench_config.yaml --x smp --y iops --repeat 2 --comp 1,2 --alias ssd
+     $ ./crimson_auto_bench.py --run bench_config.yaml --x osd_cores --y iops --repeat 2 --alias ssd
+     $ ./crimson_auto_bench.py --run bench_config.yaml --x osd_cores --y iops --repeat 2 --comp 1,2 --alias ssd
 
        # (1) this will generate dir autobench.20240111.113705 (--bench doesn't need --x, --y, --comp, --alias,
        # you can input them when using --ana to analyse the results of --bench)
      $ ./crimson_auto_bench.py --bench bench_config.yaml --repeat 2
        # will generate dir autobench.20240111.113705.graphic
-     $ ./crimson_auto_bench.py --ana autobench.20240111.113705 --x smp --y iops latency --alias ssd
+     $ ./crimson_auto_bench.py --ana autobench.20240111.113705 --x osd_cores --y iops latency --alias ssd
        # (2) combine two tests into one graphic
-     $ ./crimson_auto_bench.py --ana autobench.20240111.113705 --x smp --y iops latency --comp 1,2 --alias ssd
+     $ ./crimson_auto_bench.py --ana autobench.20240111.113705 --x osd_cores --y iops latency --comp 1,2 --alias ssd
 
        # will generate dir autobench.20240111.113705.autobench.20240112.124205.graphic
      $ ./crimson_auto_bench.py --ana autobench.20240111.113705 autobench.20240112.124205 \
-                               --x smp --y iops --comp 1,2 1,2 --alias hdd ssd
+                               --x osd_cores --y iops --comp 1,2 1,2 --alias hdd ssd
 
 Example iops result graphic of command (1) and (2) above:
 

--- a/tools/crimson/README.rst
+++ b/tools/crimson/README.rst
@@ -158,9 +158,9 @@ This is an automatical bench tool using crimson bench tool to run, anlyase
 Use --run to run the whole process, --bench to only run tests, --ana to 
 organize data and draw graphics for exist bench results.
 
-When --bench or --run, this tool will read --config target config yaml file
-(bench_config.yaml by default) to do bench tasks. In yaml file, each group of 
-config represents a test, corresponding to run crimson bench tool once.
+When --bench or --run, this tool will read target config yaml file
+to do bench tasks. In yaml file, each group of config represents a test, 
+corresponding to run crimson bench tool once.
 
 So if there are multiple groups of config in config file, that means to run 
 crimson bench tool for multiple times using the configuration in the config 
@@ -249,12 +249,12 @@ Example:
 .. code-block:: console
 
        # will generate dir autobench.20240111.113705 and autobench.20240111.113705.graphic
-     $ ./crimson_auto_bench.py --run --x smp --y iops --repeat 2 --config bench_config.yaml --alias ssd
-     $ ./crimson_auto_bench.py --run --x smp --y iops --repeat 2 --comp 1,2 --config bench_config.yaml --alias ssd
+     $ ./crimson_auto_bench.py --run bench_config.yaml --x smp --y iops --repeat 2 --alias ssd
+     $ ./crimson_auto_bench.py --run bench_config.yaml --x smp --y iops --repeat 2 --comp 1,2 --alias ssd
 
        # (1) this will generate dir autobench.20240111.113705 (--bench doesn't need --x, --y, --comp, --alias,
        # you can input them when using --ana to analyse the results of --bench)
-     $ ./crimson_auto_bench.py --bench --repeat 2 --config bench_config.yaml
+     $ ./crimson_auto_bench.py --bench bench_config.yaml --repeat 2
        # will generate dir autobench.20240111.113705.graphic
      $ ./crimson_auto_bench.py --ana autobench.20240111.113705 --x smp --y iops latency --alias ssd
        # (2) combine two tests into one graphic

--- a/tools/crimson/bench_config.yaml
+++ b/tools/crimson/bench_config.yaml
@@ -4,7 +4,7 @@ alias: eg.0.classic
 rand_write: 1
 client: 1 2
 block_size: 4K
-smp: 1 2
+osd_cores: 1 2
 time: 5
 tolerance_time: 10
 retry_limit: 2
@@ -14,7 +14,7 @@ alias: eg.1.crimson
 rand_write: 1
 client: 1 2
 block_size: 4K
-smp: 1 2
+osd_cores: 1 2
 time: 5
 tolerance_time: 10
 retry_limit: 2

--- a/tools/crimson/crimson_auto_bench.py
+++ b/tools/crimson/crimson_auto_bench.py
@@ -155,7 +155,7 @@ def record_system_info(root, configs):
     os.system(f"lspci -vv >> {path}")
     os.system(f"echo >> {path}")
 
-# e.g. config_file='./config.yaml', x='smp', comp=[1, 2, 3]
+# e.g. config_file='./config.yaml', x='osd_cores', comp=[1, 2, 3]
 def read_config(config_file, x = None, comp = None):
     config_file_pwd = f"{config_file}"
     f = open(config_file_pwd, 'r')
@@ -506,7 +506,7 @@ if __name__ == "__main__":
                         type=str,
                         help="x axis of result graphics, the main variable in the target"\
                             " graphics to draw x-y graphics. required when --ana or --run."\
-                            " x can be smp, client, thread, osd_op_num_shards, etc. all the"\
+                            " x can be osd_cores, client, thread, osd_op_num_shards, etc. all the"\
                             " parameters in the crimson bench tool can be x.")
     parser.add_argument('--y',
                         nargs='+',

--- a/tools/crimson/crimson_auto_bench.py
+++ b/tools/crimson/crimson_auto_bench.py
@@ -620,3 +620,13 @@ if __name__ == "__main__":
             draw(m_analysed_results, m_configs, args.x, y, res_path, \
                  m_comp, args.alias, m_repnums)
 
+        # copy sys_info.txt, config.yaml to graphic result directory
+        for root_index, root in enumerate(roots):
+            config_path = f"{current_path}/{root}/config.yaml"
+            sys_info_path = f"{current_path}/{root}/sys_info.txt"
+            tgt_config_path = f'{root_index}.config.yaml' if len(roots) != 1 else 'config.yaml'
+            tgt_sys_info_path = f'{root_index}.sys_info.txt' if len(roots) != 1 else 'sys_info.txt'
+            tgt_config_path = f'{current_path}/{res_path}/{tgt_config_path}'
+            tgt_sys_info_path = f'{current_path}/{res_path}/{tgt_sys_info_path}'
+            os.system(f'cp {config_path} {tgt_config_path}')
+            os.system(f'cp {sys_info_path} {tgt_sys_info_path}')

--- a/tools/crimson/crimson_auto_bench.py
+++ b/tools/crimson/crimson_auto_bench.py
@@ -301,7 +301,7 @@ def adjust_results(results, y):
         all_test_res.append(test_res)
     return all_test_res
 
-def draw(m_analysed_results, m_configs, x, y, res_path, m_comp, alias):
+def draw(m_analysed_results, m_configs, x, y, res_path, m_comp, alias, m_repnums):
     res_path = f'{current_path}/{res_path}'
     delete_and_create_at(res_path)
     for auto_bench_id, analysed_results in enumerate(m_analysed_results):
@@ -319,6 +319,9 @@ def draw(m_analysed_results, m_configs, x, y, res_path, m_comp, alias):
             comp = m_comp[auto_bench_id]
         color_set = ['b', 'g', 'r', 'c', 'm', 'y', 'k']
         color_set_p = 0
+        repnum_title = f'repeat:{m_repnums[0]}'
+        for rep_id in range(1, len(m_repnums)):
+            repnum_title += f',{m_repnums[rep_id]}'
         for test_id, test in enumerate(analysed_results):
             if test == []:
                 print(f'test {test_id} failed')
@@ -345,7 +348,7 @@ def draw(m_analysed_results, m_configs, x, y, res_path, m_comp, alias):
                 for y_content in y_data[x_id]:
                     df.loc[len(df.index)] = {f'{x}': x_content, f'{y}' : y_content}
 
-            plt.title(f"{x}-{y}".lower())
+            plt.title(f"{x}-{y} ({repnum_title})".lower())
             plt.xlabel(f"{x}")
             plt.ylabel(f"{y}")
             color = color_set[color_set_p]
@@ -501,6 +504,7 @@ if __name__ == "__main__":
                             " bench results")
         m_configs = list()
         m_results = list()
+        m_repnums = list()
         # comp process example: ["1,2,3", "1,2,3"] -> [[1,2,3],[1,2,3]]
         # structure like this is for the needs of cross bench results analyse.
         m_comp = None
@@ -522,6 +526,9 @@ if __name__ == "__main__":
             res_path += f"{root}."
             m_configs.append(configs)
             m_results.append(results)
+            # skip config.yaml, failure_log.txt, sys_info.txt
+            repeat_num = len(os.listdir(root)) - 3
+            m_repnums.append(repeat_num)
 
         # the path of graphic result will be the same as the bench result
         res_path += f"{res_path_suffix}"
@@ -534,5 +541,5 @@ if __name__ == "__main__":
                 analysed_results = adjust_results(results, y)
                 m_analysed_results.append(analysed_results)
             draw(m_analysed_results, m_configs, args.x, y, res_path, \
-                 m_comp, args.alias)
+                 m_comp, args.alias, m_repnums)
 

--- a/tools/crimson/crimson_auto_bench.py
+++ b/tools/crimson/crimson_auto_bench.py
@@ -406,6 +406,8 @@ def draw(m_analysed_results, m_configs, x, y, res_path, m_comp, alias, m_repnums
                     marker='o', label=f'{output_auto_bench_name}{test_alias}', color=color)
             plt.plot(x_data, y_data_mean, linestyle='-', \
                      label=f'{output_auto_bench_name}{test_alias} mean', color=color)
+            if start_from_zero:
+                plt.ylim(ymin=0)
             plt.grid(True, color='gray', linestyle='--')
             plt.legend(loc=2)
             plt.rc('legend', fontsize='x-small')
@@ -497,12 +499,18 @@ if __name__ == "__main__":
                         type=str,
                         default=["IOPS"],
                         help="the label name of y asix of the result graphics, IOPS by default")
+    parser.add_argument('--no-start-from-zero',
+                        action='store_true',
+                        help="y axis will not start from zero")
 
     args = parser.parse_args()
     res_path_suffix = 'graphic'
     no_disk_test = False
+    start_from_zero = True
     if args.no_disk_test:
         no_disk_test = True
+    if args.no_start_from_zero:
+        start_from_zero = False
     tool_path = (os.path.dirname(os.path.realpath(__file__)))
     current_path = os.getcwd()
 

--- a/tools/crimson/crimson_bench_tool.py
+++ b/tools/crimson/crimson_bench_tool.py
@@ -762,8 +762,8 @@ class TesterExecutor():
             for thread_num in env.args.thread:
                 env.smp_num = env.smp_list[client_index]
                 env.thread_num = thread_num
-                tester_id = f"{tester_count}.client{{{env.client_num}}}_thread" \
-                    f"{{{env.thread_num}}}_smp{{{env.smp_num}}}"
+                tester_id = f"{tester_count}.client-{env.client_num}_thread" \
+                    f"-{env.thread_num}_smp-{env.smp_num}"
 
                 retry_count = 0
                 test_case_result = dict()
@@ -927,7 +927,7 @@ class Environment():
         else:
             self.log += "_classic"
         self.log += f"_{self.args.store}"
-        self.log += f"_osd:{self.args.osd}_ps:{self.pool_size}"
+        self.log += f"_osd-{self.args.osd}_ps-{self.pool_size}"
 
     def init_thread_list(self):
         # 1. add the test case based thread classes and the ratio to the dict.
@@ -1576,7 +1576,7 @@ if __name__ == "__main__":
                     This tool will add _crimson/classic_backend_osd_poolsize to be log \
                     dir name and store all tasks results and osd log and osd stdout.\
                     e.g. By default, log directory might be named log_20231222.165125\
-                    _crimson_bluestore_osd:1_ps:1')
+                    _crimson_bluestore_osd-1_ps-1')
     parser.add_argument('--full-result',
                         action='store_true',
                         help='output full results, including ceph config etc.')

--- a/tools/crimson/crimson_bench_tool.py
+++ b/tools/crimson/crimson_bench_tool.py
@@ -74,6 +74,7 @@ class Task(threading.Thread):
                 self.env.set_task_done()
         if fail:
             self.env.exec(f"kill -9 {proc.pid}")
+            os.system(f"wait {proc.pid}")
 
     # rewrite method analyse() to analyse the output from executing the
     # command and return a result dict as format {param : result}
@@ -1000,8 +1001,11 @@ class Environment():
             self.timecontinuous_threadclass_list.append(IOStatThread)
 
     def general_pre_processing(self, tester_id):
+        # killall
+        os.system("killall -9 -w rados fio ceph")
         os.system("killall -9 -w ceph-mon ceph-mgr ceph-osd "\
-                "crimson-osd rados fio node ceph ceph-run")
+                "crimson-osd")
+        os.system("killall -9 -w ceph-run")
         os.system("rm -rf ./dev/* ./out/*")
 
         # prepare test group directory
@@ -1222,8 +1226,14 @@ class Environment():
 
     def general_post_processing(self):
         # killall
+        os.system("killall -9 -w rados fio ceph")
+        stop_cmd = "../src/stop.sh"
+        if self.args.crimson:
+            stop_cmd += " --crimson"
+        os.system(stop_cmd)
         os.system("killall -9 -w ceph-mon ceph-mgr ceph-osd "\
-                "crimson-osd rados fio node ceph ceph-run")
+                "crimson-osd")
+        os.system("killall -9 -w ceph-run")
         # delete dev
         os.system("rm -rf ./dev/* ./out/*")
         self.pid = list()

--- a/tools/crimson/crimson_bench_tool.py
+++ b/tools/crimson/crimson_bench_tool.py
@@ -699,7 +699,7 @@ class Tester():
         self.detector.join()
 
         if self.env.check_failure():
-            raise TestFailError("Tester Failed", self.env)
+            raise TestFailError('(Test Failed)', self.env)
 
         test_case_result = dict()
 
@@ -772,6 +772,8 @@ class TesterExecutor():
                     if retry_count > env.args.retry_limit:
                         os.system(f"touch {env.log}/__failed__")
                         raise Exception(f"Test Failed: Maximum retry limit exceeded.")
+                    if retry_count != 0:
+                        print(f"will retry...start the {retry_count}th tryment.")
                     try:
                         env.before_run_case(tester_id)
                         tester = Tester(env, tester_id)
@@ -782,12 +784,9 @@ class TesterExecutor():
                             test_case_result.update(env.additional_result.copy())
                         test_case_result.update({'==========':'=============='})
                     except TestFailError:
-                        print("will retry...")
                         retry_count += 1
                         test_case_result = dict()
                         self.rollback(env, tester_id, retry_count)
-                        if tester:
-                            del tester
                     else:
                         succeed = True
                 env.after_run_case(test_case_result)
@@ -1418,7 +1417,7 @@ class Environment():
             thread.join()
         detector.join()
         if self.check_failure():
-            raise TestFailError("Warmup Failed", self)
+            raise TestFailError("(Warmup Failed)", self)
         print('fio pre write OK.')
         env.reset_task_done()
 
@@ -1462,7 +1461,7 @@ class Environment():
             thread.join()
         detector.join()
         if self.check_failure():
-            raise TestFailError("Warmup Failed", self)
+            raise TestFailError("(Warmup Failed)", self)
         print('rados pre write OK.')
         env.reset_task_done()
 

--- a/tools/crimson/fio_config.yaml
+++ b/tools/crimson/fio_config.yaml
@@ -2,7 +2,7 @@ alias: eg.0.classic
 fio_rbd_rand_write: 1
 client: 1 1
 block_size: 4K
-smp: 1 2
+osd_cores: 1 2
 time: 5
 tolerance_time: 5
 retry_limit: 2
@@ -13,7 +13,7 @@ alias: eg.1.crimson
 fio_rbd_rand_write: 1
 client: 1 1
 block_size: 4K
-smp: 1 2
+osd_cores: 1 2
 time: 5
 tolerance_time: 5
 retry_limit: 2


### PR DESCRIPTION
1. fix path problem
2. integrate rados pre write into retry mechanism
3. optimize graphics and result analysis
4. record key cmd to cmd_log.txt
5. record crimson_bench_tool crash caused by config/unkown error
6. print retry information
7. add repeat num to graphic
8. do device basic tests before ceph tests
9. update isolate alien cores setting
10. use osd_op_num_shards = smp by default.
11. graphic: let y axis start from zero by default
12. graphic: add option --no-start-from-zero
13. config: use MGR=0
14. config: adjust --client param
15. config: adjust --run, --bench param
16. config: add --simple-result
17. config: use block_size = 4K if no input
18. add gap between each test in crimson auto bench
19. add simple alias for all param
20. adjust process killing to avoid zombie process
21. change param smp to osd_cores
22. save sys_info.txt, config.yaml to graphic result directory
23. centrally manage bench threads core usage into Task