### PR TITLE
Extend librbdfio.py with a new workloads block. Add minor fixes.

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,12 +1,12 @@
 import logging
+from abc import ABC, abstractmethod
 
-import settings
-import common
 import hashlib
 import os
 import json
 import yaml
-from abc import ABC, abstractmethod
+import settings
+import common
 
 logger = logging.getLogger('cbt')
 
@@ -22,6 +22,8 @@ class Benchmark(object):
                                         'results',
                                         '{:0>8}'.format(config.get('iteration')),
                                         'id-{}'.format(digest))
+        # This would show several dirs if run continuously
+        logger.info("Results dir: %s", self.archive_dir )
         self.run_dir = os.path.join(settings.cluster.get('tmp_dir'),
                                     '{:0>8}'.format(config.get('iteration')),
                                     self.getclass())
@@ -68,7 +70,9 @@ class Benchmark(object):
                 with open(paranoid_path) as f:
                     paranoid_level = int(f.read())
                     if paranoid_level >= 1:
-                        msg = '''Perf must be run by user with CAP_SYS_ADMIN to extract CPU related metrics. Or you could set %s to 0, which is %d now'''
+                        msg = ('''Perf must be run by user with CAP_SYS_ADMIN to extract'''
+                        '''CPU related metrics. Or you could set %s to 0,'''
+                        '''which is %d now''')
                         logger.warning('%s. %s is %d', msg, paranoid_path, paranoid_level)
                 continue
             baseline_getter = getattr(baseline_analyzer, 'get_' + alias)

--- a/benchmark/librbdfio.py
+++ b/benchmark/librbdfio.py
@@ -1,16 +1,22 @@
-import common
-import settings
-import monitoring
+"""
+    lirbdfio.py -- module to support the FIO benchmark exercising RBD.
+"""
 import os
 import time
 import logging
+import pprint
+import common
+import settings
+import monitoring
 
 from .benchmark import Benchmark
 
 logger = logging.getLogger("cbt")
 
-
 class LibrbdFio(Benchmark):
+    """
+    Class LibrbdFio
+    """
 
     def __init__(self, archive_dir, cluster, config):
         super(LibrbdFio, self).__init__(archive_dir, cluster, config)
@@ -22,6 +28,8 @@ class LibrbdFio(Benchmark):
         self.recov_test_type = config.get('recov_test_type', 'blocking')
         self.data_pool_profile = config.get('data_pool_profile', None)
         self.time = config.get('time', None)
+        # Global FIO options can be overwritten for specific workload options
+        # would be nice to have them as a separate class -- future PR
         self.time_based = bool(config.get('time_based', False))
         self.ramp = config.get('ramp', None)
         self.iodepth = config.get('iodepth', 16)
@@ -31,8 +39,8 @@ class LibrbdFio(Benchmark):
         self.rwmixread = config.get('rwmixread', 50)
         self.rwmixwrite = 100 - self.rwmixread
         self.log_avg_msec = config.get('log_avg_msec', None)
-#        self.ioengine = config.get('ioengine', 'libaio')
         self.op_size = config.get('op_size', 4194304)
+
         self.pgs = config.get('pgs', 2048)
         self.vol_size = config.get('vol_size', 65536)
         self.vol_object_size = config.get('vol_object_size', 22)
@@ -40,16 +48,32 @@ class LibrbdFio(Benchmark):
         self.procs_per_volume = config.get('procs_per_volume', 1)
         self.random_distribution = config.get('random_distribution', None)
         self.rate_iops = config.get('rate_iops', None)
-        self.fio_out_format = "json,normal"
+        self.fio_out_format = config.get('fio_out_format', 'json,normal')
         self.data_pool = None
         # use_existing_volumes needs to be true to set the pool and rbd names
