### PR TITLE
Add a warning cosbench will be deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # CBT - The Ceph Benchmarking Tool
 
+Release v0.3 will be the final version of CBT that contains support for cosbench.
+There will be a PR soon that will deprecate support for cosbench. If you require
+support for cosbench please continue to use v0.3.
+
 ## INTRODUCTION
 
 CBT is a testing harness written in python that can automate a variety of tasks

--- a/benchmark/cosbench.py
+++ b/benchmark/cosbench.py
@@ -20,6 +20,8 @@ class Cosbench(Benchmark):
 
         config = self.parse_conf(config)
 
+        logger.warning("Cosbench support within CBT will be deprecated in a later PR. Please use release tag v0.3 for continued use of cosbench.")
+
         self.op_size = config["obj_size"]
         self.total_procs = config["workers"]
         self.containers = config["containers_max"]


### PR DESCRIPTION
This change adds a warning into the cosbench benchmark class to indicate that cosbench support will be deprecated in a later PR and to use the v0.3 release tag if you want to continue using cosbench with CBT.

A similar statement has been added to the README.md.