-        self.use_existing_volumes = config.get('use_existing_volumes', False)
+        self.use_existing_volumes = bool(config.get('use_existing_volumes', False))
+        self.no_sudo = bool(config.get('no_sudo', False))
+        self.idle_monitor_sleep = config.get('idle_monitor_sleep', 60)
         self.pool_name = config.get("poolname", "cbt-librbdfio")
         self.recov_pool_name = config.get("recov_pool_name", "cbt-librbdfio-recov")
         self.rbdname = config.get('rbdname', '')
+        # workloads: specify a list of tests
+        self.global_fio_options = {}
+        self.workloads = config.get('workloads', {})
+        if self.workloads:
+            self.backup_global_fio_options()
+        self.prefill_vols = config.get('prefill', {'blocksize': '4M',
+                                              'numjobs': '1'})
+        self.total_procs =  (self.procs_per_volume * self.volumes_per_client *
+                             len(settings.getnodes('clients').split(',')))
+        self.base_run_dir = self.run_dir # we need this for the new workloads block
+        self.run_dir =  f'{self.base_run_dir}/'
+        if self.osd_ra is not None:
+            self.run_dir += f'osd_ra-{int(self.osd_ra):08d}/'
+        self.run_dir +=  ( f'op_size-{int(self.op_size):08d}/'
+                        f'concurrent_procs-{int(self.total_procs):03d}/'
+                        f'iodepth-{int(self.iodepth):03d}/{self.mode}' )
 
-        self.total_procs = self.procs_per_volume * self.volumes_per_client * len(settings.getnodes('clients').split(','))
-        self.run_dir = '%s/osd_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.run_dir, int(self.osd_ra), int(self.op_size), int(self.total_procs), int(self.iodepth), self.mode)
         self.out_dir = self.archive_dir
 
         self.norandommap = config.get("norandommap", False)
@@ -57,65 +81,130 @@ class LibrbdFio(Benchmark):
         # Make the file names string (repeated across volumes)
         self.names = ''
         for proc_num in range(self.procs_per_volume):
-            rbd_name = 'cbt-librbdfio-`%s`-file-%d' % (common.get_fqdn_cmd(), proc_num)
-            self.names += '--name=%s ' % rbd_name
+            rbd_name = f'cbt-librbdfio-`{common.get_fqdn_cmd()}`-file-{proc_num:d}'
+            self.names += f'--name={rbd_name} '
+
+
+    def backup_global_fio_options(self):
+        """
+        Backup/copy the FIO global options into a dictionary
+        """
+        self.global_fio_options['time_based'] = self.time_based
+        self.global_fio_options['ramp'] = self.ramp
+        self.global_fio_options['iodepth'] = self.iodepth
+        self.global_fio_options['numjobs'] = self.numjobs
+        self.global_fio_options['mode'] = self.mode
+        self.global_fio_options['end_fsync'] = self.end_fsync
+        self.global_fio_options['rwmixread'] = self.rwmixread
+        self.global_fio_options['rwmixwrite'] = self.rwmixwrite
+        self.global_fio_options['log_avg_msec'] = self.log_avg_msec
+        self.global_fio_options['op_size'] = self.op_size
+
+
+    def restore_global_fio_options(self):
+        """
+        Restore the global values that are set before each workload
+        """
+        self.ramp = self.global_fio_options['ramp']
+        self.iodepth = self.global_fio_options['iodepth']
+        self.numjobs = self.global_fio_options['numjobs']
+        self.mode = self.global_fio_options['mode']
+        self.end_fsync = self.global_fio_options['end_fsync']
+        self.rwmixread = self.global_fio_options['rwmixread']
+        self.rwmixwrite = self.global_fio_options['rwmixwrite']
+        self.log_avg_msec = self.global_fio_options['log_avg_msec']
+        self.op_size = self.global_fio_options['op_size']
+        self.time_based = self.global_fio_options['time_based']
+
 
     def exists(self):
+        """
+        Verify whether the out_dir exists
+        """
         if os.path.exists(self.out_dir):
             logger.info('Skipping existing test in %s.', self.out_dir)
             return True
         return False
 
+
     def initialize(self):
         super(LibrbdFio, self).initialize()
-
         # Clean and Create the run directory
         common.clean_remote_dir(self.run_dir)
         common.make_remote_dir(self.run_dir)
-
-        logger.info('Pausing for 60s for idle monitoring.')
-        monitoring.start("%s/idle_monitoring" % self.run_dir)
-        time.sleep(60)
+        logger.info('Pausing for %ds for idle monitoring.', self.idle_monitor_sleep)
+        monitoring.start( f"{self.run_dir}/idle_monitoring" )
+        time.sleep(self.idle_monitor_sleep)
         monitoring.stop()
-
-        common.sync_files('%s/*' % self.run_dir, self.out_dir)
-
+        common.sync_files( f'{self.run_dir}/*', self.out_dir)
         # Create the recovery image based on test type requested
         if 'recovery_test' in self.cluster.config and self.recov_test_type == 'background':
             self.mkrecovimage()
+        if self.workloads:
+            logger.info(" %d Workloads:\n    %s", len(self.workloads.keys()),
+                        pprint.pformat(self.workloads).replace("\n", "\n    "))
+        logger.info('Creating fio images...')
         self.mkimages()
-        # populate the fio files
-        ps = []
-        logger.info('Attempting to populating fio files...')
-        if (self.use_existing_volumes == False):
-            for volnum in range(self.volumes_per_client):
-                rbd_name = 'cbt-librbdfio-`%s`-%d' % (common.get_fqdn_cmd(), volnum)
-                pre_cmd = 'sudo %s --ioengine=rbd --clientname=admin --pool=%s --rbdname=%s --invalidate=0  --rw=write --numjobs=%s --bs=4M --size %dM %s --output-format=%s > /dev/null' % (self.cmd_path, self.pool_name, rbd_name, self.numjobs, self.vol_size, self.names, self.fio_out_format)
-                p = common.pdsh(settings.getnodes('clients'), pre_cmd)
-                ps.append(p)
-            for p in ps:
-                p.wait()
+        logger.info('Attempting to prefill fio images...')
+        self.prefill()
+
+
+    def run_workloads(self):
+        """
+        Main loop for executing workloads
+        """
+        for wk in self.workloads:
+            ps = []
+            # aggregate/overwrite the global options
+            test = dict(self.global_fio_options, **self.workloads[wk])
+            enable_monitor = True
+            logger.info('Running rbd fio %s test, mode %s', wk, test['mode'])
+            if 'monitor' in test:
+                enable_monitor = bool(test['monitor'])
+            for job in test['numjobs']:
+                for iod in test['iodepth']:
+                    self.mode = test['mode']
+                    if 'op_size' in test:
+                        self.op_size = test['op_size']
+                    self.mode = test['mode']
+                    self.numjobs = job
+                    self.iodepth = iod
+                    self.run_dir =  ( f'{self.base_run_dir}/{self.mode}_{int(self.op_size)}/'
+                                     f'iodepth-{int(self.iodepth):03d}/numjobs-{int(self.numjobs):03d}' )
+                    common.make_remote_dir(self.run_dir)
+
+                    for i in range(self.volumes_per_client):
+                        fio_cmd = self.mkfiocmd(i)
+                        p = common.pdsh(settings.getnodes('clients'), fio_cmd)
+                        ps.append(p)
+                    if enable_monitor:
+                        time.sleep(self.ramp) # ramp up time before measuring
+                        monitoring.start(self.run_dir)
+                    for p in ps:
+                        p.wait()
+                    if enable_monitor:
+                        monitoring.stop(self.run_dir)
+                    self.restore_global_fio_options()
+
+        logger.info('== Workloads completed ==')
+
 
     def run(self):
         super(LibrbdFio, self).run()
-
         # We'll always drop caches for rados bench
         self.dropcaches()
-
         # Create the run directory
         common.make_remote_dir(self.run_dir)
-
         # dump the cluster config
         self.cluster.dump_config(self.run_dir)
-
         time.sleep(5)
-
         # If the pg autoscaler kicks in before starting the test,
         # wait for it to complete. Otherwise, results may be skewed.
-        ret = self.cluster.check_pg_autoscaler(self.wait_pgautoscaler_timeout, "%s/pgautoscaler.log" % self.run_dir)
+        ret = self.cluster.check_pg_autoscaler(self.wait_pgautoscaler_timeout,
+                                               f"{self.run_dir}/pgautoscaler.log")
         if ret == 1:
-            logger.warn("PG autoscaler taking longer to complete. Continuing anyway...results may be skewed.")
-
+            logger.warn("PG autoscaler taking longer to complete."
+                        "Continuing anyway...results may be skewed.")
         # Start the recovery thread if requested
         if 'recovery_test' in self.cluster.config:
             if self.recov_test_type == 'blocking':
@@ -128,16 +217,20 @@ class LibrbdFio(Benchmark):
             # Wait for a signal from the recovery thread to initiate client IO
             self.cluster.wait_start_io()
 
-        monitoring.start(self.run_dir)
-
-        logger.info('Running rbd fio %s test.', self.mode)
-        ps = []
-        for i in range(self.volumes_per_client):
-            fio_cmd = self.mkfiocmd(i)
-            p = common.pdsh(settings.getnodes('clients'), fio_cmd)
-            ps.append(p)
-        for p in ps:
-            p.wait()
+        if len(self.workloads) > 0:
+            # New style: execute the list of workloads
+            self.run_workloads()
+        else:
+            # Original style
+            monitoring.start(self.run_dir)
+            logger.info('Running rbd fio %s test.', self.mode)
+            ps = []
+            for i in range(self.volumes_per_client):
+                fio_cmd = self.mkfiocmd(i)
+                p = common.pdsh(settings.getnodes('clients'), fio_cmd)
+                ps.append(p)
+            for p in ps:
+                p.wait()
         # If we were doing recovery, wait until it's done.
         if 'recovery_test' in self.cluster.config:
             self.cluster.wait_recovery_done()
@@ -146,24 +239,31 @@ class LibrbdFio(Benchmark):
 
         # Finally, get the historic ops
         self.cluster.dump_historic_ops(self.run_dir)
-        common.sync_files('%s/*' % self.run_dir, self.out_dir)
+        common.sync_files(f'{self.run_dir}/*', self.out_dir)
         self.analyze(self.out_dir)
 
+
     def mkfiocmd(self, volnum):
+        """
+        Construct a FIO cmd (note the shell interpolation for the host
+        executing FIO).
+        """
         if self.use_existing_volumes and len(self.rbdname):
             rbdname = self.rbdname
         else:
-            rbdname = 'cbt-librbdfio-`%s`-%d' % (common.get_fqdn_cmd(), volnum)
+            rbdname = f'cbt-librbdfio-`{common.get_fqdn_cmd()}`-{volnum:d}'
 
         logger.debug('Using rbdname %s', rbdname)
-        out_file = '%s/output.%d' % (self.run_dir, volnum)
+        out_file = f'{self.run_dir}/output.{volnum:d}'
 
-        fio_cmd = 'sudo %s --ioengine=rbd --clientname=admin --pool=%s --rbdname=%s --invalidate=0' % (self.cmd_path_full, self.pool_name, rbdname)
+        fio_cmd = ''
+        if not self.no_sudo:
+            fio_cmd = 'sudo '
+        fio_cmd += '%s --ioengine=rbd --clientname=admin --pool=%s --rbdname=%s --invalidate=0' % (self.cmd_path, self.pool_name, rbdname)
         fio_cmd += ' --rw=%s' % self.mode
         fio_cmd += ' --output-format=%s' % self.fio_out_format
         if (self.mode == 'readwrite' or self.mode == 'randrw'):
             fio_cmd += ' --rwmixread=%s --rwmixwrite=%s' % (self.rwmixread, self.rwmixwrite)
-#        fio_cmd += ' --ioengine=%s' % self.ioengine
         if self.time is not None:
             fio_cmd += ' --runtime=%d' % self.time
         if self.time_based is True:
@@ -198,21 +298,31 @@ class LibrbdFio(Benchmark):
         fio_cmd += ' %s > %s' % (self.names, out_file)
         return fio_cmd
 
+
     def mkrecovimage(self):
+        """
+        Create a reecovery image
+        """
         logger.info('Creating recovery image...')
-        monitoring.start("%s/recovery_pool_monitoring" % self.run_dir)
-        if (self.use_existing_volumes == False):
-          self.cluster.rmpool(self.recov_pool_name, self.recov_pool_profile)
-          self.cluster.mkpool(self.recov_pool_name, self.recov_pool_profile, 'rbd')
-          for node in common.get_fqdn_list('clients'):
-              for volnum in range(0, self.volumes_per_client):
-                  node = node.rpartition("@")[2]
-                  self.cluster.mkimage('cbt-librbdfio-recov-%s-%d' % (node,volnum), self.vol_size, self.recov_pool_name, self.data_pool, self.vol_object_size)
+        monitoring.start( f"{self.run_dir}/recovery_pool_monitoring" )
+        if self.use_existing_volumes is False:
+            self.cluster.rmpool(self.recov_pool_name, self.recov_pool_profile)
+            self.cluster.mkpool(self.recov_pool_name, self.recov_pool_profile, 'rbd')
+            for node in common.get_fqdn_list('clients'):
+                for volnum in range(0, self.volumes_per_client):
+                    node = node.rpartition("@")[2]
+                    self.cluster.mkimage( f'cbt-librbdfio-recov-{node}-{volnum:d}',
+                                         self.vol_size, self.recov_pool_name, self.data_pool,
+                                         self.vol_object_size )
         monitoring.stop()
 
+
     def mkimages(self):
-        monitoring.start("%s/pool_monitoring" % self.run_dir)
-        if (self.use_existing_volumes == False):
+        """
+        Create an RBD pool and a number of volumes per client
+        """
+        monitoring.start( f"{self.run_dir}/pool_monitoring" )
+        if self.use_existing_volumes is False:
             self.cluster.rmpool(self.pool_name, self.pool_profile)
             self.cluster.mkpool(self.pool_name, self.pool_profile, 'rbd')
             if self.data_pool_profile:
@@ -222,22 +332,57 @@ class LibrbdFio(Benchmark):
         for node in common.get_fqdn_list('clients'):
             for volnum in range(0, self.volumes_per_client):
                 node = node.rpartition("@")[2]
-                self.cluster.mkimage('cbt-librbdfio-%s-%d' % (node,volnum), self.vol_size, self.pool_name, self.data_pool, self.vol_object_size)
+                self.cluster.mkimage( f'cbt-librbdfio-{node}-{volnum:d}',
+                                     self.vol_size, self.pool_name, self.data_pool,
+                                     self.vol_object_size)
         monitoring.stop()
+
+
+    def prefill(self):
+        """
+        Execute a FIO cmd to prefill the volumes
+        """
+        ps = []
+        if not self.use_existing_volumes:
+            for volnum in range(self.volumes_per_client):
+                rbd_name = f'cbt-librbdfio-`{common.get_fqdn_cmd()}`-{volnum:d}'
+                pre_cmd = ''
+                if not self.no_sudo:
+                    pre_cmd += 'sudo '
+                numjobs = self.prefill_vols['numjobs']
+                bs = self.prefill_vols['blocksize']
+                pre_cmd += ( f'{self.cmd_path} --ioengine=rbd --clientname=admin'
+                            f' --pool={self.pool_name}'
+                            f' --rbdname={rbd_name} --invalidate=0  --rw=write'
+                            f' --numjobs={numjobs}'
+                            f' --bs={bs}'
+                            f' --size {self.vol_size:d}M {self.names}'
+                            f' --output-format={self.fio_out_format} > /dev/null' )
+                p = common.pdsh(settings.getnodes('clients'), pre_cmd)
+                ps.append(p)
+            for p in ps:
+                p.wait()
+
 
     def recovery_callback_blocking(self):
         common.pdsh(settings.getnodes('clients'), 'sudo killall -2 fio').communicate()
 
+
     def recovery_callback_background(self):
         logger.info('Recovery thread completed!')
 
+
     def parse(self, out_dir):
+        """
+        Filters the JSON output from the mix output and writes it to a
+        separate file.
+        """
         for client in settings.getnodes('clients').split(','):
             host = settings.host_info(client)["host"]
             for i in range(self.volumes_per_client):
                 found = 0
-                out_file = '%s/output.%d.%s' % (out_dir, i, host)
-                json_out_file = '%s/json_output.%d.%s' % (out_dir, i, host)
+                out_file = f'{out_dir}/output.{i:d}.{host}'
+                json_out_file = f'{out_dir}/json_output.{i:d}.{host}'
                 with open(out_file) as fd:
                     with open(json_out_file, 'w') as json_fd:
                         for line in fd.readlines():
@@ -250,9 +395,11 @@ class LibrbdFio(Benchmark):
                                 if "Starting" in line:
                                     found = 1
 
+
     def analyze(self, out_dir):
         logger.info('Convert results to json format.')
         self.parse(out_dir)
+
 
     def __str__(self):
         return "%s\n%s\n%s" % (self.run_dir, self.out_dir, super(LibrbdFio, self).__str__())

--- a/common.py
+++ b/common.py
@@ -114,7 +114,7 @@ def get_localnode(nodes):
 
     # if more than one node is listed, fallback to pdsh
     nodes_list = expanded_node_list(nodes)
-    if len(nodes_list) > 1:
+    if len(nodes_list) < 1:
         return None
 
     local_fqdn = get_fqdn_local()
@@ -122,7 +122,9 @@ def get_localnode(nodes):
     local_short_hostname = local_hostname.split('.')[0]
 
     remote_host = settings.host_info(nodes_list[0])['host']
-    if remote_host in (local_fqdn, local_hostname, local_short_hostname):
+    #logger.debug('remote_host=%s, local_fqdn=%s local_hostname=%s local_short_hostname=%s'
+    #                 % (remote_host, str(local_fqdn), str(local_hostname), str(local_short_hostname) ))
+    if remote_host in ('localhost', local_fqdn, local_hostname, local_short_hostname):
         return remote_host
     return None
 
@@ -131,7 +133,7 @@ def sh(local_node, command, continue_if_error=True):
     return CheckedPopenLocal(local_node, join_nostr(command),
                              continue_if_error=continue_if_error, shell=True)
 
-
+# Follow-up: implement recognise port option
 def pdsh(nodes, command, continue_if_error=True):
     local_node = get_localnode(nodes)
     if local_node:
@@ -142,6 +144,7 @@ def pdsh(nodes, command, continue_if_error=True):
         env = {}
         if pdsh_ssh_args:
             env = {'PDSH_SSH_ARGS':pdsh_ssh_args}
+        # -f: fan out n nodes, -R rcmd name, -w target node list
         args = [pdsh_cmd, '-f', str(len(expanded_node_list(nodes))), '-R', 'ssh', '-w', nodes, join_nostr(command)]
         # -S means pdsh fails if any host fails
         if not continue_if_error:
@@ -219,7 +222,7 @@ def get_fqdn_list(nodes):
 
 def get_fqdn_local():
     local_fqdn = socket.getfqdn()
-    logger.debug('get_fqdn_local()=%s' % local_fqdn)
+    #logger.debug('get_fqdn_local()=%s' % local_fqdn)
     return local_fqdn
 
 

--- a/example/rbd_fio_test.yml
+++ b/example/rbd_fio_test.yml
@@ -1,0 +1,112 @@
+cluster:
+  use_existing: True
+  osds_per_node: 1
+  user: 'root'
+  head: "sv1-ceph3.ssd.hursley.ibm.com"
+    #head: "ceph3"
+    #clients: [localhost]
+  clients: ["sv1-ceph3.ssd.hursley.ibm.com"]
+    #osds: ["localhost"]
+  osds: ["sv1-ceph3.ssd.hursley.ibm.com"]
+    #mons: ["localhost"]
+  iterations: 1
+  conf_file: '/ceph/build/ceph.conf'
+  ceph-osd_cmd: '/ceph/build/bin/ceph-osd'
+  ceph-mon_cmd: '/ceph/build/bin/ceph-mon'
+  ceph-run_cmd: '/ceph/build/bin/ceph-run'
+  ceph-rgw_cmd: '/ceph/build/bin/radosgw'
+  ceph-mgr_cmd: '/ceph/build/bin/ceph-mgr'
+  ceph-mds_cmd: '/ceph/build/bin/ceph-mds'
+  ceph-authtool_cmd: '/ceph/build/bin/ceph-authtool'
+  radosgw-admin_cmd: '/ceph/build/bin/radosgw-admin'
+  ceph_cmd: '/ceph/build/bin/ceph'
+  ceph-fuse_cmd: '/ceph/build/bin/ceph-fuse'
+  rados_cmd: '/ceph/build/bin/rados'
+  rbd_cmd: '/ceph/build/bin/rbd'
+  rbd-nbd_cmd: '/ceph/build/bin/rbd-nbd_cmd'
+  rbd-fuse_cmd: '/ceph/build/bin/rbd-fuse_cmd'
+  tmp_dir: "/tmp/cbt"
+  pid_dir: "/ceph/build/out/"
+  pdsh_ssh_args: "-a -p 8023 -x -l%u %h"
+  pool_profiles:
+    rbd:
+      pg_size: 256
+      pgp_size: 256
+        #replication: 1
+monitoring_profiles:
+# These monitor only the OSD node/process
+  collectl:
+    # These options indicate:
+    # collect 30 samples, summary mem and CPU util, each 5 secs for CPU samples, 10 sec for all other,
+    # process options: threads utilisation
+    # filter samples for CPUs 0 to 3 (e.g. Crimson IO reactor cores),
+    # filter samples for process osd (redundant),
+    # produce gnuplot file data format (aka csv) in output file (gziped)
+    #
+    args: '-c 30 -sZC -i 5:10 --procopts t --cpufilt 0-3 --procfilt cosd -P -f {collectl_dir}'
+  perf:
+    perf_cmd: 'perf'
+    # This collects 10 secs of data to produce flame graphs
+    args: 'record -e cycles:u --call-graph dwarf -i -p {pid} -o {perf_dir}/{pid}_osd_perf.out sleep 10'
+  top:
+    top_cmd: 'top'
+      # This collects 30 samples, Core and thread CPU utilisation
+    args: '-b -H -1 -p {pid} -n 30 > {top_dir}/{pid}_osd_top.out'
+benchmarks:
+  librbdfio:
+    cmd_path: '/usr/local/bin/fio'
+    # ToDo: consider a subdict that defines the global FIO options
+    # but we need to ensure backwards compatibility with existing .yaml
+    wait_pgautoscaler_timeout: 2 # in secs
+    use_existing_volumes: False
+    no_sudo: True
+    ## Global FIO options
+    pool_profile: 'rbd'
+    vol_size: 1024  # Volume size in Megabytes
+      #vol_name: 'fio_test_%d' # TBC. valid python format string
+      #rbdname: 'fio_test_%d'
+    idle_monitor_sleep: 5 # in seconds
+    fio_out_format: 'json'
+    iterations: 3
+    time: 300 # length of run
+    ramp: 30 # ramp up time
+    log_avg_msec: 100
+    log_iops: True
+    log_bw:  True
+    log_lat: True
+    poolname: 'rbd'
+    mode: 'randwrite'
+    iodepth: [1, 4 ,16]
+    numjobs: [1, 4, 8]
+    op_size: [4096] # block IO size in bytes
+    procs_per_client: [1]
+    volumes_per_client: [1] # volumes per ceph node
+      # for tests involving specific CPU cores:
+    fio_cpu_set: '15-15'
+    # Optional FIO options for the /prefill stage
+    prefill:
+      blocksize: '4M'
+      numjobs: 1
+    # Each block below uses its own local options during its execution
+    workloads:
+      precondition:
+        jobname: 'precond1rw'
+        mode: 'randwrite'
+        numjobs: [ 1 ]
+        iodepth: [ 4 ]
+        monitor: False # whether to run the monitors along the test
+      test1:
+        jobname: 'rr'
+        mode: 'randread'
+        numjobs: [ 1]
+        iodepth: [ 1]
+          #numjobs: [ 1, 4, 8 ]
+          #iodepth: [ 1, 4, 8 ]
+        # ToDo: can we add a list of the monitoring subset we are interested for this workload?
+      test2:
+        jobname: 'rw'
+        mode: 'randwrite'
+        numjobs: [ 1 ]
+        iodepth: [ 1 ]
+          #numjobs: [ 1, 4, 8 ]
+          #iodepth: [ 1, 4, 8 ]

--- a/settings.py
+++ b/settings.py
@@ -93,10 +93,17 @@ def host_info(host):
     if '@' in host:
         user, host = host.split('@')
         ret['user'] = user
+    if ':' in host:
+        host, port = host.split(':')
+        ret['port'] = port
     if user:
         ret['user'] = user
     ret['host'] = host
-    ret['addr'] = socket.gethostbyname(host)
+    # Follow-up: add support for socket.getaddrinfo
+    try:
+        ret['addr'] = socket.gethostbyname(host)
+    except socket.gaierror as e:
+        shutdown(f'Was not able to gethostbyname: {host}')
     return ret
 
 
@@ -116,7 +123,7 @@ def getnodes(*nodelists):
                              nodelist, cur)
 
     str_nodes = ','.join(uniquenodes(nodes))
-    logger.debug("Nodes : %s", str_nodes)
+    #logger.debug("Nodes : %s", str_nodes)
     return str_nodes
 
 


### PR DESCRIPTION
This is my first PR, please be gentle in the review. We add the following new features into the CBT for the benchmark librbdfio:

-  Extend the test plan .yml with a new block section 'workloads' to allow a list of performance tests to be indicated, each with its own range of iodepth and numjobs to iterate. An example of this is provided in `example/rbd_fio_test.yml`

- Extend librbdfio.py with support for such 'workloads' block.


### New workloads block
The value of this new workloads block is to allow a finer description of a test job, for example, indicating a range for the iodepth and numjobs FIO parameters, as well as whether to monitor the execution (eg. with perf, top, or collectl). This allow the collection of measurements for computing a response curve.
Here is a snippet that describes:

- a precondition phase consisting on a random write workload, that is not being monitored, then
- a random read workload over the ranges indicated for the FIO parameters numjobs and iodepth
- a random write workload. 

 ```yaml
  workloads:
     precond1:
       jobname: 'precond1rw'
       mode: 'randwrite'
       numjobs: [ 1 ]
       iodepth: [ 8 ]
       monitor: False
     test1:
       jobname: 'rr'
       mode: 'randread'
       numjobs: [ 1, 4, 8 ]
       iodepth: [ 1, 4, 16]
     test2:
       jobname: 'rw'
       mode: 'randwrite'
       numjobs: [ 4 ]
       iodepth: [ 16 ]
```

The following snippet shows the execution of the precondition phase:
![Screenshot 2024-05-07 at 16 07 38](https://github.com/ceph/cbt/assets/23522684/b7524269-8ebd-4628-bb42-2ab0a7672b15)

The following snippet shows the execution of the tests1 and 2:
![Screenshot 2024-05-07 at 16 08 14](https://github.com/ceph/cbt/assets/23522684/32f8060e-f73b-4fd1-80c2-b5bef19da19a)

The following snippet shows the resulting files from the execution of the test:
![Screenshot 2024-05-13 at 11 56 20](https://github.com/ceph/cbt/assets/23522684/93c423d7-957a-48e4-bee8-17d5a578a824)

