### PR TITLE
First version of the report generator. Add further tools.

### DIFF
--- a/tools/diskstat_diff.py
+++ b/tools/diskstat_diff.py
@@ -1,0 +1,213 @@
+#!/usr/bin/python
+"""
+This script expect an input .json file name as argument, and a .json stream
+from stdin, and
+calculates its difference, (producing a gnuplot .plot and dat for it)
+Might generalise later for a whole set of samples (like we do with top).
+It could also be extended to process .json from ceph conf osd tell dump_metrics.
+"""
+
+import argparse
+import logging
+import os
+import sys
+import re
+import json
+import tempfile
+
+__author__ = "Jose J Palacios-Perez"
+
+logger = logging.getLogger(__name__)
+
+
+def serialize_sets(obj):
+    """
+    Serialise sets as lists
+    """
+    if isinstance(obj, set):
+        return list(obj)
+
+    return obj
+
+
+class DiskStatEntry(object):
+    """
+    Calculate the difference between an diskstat .json file and
+    a .json stream from stdin, and
+    produce a gnuplot and .JSON of the difference
+    jc --pretty /proc/diskstats
+    {
+    "maj": 8,
+    "min": 1,
+    "device": "sda1",
+    "reads_completed": 43291,
+    "reads_merged": 34899,
+    "sectors_read": 4570338,
+    "read_time_ms": 20007,
+    "writes_completed": 6562480,
+    "writes_merged": 9555760,
+    "sectors_written": 1681486816,
+    "write_time_ms": 10427489,
+    "io_in_progress": 0,
+    "io_time_ms": 2062151,
+    "weighted_io_time_ms": 10447497,
+    "discards_completed_successfully": 0,
+    "discards_merged": 0,
+    "sectors_discarded": 0,
+    "discarding_time_ms": 0,
+    "flush_requests_completed_successfully": 0,
+    "flushing_time_ms": 0
+    }
+
+    Only interested in the following measurements:
+    "device" "reads_completed" "read_time_ms" "writes_completed" "write_time_ms"
+    """
+
+    def __init__(self, aname: str, regex: str, directory: str):
+        """
+        This class expects two input .json files
+        Calculates the difference b - a and replaces b with this
+        The result is a dict with keys the device names, values the measurements above
+        """
+        self.aname = aname
+        self.regex = re.compile(regex)  # , re.DEBUG)
+        self.time_re = re.compile(r"_time_ms$")
+        self.measurements = [
+            "reads_completed",
+            "read_time_ms",
+            "writes_completed",
+            "write_time_ms",
+        ]
+
+        self.directory = directory
+        self._diff = {}
+
+    def filter_metrics(self, ds):
+        """
+        Filter the (array of dicts) to the measurements we want, of those device names
+        """
+        result = {}
+        for item in ds:
+            dv = item["device"]
+            # Can we use list comprehension here?
+            if self.regex.search(dv):
+                if dv not in result:
+                    result.update({dv: {}})
+                for m in self.measurements:
+                    result[dv].update({m: item[m]})
+        return result
+
+    def get_diff(self, a_data, b_data):
+        """
+        Calculate the difference of b_data - a_data
+        Assigns the result to self._diff
+        """
+        for dev in b_data:
+            for m in b_data[dev]:
+                if self.time_re.search(m):
+                    _max = max([b_data[dev][m], a_data[dev][m]])
+                    b_data[dev][m] = _max
+                else:
+                    b_data[dev][m] -= a_data[dev][m]
+        self._diff = b_data
+
+    def load_json(self, json_fname):
+        """
+        Load a .json file containing diskstat metrics
+        Returns a dict with keys only those interested device names
+        """
+        try:
+            with open(json_fname, "r") as json_data:
+                ds_list = []
+                # check for empty file
+                f_info = os.fstat(json_data.fileno())
+                if f_info.st_size == 0:
+                    logger.error(f"JSON input file {json_fname} is empty")
+                    return ds_list
+                ds_list = json.load(json_data)
+                return self.filter_metrics(ds_list)
+        except IOError as e:
+            raise argparse.ArgumentTypeError(str(e))
+
+    def save_json(self):
+        """
+        Save the difference
+        """
+        if self.aname:
+            with open(self.aname, "w", encoding="utf-8") as f:
+                json.dump(
+                    self._diff, f, indent=4, sort_keys=True, default=serialize_sets
+                )
+                f.close()
+
+    def run(self):
+        """
+        Entry point: processes the input files, then produces the diff
+        and saves it back to -a
+        """
+        os.chdir(self.directory)
+        a_data = self.load_json(self.aname)
+        b_data = self.filter_metrics(json.load(sys.stdin))
+        self.get_diff(a_data, b_data)
+        self.save_json()
+
+
+def main(argv):
+    examples = """
+    Examples:
+    # Calculate the difference in diskstats between the start/end of a performance run:
+    # jc --pretty /proc/diskstats  > _start.json
+    < .. run test.. >
+    # jc --pretty /proc/diskstats | %prog -a _start.json
+
+    """
+    parser = argparse.ArgumentParser(
+        description="""This tool is used to calculate the difference in diskstat measurements""",
+        epilog=examples,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-a",
+        type=str,
+        required=True,
+        help="Input .json file",
+        default=None,
+    )
+    parser.add_argument(
+        "-r",
+        "--regex",
+        type=str,
+        required=False,
+        help="Regex to describe the device names",
+        default=r"nvme\d+n1p2",
+    )
+
+    parser.add_argument(
+        "-d", "--directory", type=str, help="Directory to examine", default="./"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="True to enable verbose logging mode",
+        default=False,
+    )
+
+    options = parser.parse_args(argv)
+
+    if options.verbose:
+        logLevel = logging.DEBUG
+    else:
+        logLevel = logging.INFO
+
+    with tempfile.NamedTemporaryFile(dir="/tmp", delete=False) as tmpfile:
+        logging.basicConfig(filename=tmpfile.name, encoding="utf-8", level=logLevel)
+
+    logger.debug(f"Got options: {options}")
+
+    dsDiff = DiskStatEntry(options.a, options.regex, options.directory)
+    dsDiff.run()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tools/fio-parse-jsons/fio-parse-jsons.py
+++ b/tools/fio-parse-jsons/fio-parse-jsons.py
@@ -6,14 +6,14 @@
 # Input parameters:
 #
 # -c <file_name>- a file name containing a list of JSONs FIO output
-#  result files, each following the naming convention:
+#  result files, each following the (workload) naming convention:
 #  <prefix>_\d+job_d+io_<suffix>
 #
 # -t <title> - a string describing the Title for the chart, eg.
 # 'Crimson 4k Random Write (Single 200GB OSD)'
 #
 # -a <file_name> - a JSON filename with the CPU average list, normally
-# produced by the parse-top.pl script.
+# produced by the parse-top.py script.
 #
 # -d <dir> - work directory
 #
@@ -34,6 +34,8 @@ import re
 import math
 import functools
 from operator import add
+
+__author__ = 'Jose J Palacios-Perez'
 
 # Predefined dictionary of metrics (query paths on the ouput FIO .json) for typical workloads
 # Keys are metric names, vallues are the string path in the .json to seek
@@ -62,7 +64,7 @@ predef_dict = {
         "usr_cpu": "usr_cpu",
         "sys_cpu": "sys_cpu",
     },
-    "seqwrite": {
+    "write": { # aka seqwrite
         "bw": "write/bw",
         "total_ios": "write/total_ios",
         "clat_ms": "write/clat_ns",
@@ -70,7 +72,7 @@ predef_dict = {
         "usr_cpu": "usr_cpu",
         "sys_cpu": "sys_cpu",
     },
-    "seqread": {
+    "read": { # seqread
         "bw": "read/bw",
         "total_ios": "read/total_ios",
         "clat_ms": "read/clat_ns",
@@ -138,7 +140,7 @@ def process_fio_item(k, next_node_list):
     json files for the same timestamp and then divide by total IOPs to get
     an average latency
     """
-    #    match k: # Python version on the SV1 node does not support 'match'
+    #    match k: # Python version on node does not support 'match'
     #    case 'iops' | 'usr_cpu' | 'sys_cpu':
     if re.search("iops|usr_cpu|sys_cpu|iodepth|total_ios", k):
         return next_node_list[0]
@@ -236,14 +238,12 @@ def get_jobs_type(job, jobname: str):
     FIO job files are follow the convention of jobtype being the
     global "rw" attribute.
     """
-    #jobname = str(job["jobname"])
     if jobname in predef_dict:
         # this gives the paths to query for the metrics
         query_dict = predef_dict[jobname]
     else:
         jobname = job["job options"]["rw"]
         query_dict = predef_dict[jobname]
-        #result_dict["jobname"] = jobname
     return query_dict 
 
 
@@ -259,7 +259,6 @@ def process_fio_json_file(json_file, json_tree_path):
         if f_info.st_size == 0:
             print(f"JSON input file {json_file} is empty")
             return result_dict
-        # parse the JSON object
         node = json.load(json_data)
         # Extract the json timestamp: useful for matching same workloads from
         # different FIO processes
@@ -292,6 +291,8 @@ def process_fio_json_file(json_file, json_tree_path):
 def traverse_files(sdir, config, json_tree_path):
     """
     Traverses the JSON files given in the config
+    Returns a dictionary whose keys are the input .json file names, values
+    are the (sub)dictionary of the metrics collected from the input .json file
     """
     os.chdir(sdir)
     try:
@@ -312,34 +313,40 @@ def traverse_files(sdir, config, json_tree_path):
     return dict_new
 
 
-def gen_plot(config, data, list_subtables, title):
+def gen_plot(config, data, list_subtables, title, header_keys ):
     """
-    Generate a gnuplot script and .dat files -- assumes OSD CPU util only
+    Generate a gnuplot script and .dat files -- for response
+    latency curves, it charts Throughput/latency against CPU util
+    of the group of processes (eg OSD, FIO)
     """
     plot_dict = {
         # Use the dict key as the suffix for the output file .png,
         # the .dat file is the same for the different charts
-        "iops_vs_lat_vs_cpu_sys": {
+        "iops_vs_lat_vs_cpu": {
             "ylabel": "Latency (ms)",
-            "ycolumn": "4",
-            "y2label": "OSD CPU system",
-            "y2column": "9",
-        },
-        "iops_vs_lat_vs_cpu_usr": {
-            "ylabel": "Latency (ms)",
-            "ycolumn": "4",
-            "y2label": "OSD CPU user",
-            "y2column": "8",
-        },
+            "ycolumn": "clat_ms",
+            "y2label": "CPU",
+            "y2column": "OSD_cpu",
+        }
     }
-    header = """
+    pg_y2column = {
+        'OSD_cpu': 8,
+        #'OSD_mem': 9,
+        'FIO_cpu': 10,	
+        #'FIO_mem': 11, 
+    }
+    # Use the header_keys to ensure we refer to the correct column number
+    for k in pg_y2column.keys():
+        pg_y2column[k]=str(header_keys[k])
+
+    header = r"""
 set terminal pngcairo size 650,420 enhanced font 'Verdana,10'
 set key box left Left noreverse title 'Iodepth'
 set datafile missing '-'
 set key outside horiz bottom center box noreverse noenhanced autotitle
 set grid
 set autoscale
-#set logscale
+set xtics border in scale 1,0.5 nomirror rotate by -45  autojustify
 # Hockey stick graph:
 set style function linespoints
 """
@@ -350,17 +357,14 @@ set style function linespoints
     # Gnuplot quirk: '_' is interpreted as a sub-index:
     _title = title.replace("_", "-")
 
-    with open(out_plot, "w") as f:
-        f.write(header)
-        for pk in plot_dict.keys():
-            out_chart = config.replace("list", pk + ".png")
-            ylabel = plot_dict[pk]["ylabel"]
-            ycol = plot_dict[pk]["ycolumn"]
-            y2label = plot_dict[pk]["y2label"]
-            y2col = plot_dict[pk]["y2column"]
-            template += f"""
+    for pk in plot_dict.keys():
+        out_chart = config.replace("list", pk + ".png")
+        ylabel = plot_dict[pk]["ylabel"]
+        ycol = str(header_keys[plot_dict[pk]["ycolumn"]])
+        y2label = plot_dict[pk]["y2label"]
+        template += f"""
 set ylabel "{ylabel}"
-set xlabel "IOPS"
+set xlabel "IOPS (thousand)"
 set y2label "{y2label}"
 set ytics nomirror
 set y2tics
@@ -370,21 +374,27 @@ set autoscale y2
 set output '{out_chart}'
 set title "{_title}"
 """
-            # To plot CPU util in the same response curve, we need the extra axis
-            # This list_subtables indicates how many sub-tables the .datfile will have
-            # The stdev is the error column:5
-            if len(list_subtables) > 0:
-                head = f"plot '{out_data}' index 0 using 2:{ycol}:5 t '{list_subtables[0]} q-depth' w yerr axes x1y1"
-                head += f",\\\n '' index 0 using 2:{ycol}:5 notitle w lp axes x1y1"
-                head += f",\\\n '' index 0 using 2:{y2col} w lp axes x1y2 t 'CPU%'"
+        # To plot CPU util in the same response curve, we need the extra axis
+        # This list_subtables indicates how many sub-tables the .datfile will have
+        # The stdev is the error column:5
+        if len(list_subtables) > 0:
+            head = f"plot '{out_data}' index 0 using ($2/1e3):{ycol}:5 t '{list_subtables[0]} q-depth' w yerr axes x1y1 lc 1"
+            head += f",\\\n '' index 0 using ($2/1e3):{ycol} notitle w lp lc 1 axes x1y1"
+            for pg,y2col  in pg_y2column.items():
+                head += f",\\\n '' index 0 using ($2/1e3):{y2col} w lp axes x1y2 t '{pg}'"
+            if len(list_subtables) > 1:
                 tail = ",\\\n".join(
                     [
-                        f"  '' index {i} using 2:{ycol} t '{list_subtables[i]} q-depth' w lp axes x1y1"
+                        f"  '' index {i} using ($2/1e3):{ycol} t '{list_subtables[i]} q-depth' w lp axes x1y1"
                         for i in range(1, len(list_subtables))
                     ]
                 )
                 template += ",\\\n".join([head, tail])
+            else:
+                template += head + "\n"
 
+    with open(out_plot, "w") as f:
+        f.write(header)
         f.write(template)
         f.close()
     with open(out_data, "w") as f:
@@ -414,10 +424,6 @@ def initial_fio_table(dict_files, multi):
                 if k not in table:
                     avg[k] = 0.0
                 avg[k] += item[k]
-    # Probably might use some other avg rather than arithmetic avg
-    # For a sinlge data point, table == avg
-    # For multiple FIO: probably want to do the same reduction as multi job
-    # For response time curves, we want to have the sequence of increasing queue depth
     for k in avg.keys():
         avg[k] /= len(table[k])
     return table, avg
@@ -454,25 +460,62 @@ def aggregate_cpu_avg(avg, table, avg_cpu):
 
 def aggregate_proc_cpu_avg(avg, table, avg_cpu, proc):
     """
-    This function assumes that the avg .JSON file contains the OSD field
+    This function assumes that the avg .JSON file contains the following fields:
+    avg$VAR1 = {
+          'FIO' => {
+                     'cpu' => {
+                                'index' => 10,
+                                'total' => '296.850333333333',
+                                'data' => [ .. ]
+                                }
+                    'mem' > { similar dict }
+                    }
+        'OSD' => { similar dict }
     """
     if len(avg_cpu):
         print(f" avg_cpu list has: {len(avg_cpu)} items")
         for cpu_item in avg_cpu:
-            for metric in cpu_item[proc]:  # 'sys', 'us' normally from the OSD
-                cpu_avg_k = 0
-                samples = cpu_item[metric]
-                for cpu in samples.keys():
-                    cpu_avg_k += samples[cpu]
-                cpu_avg_k /= len(samples.keys())
-                # Aggregate the CPU values in the avg table
-                if metric not in avg:
-                    avg[metric] = 0
-                avg[metric] += cpu_avg_k
-                # Aggregate the CPU values in the FIO table
-                if metric not in table:
-                    table[metric] = []
-                table[metric].append(cpu_avg_k)
+            if proc in cpu_item:
+                for metric in cpu_item[proc]: # 'cpu', 'mem' from the OSD
+                    # Aggregate the CPU values in the avg table
+                    mt = f"{proc}_{metric}"
+                    table[mt]= cpu_item[proc][metric]["data"]
+
+        pp = pprint.PrettyPrinter(width=41, compact=True)
+        print(f"Table (after aggregating {proc} CPU avg data):")
+        pp.pprint(table)
+
+def _aggregate_proc_cpu_avg_(avg, table, avg_cpu, proc):
+    """
+    This function is going to be deprecated soon
+    """
+    cpu_proc = {} # proc: {"mem": 0.0, "cpu": 0.0}}
+    num_entries=0
+    #metrics = []
+    if len(avg_cpu):
+        print(f" avg_cpu list has: {len(avg_cpu)} items")
+        for cpu_item in avg_cpu:
+            if proc in cpu_item:
+                if not cpu_proc:
+                    cpu_proc = cpu_item[proc]
+                else:
+                    for metric in cpu_item[proc]: # 'cpu', 'mem' from the OSD
+                        # We could detect the layout of this .json, whether is from
+                        # a Response latency or individual run
+                        cpu_proc[metric] = cpu_item[proc][metric]["data"]
+                        num_entries += 1
+
+        for metric in cpu_proc:
+            if num_entries > 1:
+                cpu_proc[metric] /= num_entries 
+            # Aggregate the CPU values in the avg table
+            mt = f"{proc}_{metric}"
+            if mt not in avg:
+                avg[mt] = cpu_proc[metric]
+            # Aggregate the CPU values in the FIO table
+            if mt not in table:
+                table[mt] = []
+            table[mt].append(avg[mt])
 
         pp = pprint.PrettyPrinter(width=41, compact=True)
         print(f"Table (after aggregating {proc} CPU avg data):")
@@ -494,24 +537,27 @@ def gen_table(dict_files, config, title, avg_cpu, multi=False):
     Each row of the table is the results from a run in a single .json
 
     The avg_cpu is a list of dict each with keys 'sys' and 'us', containing values per cpu core
+    This list of dicts now also has an entry for the process groups (eg OSD, FIO) which the
+    response curves use.
 
-    The optional multi option is used to differentiate between multiple FIO instances,
+    The optional multi option (would be deprecated) is used to differentiate between multiple FIO instances,
     which involve several .json files all from a concurrent execution (within the same timespan),
-    as opposed to a response curve run which also involve
-    several json files but within its own timespan.
+    as opposed to a response curve run which also involve several json files but within its own timespan.
 
     For a response curve over a double range (that is num_jobs and iodepth), the data for gnuplot is
-    separated into its own table, so the .dat file ends up with one table per num_job.
+    separated into its own tables, so the .dat file ends up with one table per num_job.
     """
     table, avg = initial_fio_table(dict_files, multi)
     table_iters = {}
     list_subtables = []
+    out_tex = config.replace("_list", ".tex")
     num_files = len(dict_files.keys())
     # The following produces a List of dicts, each with keys 'sys', 'us',
     # each sample with list of CPU (eg. 0-3, and 4-7)
     # Aggregate osd_cpu_us and osd_cpu_sys into the main table
-    #aggregate_cpu_avg(avg, table, avg_cpu)
-    aggregate_proc_cpu_avg(avg, table, avg_cpu, "OSD")
+    for pname in ("OSD", "FIO"):
+        aggregate_proc_cpu_avg(avg, table, avg_cpu, pname)
+    
     save_table_json(table,config.replace("_list", ".json"))
     # Note: in general the CPU measurements are global across the test time
     # for all FIO processes, so in the MultiFIO case we need to reduce the FIO measurements first
@@ -526,17 +572,32 @@ def gen_table(dict_files, config, title, avg_cpu, multi=False):
 
     wiki = (
         r"""{| class="wikitable"
-|-
-! colspan="7"  | """
+|- """ +
+        f"""
+ ! colspan=\"{len(table)}\"  | 
+        """
         + config.replace("_list", "")
         + """
-! colspan="2"  | OSD CPU%
 |-
 ! """
     )
     wiki += " !! ".join(table.keys())
     wiki += "\n|-\n"
 
+    latex = (
+         r"""
+\begin{table}[h!]
+\centering
+\begin{tabular}[t]{*{""" + f"{len(table)}" + r""" }{|c|}}
+\hline 
+"""
+    )
+    latex += " & ".join(map(lambda x: x.replace(r"_",r"\_"), list(table.keys())))
+    latex += r"\\" + "\n" + r"\hline" + "\n"
+
+    # Construct a header_keys list that describes the order of the columns in the gnuplot .dat
+    # table
+    header_keys = { v:i for i,v in enumerate(table.keys(),1) }
     for k in table.keys():
         table_iters[k] = iter(table[k])
     # Construct the wiki table: the order given by the file names is important here,
@@ -564,11 +625,14 @@ def gen_table(dict_files, config, title, avg_cpu, multi=False):
                 if k == "iodepth":  # This metric is the first column
                     gplot += f" {item} "
                     wiki += f" | {item} "
+                    latex += f"{item} "
                 else:
                     gplot += f" {item:.2f} "
                     wiki += f" || {item:.2f} "
+                    latex += f" & {item:.2f} "
             gplot += "\n"
             wiki += "\n|-\n"
+            latex += r"\\" + "\n" + r"\hline" + "\n"
     if multi:
         wiki += "! Avg:"
         for k in avg.keys():
@@ -585,7 +649,19 @@ def gen_table(dict_files, config, title, avg_cpu, multi=False):
     wiki += "|}\n"
     print(f" Wiki table: {title}")
     print(wiki)
-    gen_plot(config, gplot, list_subtables, title)
+    latex += f"""
+\\hline
+\\end{{tabular}}
+\\caption{{Performance Throughput vs Latency vs CPU util: {title}.}}
+\\label{{table:iops-lat-cpu-{title}}}
+\\end{{table}}
+"""
+    print(latex)
+    with open(out_tex, "w") as f:
+        f.write(latex)
+        f.close()
+
+    gen_plot(config, gplot, list_subtables, title, header_keys )
     print("Done")
 
 
@@ -607,6 +683,7 @@ def load_avg_cpu_json(json_fname):
     """
     Load a .json file containing the CPU avg samples -- normally produced by the script
     parse-top.pl
+    Probably extend this single .json for all the required files
     """
     try:
         with open(json_fname, "r") as json_data:

--- a/tools/gen_json_xtractor.py
+++ b/tools/gen_json_xtractor.py
@@ -1,0 +1,353 @@
+"""
+Refactoring of the standalone tool fio-parse-jsons.py into modules that can be reused.
+"""
+
+import os
+import math
+import logging
+import re
+import json
+import functools
+from operator import add
+from abc import ABC, abstractmethod
+
+__author__ = "Jose J Palacios-Perez"
+logger = logging.getLogger(__name__)
+
+
+# These generic functions do not need to be part of a class
+# Might be better placed on an common/utils module?
+def combined_mean(a, b):
+    """
+    Calculates the combined mean of two groups:
+    X_c = frac{ n_1*mean(X_1)+n_2*mean(X_2)) }{ (n_1+n_2) }
+    FIO already provides the (mean,stdev) of completion latency per sample
+    Expects two tuples: (mx_1, n_1) and (mx_2,n_2), and returns a tuple.
+    """
+    mx_1, n_1 = a
+    mx_2, n_2 = b
+    n_c = n_1 + n_2
+    return ((n_1 * mx_1 + n_2 * mx_2) / n_c, n_c)
+
+
+def combined_std_dev(a, b):
+    """
+    Calculats the combined std dev, normally for the completion latency
+    Expects a,b to be tuples (s_i,x_i) std dev and mean, respectively,
+    and returns a tuple.
+    """
+    y_1, n_1 = a
+    y_2, n_2 = b
+    s_1, mx_1 = y_1
+    s_2, mx_2 = y_2
+    mx_c, _nc = combined_mean((mx_1, n_1), (mx_2, n_2))
+    v_1 = s_1 * s_1
+    v_2 = s_2 * s_2
+    q_1 = (n_1 - 1.0) * v_1 + n_1 * (mx_1 * mx_1)
+    q_2 = (n_2 - 1.0) * v_2 + n_2 * (mx_2 * mx_2)
+    q_c = q_1 + q_2
+    n_c = n_1 + n_2
+    return ((math.sqrt((q_c - n_c * mx_c * mx_c) / (n_c - 1.0)), mx_c), n_c)
+
+
+class JsonXtractor(ABC):
+    # This is a generic JSON xtractor used by several modules and scripts
+    # each subclass MUST provide its own dictionary for paths and leaf-node
+    # accessor
+
+    def __init__(self):
+        """
+        Constructor: should really check whether the instance has provided this attribute
+        """
+        # self.predef_dict = path_dict
+        pass
+
+    def filter_json_node(self, next_branch, jnode_list_in):
+        """
+        Traverse the JSON jnode_list_in according to the next_branch:
+        jnode_list_in: [dict]
+        Assumption: json output of non-leaf nodes consists of either
+        - dictionary - key field selects sub-value
+        - sequence - key field syntax is name=value, where
+                  name is a dictionary key of sequence elements, and
+                  value is the desired value to select a sequence element
+        """
+        next_node_list = []
+        # Nothing to do if the input next_branch is empty
+        if not next_branch:
+            return next_node_list
+        for n in jnode_list_in:
+            dotlist = next_branch.split("=")
+            if len(dotlist) > 2:
+                print(f"unrecognized syntax at {next_branch}")
+                # logger.debug(f"unrecognized syntax at {next_branch}")
+                return []
+            if len(dotlist) == 1:
+                assert isinstance(n, dict)
+                next_node_list.append(n[next_branch])
+            else:  # must be a sequence, take any element with key matching value
+                select_key = dotlist[0]
+                select_value = dotlist[1]
+                assert isinstance(n, list)
+                for e in n:
+                    # n is a list
+                    # print 'select with key %s value %s sequence
+                    # element %s'%(select_key, select_value, e)
+                    if select_value == "*":
+                        next_node_list.append(e)
+                    else:
+                        v = e[select_key]
+                        if v == select_value:
+                            next_node_list.append(e)
+                            # print('selecting: %s'%str(e))
+                if len(next_node_list) == 0:
+                    print(f"{select_key}={select_value} not found")
+                    # logger.debug(f"{select_key}={select_value} not found")
+                    return []
+        return next_node_list
+
+    def load_json_file(self, json_file):
+        """
+        Generic wrapper for json.load()
+        Returns a dictionary
+        """
+        node = {}
+        with open(json_file, "r") as json_data:
+            # check for empty file
+            f_info = os.fstat(json_data.fileno())
+            if f_info.st_size == 0:
+                print(f"JSON input file {json_file} is empty")
+            else:
+                # parse the JSON object
+                node = json.load(json_data)
+            return node
+
+    @abstractmethod
+    def process_leaf_item(self, key, next_node_list):
+        """
+        Abstract method that the subclass MUST implement
+        """
+        pass
+
+    @abstractmethod
+    def apply_reductor(self, result_dict, metric):
+        """
+        Applies the particular reduction to the list of values.
+        Returns a value (scalar numeric)
+        """
+        pass
+
+
+class JsonFioXtractor(JsonXtractor):
+    """
+    Subclass for FIO .json output
+    This is normally to produce a single TestRunResult
+    The structure is <jobtype> : {dict of paths to .json fields}
+    """
+
+    # This dict specifies the paths that the key is associated with:
+    # 'jobs/jobname=*/read/iops'
+    predef_dict = {
+        "randwrite": {
+            "iops": "write/iops",
+            "total_ios": "write/total_ios",
+            "clat_ms": "write/clat_ns",
+            "clat_stdev": "write/clat_ns",
+            "usr_cpu": "usr_cpu",
+            "sys_cpu": "sys_cpu",
+        },
+        "randread": {
+            "iops": "read/iops",
+            "total_ios": "read/total_ios",
+            "clat_ms": "read/clat_ns",
+            "clat_stdev": "read/clat_ns",
+            "usr_cpu": "usr_cpu",
+            "sys_cpu": "sys_cpu",
+        },
+        "write": {  # aka seqwrite
+            "bw": "write/bw",
+            "total_ios": "write/total_ios",
+            "clat_ms": "write/clat_ns",
+            "clat_stdev": "write/clat_ns",
+            "usr_cpu": "usr_cpu",
+            "sys_cpu": "sys_cpu",
+        },
+        "read": {  # seqread
+            "bw": "read/bw",
+            "total_ios": "read/total_ios",
+            "clat_ms": "read/clat_ns",
+            "clat_stdev": "read/clat_ns",
+            "usr_cpu": "usr_cpu",
+            "sys_cpu": "sys_cpu",
+        },
+    }
+
+    def __init__(self):
+        """
+        Constructor: use the class attribute predef_dict to specify the paths
+        """
+        # self.pathd = predef_dict
+        pass
+
+    def process_leaf_item(self, k, next_node_list):
+        """
+        The subclass must provide this method to process leaf node items.
+        Dict of results: shall we use a generic class to encapsulate a TestRunResult?
+        file: { /path/: value, ...}
+        For default (empty paths) queries:
+        file: { /workload-type/: wrte: iops, latency_ms: (sort list by value, get top) }
+        To coalesce the results of several files:
+        use the timestamp to groups json files -- pending
+        For IOPs or BW: sum the values together from all the json files for the
+        same timestamp
+        For latency: multiply this value by IOPs, sum these values from all the
+        json files for the same timestamp and then divide by total IOPs to get
+        an average latency
+        """
+        #    match k: # Python version on the SV1 node does not support 'match'
+        #    case 'iops' | 'usr_cpu' | 'sys_cpu':
+        # For consistency, these are normally the "columns" for the TestRunResult table
+        # So we might enfoce its type...
+        if re.search("iops|usr_cpu|sys_cpu|iodepth|total_ios", k):
+            return next_node_list[0]
+        if k == "bw":
+            return next_node_list[0] / 1000
+        if k == "latency_ms":
+            #    case 'latency_ms':
+            unsorted_dict = next_node_list[0]
+            sorted_dict = dict(
+                sorted(unsorted_dict.items(), key=lambda x: x[1], reverse=True)
+            )
+            firstk = list(sorted_dict.keys())[0]
+            return firstk
+        if k == "clat_ms":
+            #    case 'clat_ns':
+            unsorted_dict = next_node_list[0]
+            clat_ms = unsorted_dict["mean"] / 1e6
+            return clat_ms
+        if k == "clat_stdev":
+            #    case 'clat_ns':
+            unsorted_dict = next_node_list[0]
+            clat_stdev = unsorted_dict["stddev"] / 1e6
+            return clat_stdev
+
+    def apply_reductor(self, result_dict, metric):
+        """
+        Applies the particular reduction to the list of values.
+        Returns a value (scalar numeric)
+        """
+        if re.search("iops|usr_cpu|sys_cpu|bw|total_ios", metric):
+            return functools.reduce(add, result_dict[metric])
+        if metric == "clat_ms":
+            z = zip(result_dict["clat_ms"], result_dict["total_ios"])
+            mx, _ = functools.reduce(lambda x, y: combined_mean(x, y), z)
+            return mx
+        if metric == "clat_stdev":
+            z = zip(result_dict["clat_stdev"], result_dict["clat_ms"])
+            zz = zip(z, result_dict["total_ios"])
+            zc, _ = functools.reduce(lambda x, y: combined_std_dev(x, y), zz)
+            sc, _ = zc
+            return sc
+
+    def reduce_result_list(self, result_dict, jobname):
+        """
+        Applies a reduction to each of the lists of the result_dict:
+        - IOPS/BW is the cummulative (sum)
+        - avg (completion) latency is the combined avg
+        - clat std dev is the combined std dev -- for the last two, we need
+        the number of samples from FIO, which is "total_ios"
+        """
+        _res = {}
+        for metric in self.predef_dict[jobname].keys():
+            _res[metric] = self.apply_reductor(result_dict, metric)
+        return _res
+
+    def process_fio_json_file(self, json_file, json_tree_path):
+        """
+        Collect metrics from an individual JSON file, which might
+        contain several entries, one per job
+        Returns a dictionary with the filtered data as specified by predef_dict
+        """
+        node = self.load_json_file(json_file)
+        result_dict = {}
+        # Extract the json timestamp: useful for matching same workloads from
+        # different FIO processes
+        result_dict["timestamp"] = str(node["timestamp"])
+        result_dict["iodepth"] = node["global options"]["iodepth"]
+        result_dict["jobname"] = node["global options"]["rw"]
+        # Use the jobname to index the predef_dict for the json query
+        jobs_list = node["jobs"]
+        print(f"Num jobs: {len(jobs_list)}")
+        job_result = {}
+        for _i, job in enumerate(jobs_list):
+            jobname = result_dict["jobname"]
+            query_dict = self.predef_dict[jobname]
+            # These keys are metrics (columns of the TestRunTable) -- they should
+            # have a fixed key order
+            for k in query_dict.keys():
+                json_tree_path = query_dict[k].split("/")
+                next_node_list = [job]
+
+                for next_branch in json_tree_path:
+                    next_node_list = self.filter_json_node(next_branch, next_node_list)
+                item = self.process_leaf_item(k, next_node_list)
+                if k not in job_result:
+                    job_result[k] = []
+                job_result[k].append(item)
+
+        reduced = self.reduce_result_list(job_result, result_dict["jobname"])
+        merged = {**result_dict, **reduced}
+        return merged
+
+
+class JsonFioSetXtractor(JsonXtractor):
+    """
+    Subclass to compare against several TestRunResult tables
+    The input list refers to TestRunResults archives or subdirectories, which have been produced
+    by the above sibling class.
+    The TestRunResult .json table is a flat dict: so we don't really need to generic xtractor above ...
+    We only probably require that the order of the keys (measurements names, or columns in the tables) are
+    fixed.
+    """
+
+    predef_dict = {
+        "randwrite": {
+            "iops": "iops",
+            "total_ios": "total_ios",
+            "clat_ms": "clat_ns",
+            "clat_stdev": "clat_stdev",
+            "usr_cpu": "usr_cpu",
+            "sys_cpu": "sys_cpu",
+            # aggregated CPU.MEM, etc
+        },
+        "randread": {
+            "iops": "iops",
+            "total_ios": "total_ios",
+            "clat_ms": "clat_ns",
+            "clat_stdev": "clat_stdev",
+            "usr_cpu": "usr_cpu",
+            "sys_cpu": "sys_cpu",
+        },
+        "write": {  # aka seqwrite
+            "bw": "bw",
+            "total_ios": "total_ios",
+            "clat_ms": "clat_ns",
+            "clat_stdev": "clat_stdev",
+            "usr_cpu": "usr_cpu",
+            "sys_cpu": "sys_cpu",
+        },
+        "read": {  # seqread
+            "bw": "bw",
+            "total_ios": "total_ios",
+            "clat_stdev": "clat_stdev",
+            "usr_cpu": "usr_cpu",
+            "sys_cpu": "sys_cpu",
+        },
+    }
+
+    def __init__(self):
+        """
+        Constructor: use the class attribute predef_dict to specify the paths
+        """
+        # self.pathd = predef_dict
+        pass

--- a/tools/gnuplot_plate.py
+++ b/tools/gnuplot_plate.py
@@ -1,0 +1,384 @@
+import logging
+import re
+
+__author__ = "Jose J Palacios-Perez"
+logger = logging.getLogger(__name__)
+
+
+class GnuplotTemplate(object):
+    """
+    This class is currently used only for parse-top.py.
+    """
+    TIMEFORMAT = '"%Y-%m-%d %H:%M:%S"'
+    NUMCOLS = 10  # by default, but should be set during construction
+
+    def __init__(
+        self, name: str, proc_groups: dict, comm_sorted: dict, num_samples: int
+    ):
+        """
+        Constructor: expect a dictionary:
+        keys: threads names,
+        values: each a list of metrics (dictionary)
+
+        <thread_id>:
+           <metrics:>
+             'cpu':
+                _data: [samples]
+                avg: geometric average (mean)
+                min: numeric
+                max: numeric
+             'mem': <similar struct>
+             'swctx': # number of context switch, taken from last_cpu
+             'num_cpus': # number of CPU cores seen in last_cpu samples
+        And we probably need a list of the top ten thread_id according to
+        CPU and MEM util
+        Might use an existing logger from the calling script.
+        """
+        self.name = name
+        self.proc_groups = proc_groups
+        self.comm_sorted = comm_sorted
+        self.num_samples = num_samples
+
+    def __str__(self):
+        """Convert to string, for str()."""
+        return "f{self.name}"
+
+    def genPlot(self, metric: str, proc_name: str):
+        """
+        Produce the output .plot and .dat for the process group proc_name with metric.
+        This is intended for the top output.
+        """
+        out_name = f"{proc_name}_{self.name}"
+        out_name = re.sub(r"[.]json", f"_{metric}", out_name)
+        dat_name = f"{out_name}.dat"
+        png_name = f"{out_name}.png"
+        plot_name = f"{out_name}.plot"
+        png_log_name = f"{out_name}-log.png"
+        chart_title = re.sub(r"[_]", "-", out_name)
+        plot_template = f"""
+set terminal pngcairo size 650,280 enhanced font 'Verdana,10'
+set output '{png_name}'
+set key outside horiz bottom center box noreverse noenhanced autotitle
+set datafile missing '-'
+set datafile separator ","
+set timefmt {self.TIMEFORMAT}
+#set format x {self.TIMEFORMAT}
+#set format y "%2.3f"
+set format y '%.0s%c'
+set style data lines
+set xtics border in scale 1,0.5 nomirror rotate by -45  autojustify
+set title "{chart_title}"
+set ylabel '{metric.upper()}%'
+set grid
+set key autotitle columnheader
+
+# Each column is a thread name
+plot '{dat_name}' using 1 w lp, for [i=2:{self.NUMCOLS}] '' using i w lp
+#plot '{dat_name}' using 1:1 title columnheader(1) w lp, for [i=3:{self.NUMCOLS}] '' using i:i title columnheader(i) w lp
+
+#set logscale y
+#set output '{png_log_name}'
+#plot '{dat_name}' using 1:2 title columnheader(2) w lp, for [i=3:{self.NUMCOLS}] '' using 1:i title columnheader(i) w lp
+"""
+        # generate dat file: order as described by self.proc_groups[pg]['sorted'][metric]
+        print(f"== Proc grp: {proc_name}:{metric} num_samples: {self.num_samples}==")
+        # comm_sorted = self.proc_groups[proc_name]['sorted'][metric]
+        _comm_sorted = self.comm_sorted[proc_name][metric]
+        # print( comm_sorted , sep=", " )
+        header = "#" + ",".join(_comm_sorted)
+        print(header)
+        ds = {}
+        # Either use num_samples or count for each comm
+        for comm in _comm_sorted:
+            _data = self.proc_groups[proc_name][comm][metric]
+            print(f"== {comm}: data len: {len(_data)} ==")
+            ds[comm] = iter(_data)
+
+        with open(dat_name, "w") as f:
+            print(header, file=f)
+            for i in range(self.num_samples):
+                row = []
+                for comm in _comm_sorted:
+                    row.append(f"{next(ds[comm]):.2f}")
+                    # catch exception if no data at that index: use a '-'
+                print(",".join(row), file=f)
+            f.close()
+
+        # print plot_template
+        with open(plot_name, "w") as f:
+            f.write(plot_template)
+            f.close()
+
+
+class FioPlot(object):
+    """
+    Class to abstract away the basic functionality for the gen_plot() method in fio-parse-jsons.py
+    """
+
+    METRICS = ['cpu', 'mem']
+
+    def __init__(self, out_name: str, list_subtables, out_dat: str =""):
+        """
+        Constructor: expects the name of the output file names to produce (.dat, .plot),
+        a string containing the .dat
+        and a list of dictionaries, each contains the "table" (columns are the dict keys -- measurements, and values
+        are arrays of measurmentes).
+        """
+        self.output = out_name # output .png filename, normally taken from config_list
+        self.list_subtables = list_subtables # typically a list of TestRunTables
+        self.data = out_dat # optional to a FioCmpPlot since its a Level2
+
+    def setHeader(self, title):
+        """
+        Sets a default header for the .plot script
+        """
+        self.header = f"""
+set terminal pngcairo size 650,420 enhanced font 'Verdana,10'
+set key box left Left noreverse title '{title}'
+set datafile missing '-'
+set key outside horiz bottom center box noreverse noenhanced autotitle
+set grid
+set autoscale
+set xtics border in scale 1,0.5 nomirror rotate by -45  autojustify
+# Hockey stick graph:
+set style function linespoints
+"""
+
+    def getSetting(self, ylabel, y2label, out_chart, _title):
+        """
+        Returns the string for the body of the settings of the .plot script
+        """
+        return f"""
+set ylabel "{ylabel}"
+set xlabel "IOPS (thousand)"
+set y2label "{y2label}"
+set ytics nomirror
+set y2tics
+set tics out
+set autoscale y
+set autoscale y2
+set output '{out_chart}'
+set title "{_title}"
+"""
+
+    def set_out_file_names(self):
+        """
+        Set the output file names for .dat and .plot to start a new plot
+        Side effect: clears the template string
+        """
+        config = self.output 
+        # header_keys = self.header_keys
+        self.template = ""
+        self.out_plot = config.replace("_list", ".plot")
+        self.out_data = config.replace("_list", ".dat")
+
+    def save_files(self):
+        """
+        Save the .dat and .plot files, if any
+        """
+        # Save the .plot script
+        with open(self.out_plot, "w") as f:
+            f.write(self.header)
+            f.write(self.template)
+            f.close()
+        # Save the .dat file
+        if self.out_data:
+            with open(self.out_data, "w") as f:
+                f.write(self.data)
+                f.close()
+
+
+class FioRcPlot(FioPlot):
+    """
+    Subclass for Level1 (that is, when the list_subtables has been extracted from FIO out .json) Response curves
+    """
+
+    def __init__(self, out_name: str, out_dat: str, list_subtables):
+        """
+        Constructor, invokes the parent method
+        """
+        super().__init__(out_name, out_dat, list_subtables)
+        # We might workout from the list_subtables[0] the header_keys
+        self.header_keys = dict(
+            [(v, i) for i, v in enumerate(list_subtables[0].keys(), 1)]
+        )
+
+    def setRcPlotDict(self):
+        """
+        Set the plot_dict for Response Curves profile
+        We might use the metric as a parameter, so iterate each
+        """
+        self.plot_dict = {
+            # Use the dict key as the suffix for the output file .png,
+            # the .dat file is the same for the different charts
+            # we only range over the columns indicated below
+            "iops_vs_lat_vs_cpu": {
+                "ylabel": "Latency (ms)",
+                "ycolumn": "clat_ms",  # get the column number from header_keys, eg "4"
+                #"y2label":  [ "CPU", "MEM" ], # idicates the keys to the dict "y2column" below
+                "y2column": { # keys are y2labels, the numeric values 
+                    "CPU" : [ "OSD_cpu", "FIO_cpu" ], # indeed, these are keys from header_keys
+                    "MEM": ['OSD_mem', 'FIO_mem' ],
+                }
+            }
+        }
+        # Notice that we produce a curve per metric, so we have the response latency
+        # (IOPS vs clat_ms) and each of the metrics (CPU/MEM) for each of the OSD, FIO processes
+        # Use the header_keys to ensure we refer to the correct column
+        #    v = str(self.header_keys[k])
+        self.setHeader("Iodepth")
+
+    def genRcPlot(self, title: str):
+        """
+        Produce the output .plot and .dat for the list_subtables, using title
+        This is intended for the typical Level1 response curves.
+        """
+        self.set_out_file_names()
+        # Gnuplot quirk: '_' is interpreted as a sub-index:
+        _title = title.replace("_", "-")
+
+        # This is for "iops_vs_lat_vs_cpu": (we could use a list of which keys we want)
+        for pk, pitem in self.plot_dict.items():
+            # Set the out .png name for this plot
+            out_chart = self.output.replace("list", pk + ".png")
+            # Get the labels (from the plot_dict)
+            ylabel = pitem["ylabel"]
+            ycol = str(self.header_keys[pitem["ycolumn"]])
+            y2label = pitem["y2label"]
+            # Catenate the Setting section of the .plot script
+            self.template += self.getSetting(ylabel, y2label, out_chart, _title)
+            # To plot CPU util in the same response curve, we need the extra axis
+            # This list_subtables indicates how many sub-tables the .datfile will have
+            # The stdev is the error column:5
+            stddev_col = self.header_keys["clat_stdev"]
+            pg_y2column = self.pg_y2column
+            list_subtables = self.list_subtables
+            if len(list_subtables) > 0:
+                head = f"plot '{self.out_data}' index 0 using ($2/1e3):{ycol}:{stddev_col} t '{list_subtables[0]} q-depth' w yerr axes x1y1 lc 1"
+                head += f",\\\n '' index 0 using ($2/1e3):{ycol} notitle w lp lc 1 axes x1y1"
+                # These are the pg metrics we are intersted: CPU or MEM
+                for pg, y2col in pg_y2column:
+                    head += f",\\\n '' index 0 using ($2/1e3):{y2col} w lp axes x1y2 t '{pg}'"
+                if len(list_subtables) > 1:
+                    tail = ",\\\n".join(
+                        [
+                            f"  '' index {i} using ($2/1e3):{ycol} t '{list_subtables[i]} q-depth' w lp axes x1y1"
+                            for i in range(1, len(list_subtables))
+                        ]
+                    )
+                    self.template += ",\\\n".join([head, tail])
+                else:
+                    self.template += head + "\n"
+
+        self.save_files()
+
+
+class FioCmpPlot(FioPlot):
+    """
+    Class to compare the results from a (Level2) set of FIO combined test result tables. This type of tables
+    have as keys the measurments (IOPs, CPU, MEM util, etc.) and as values each a list of numeric measurements.
+    The idea is to traverse over a list of combined results. Each represents a Response Curve for a specific
+    configuration, presenting them side by side for easy comparison.
+    """
+    # This dict specifies the set of combinations supported
+    plot_dict = {
+        # Use the dict key as the suffix for the output file .png,
+        # the .dat file is the same for eash set of combined chart
+        # notice the ycolumns refer to keys/columns in the 
+        "cmp_iops_vs_lat": {
+            "ylabel": "Latency (ms)",
+            "ycolumn": "clat_ms",  # "4" get the column number from header_keys
+            "y2label": "Latency (ms)",
+        },
+        "cmp_iops_vs_cpu": {
+            "ylabel": "CPU", # can factorise for the two metrics CPU, MEM
+            "ycolumn": "OSD_cpu", #"9", # corresp to OSD_cpu in the TestRunTable
+            "y2column": "FIO_cpu", #"9", # corresp to OSD_cpu in the TestRunTable
+            "y2label": "CPU",
+        },
+        "cmp_iops_vs_mem": {
+            "ylabel": "MEM",
+            "ycolumn": "OSD_mem",
+            "y2column": "FIO_mem", 
+            "y2label": "MEM",
+        },
+    }
+
+    def __init__(self, title: str, list_tables, combinator):
+        """
+        Constructor: expects
+        * the title for the set of charts
+        * the list of TestRunTables to combine
+        * a dictionary which keys indicate the entries for the combination, values are the field attributes
+          of the TestRunTables to combine
+        Example:
+        combinator= {
+          'config_list': [ 'default', 'bal_osd', 'bal_socket' ],
+          'plot_dict': ["iops_vs_cpu", "iops_vs_lat", "iops_vs_mem"], -- there is a default provided
+        }
+        list_tables= [
+         {'default': { <TestRunSpec>: <path>, '_dat': <run_filenames_dat> }}, ...
+        ]
+        """
+        # super().__init__(output, out_dat, list_subtables)
+        self.title = title
+        self.list_tables = list_tables
+        self.combinator = combinator
+        # Wont need y2 axis on a comparison chart
+
+    def setCmpPlotDict(self):
+        """
+        Set the plot_dict for Response Curves profile
+        """
+        # Probably need a separate dict to indicate which TestRunTable to compare against, for example
+        # cmp_list: default, balance_osd, balance_socket
+        # these identify the corresponding TestRunSpecs (or simply traverse the dirs/.zip and associate corresponding
+        # arrays)
+        # From these, the below dict would indicate the set of charts: one for Response latency (iops_vs_lat), which
+        # enumerates the .dat and the title for each of the cmp_list -- note that assuming for each we can identify
+        # the names for the .dat etc then we should be able to simply enumerate/iterate them.
+        # Then, for the CPU/MEM mnetrics, a comparison chart per metric -- again, we only need the .dat name, the title
+        # and columns, which we assume the header list containing the result table dictionary keys are in fixed order.
+        self.setHeader(self.title)  # e.g baseline vs sandbox, or Balance CPU strategy
+
+    def genPlot(self, title: str):
+        """
+        Produce the output .plot and .dat for the list_subtables, using title
+        This is intended for the comparison side by side of result set from response curves.
+        """
+        self.set_out_file_names()
+        # Gnuplot quirk: '_' is interpreted as a sub-index:
+        _title = title.replace("_", "-")
+        # This is for "iops_vs_lat_vs_cpu": (we could use a list of which keys we want)
+        for pk, plitem in self.plot_dict.items():
+            out_chart = self.output.replace("list", pk + ".png")
+            ylabel = plitem["ylabel"]
+            ycol = str(self.header_keys[plitem["ycolumn"]])
+            y2label = plitem["y2label"]
+            # y2col = plot_dict[pk]["y2column"]
+            self.template += self.getSetting(ylabel, y2label, out_chart, _title)
+            # To plot CPU util in the same response curve, we need the extra axis
+            # This list_subtables indicates how many sub-tables the .datfile will have
+            # The stdev is the error column:5
+            stddev_col = self.header_keys["clat_stdev"]
+            pg_y2column = self.pg_y2column
+            list_subtables = self.list_subtables
+            # This is a list of result sets, so we traverse over their associated .dat
+            if len(list_subtables) > 0:
+                head = f"plot '{self.out_data}' index 0 using ($2/1e3):{ycol}:{stddev_col} t '{list_subtables[0]} q-depth' w yerr axes x1y1 lc 1"
+                head += f",\\\n '' index 0 using ($2/1e3):{ycol} notitle w lp lc 1 axes x1y1"
+                # These are the pg metrics we are intersted: CPU or MEM
+                for pg, y2col in pg_y2column:
+                    head += f",\\\n '' index 0 using ($2/1e3):{y2col} w lp axes x1y2 t '{pg}'"
+                if len(list_subtables) > 1:
+                    tail = ",\\\n".join(
+                        [
+                            f"  '' index {i} using ($2/1e3):{ycol} t '{list_subtables[i]} q-depth' w lp axes x1y1"
+                            for i in range(1, len(list_subtables))
+                        ]
+                    )
+                    self.template += ",\\\n".join([head, tail])
+                else:
+                    self.template += head + "\n"
+
+        #self.save_files()

--- a/tools/parse-top.py
+++ b/tools/parse-top.py
@@ -1,0 +1,469 @@
+#!/usr/bin/python
+"""
+This script extracts average utilisation (CPU and MEM) from a list of process id (PIDs) from the .json output
+from the Linux command top. Produces a gnuplot script and corresponding .dat
+
+Arguments are:
+- (input) a _top.json file name, 
+- (input) a _pid.json file name,
+- (input/output) and a _cpu_avg.json file name, average over a range (typically for Response latency curves).
+
+Example of usage:
+    cat ${TEST_RESULT}_top.out | jc --top --pretty > ${TEST_RESULT}_top.json
+    python3 /root/bin/parse-top.py --config=${TEST_RESULT}_top.json --cpu="${OSD_CORES}" --avg=${OSD_CPU_AVG} \
+          --pids=${TOP_PID_JSON} 2>&1 > /dev/null
+
+"""
+
+import argparse
+import logging
+import os
+import sys
+import re
+import json
+import tempfile
+from pprint import pformat
+
+from gnuplot_plate import GnuplotTemplate
+
+__author__ = "Jose J Palacios-Perez"
+
+logger = logging.getLogger(__name__)
+
+
+def serialize_sets(obj):
+    """
+    Serialise sets as lists
+    """
+    if isinstance(obj, set):
+        return list(obj)
+
+    return obj
+
+
+DEFAULT_NUM_SAMPLES = 30
+
+
+class TopEntry(object):
+    """
+    Filter the .json to a dictionary with keys the threads command names, and values
+    array of avg measurement samples (normally 30),
+    produce as output a gnuplot (script an d.dat files) and .json
+
+    The following is an example of the structure of the input .json:
+
+    cat _top.out | python3 ~/Work/cephdev/jc/jc --top --pretty > _top.json
+    [
+    {
+    "time": "23:47:35",
+    "uptime": 211235,
+    "users": 0,
+    "load_1m": 6.06,
+    "load_5m": 7.09,
+    "load_15m": 8.13,
+    "mem_total": 385053.0,
+    "mem_free": 340771.4,
+    "mem_used": 38974.0,
+    "mem_buff_cache": 7839.5,
+    "swap_total": 0.0,
+    "swap_free": 0.0,
+    "swap_used": 0.0,
+    "mem_available": 346079.1,
+    "processes": [
+      {
+        "parent_pid": 1073313,
+        "pid": 1073378,
+        "last_used_processor": 41,
+        "priority": 20,
+        "nice": 0,
+        "virtual_mem": 16.0,
+        "resident_mem": 3.4,
+        "shared_mem": 54656.0,
+        "status": "sleeping",
+        "percent_cpu": 25.0,
+        "percent_mem": 0.9,
+        "time_hundredths": "0:25.50",
+        "command": "reactor-1"
+      },
+
+    "pid" and "parent_pid" are used to filter those processes specified in the _pid.json
+    We are only interested in the following measurements:
+    "percent_cpu" "percent_mem"
+    """
+
+    # Define some regex for threads that can be agglutinated
+    # "control" dict, the proc_groups should be containing the _data to plot
+    # These are intended for Ceph and Crimson OSD, so you might need to extend for your own
+    # needs.
+    PROC_INFO = {
+        "OSD": {
+            "tname": re.compile(
+                r"^(crimson-osd|alien-store-tp|reactor|bstore|log|cfin|rocksdb|syscall-0).*$"
+                # re.DEBUG,
+            ),
+            "regex": {
+                "reactor": re.compile(r"reactor-\d+"),
+            },
+            "pids": set([]),
+            "threads": {},
+            "sorted": {},
+            "num_samples": 0,
+        },
+        "FIO": {
+            "tname": re.compile(
+                r"^(fio|msgr-worker|io_context_pool|log|ceph_timer|safe_timer|taskfin_librbd|ms_dispatch).*$"
+            ),
+            "regex": {
+                "msgr-worker": re.compile(r"msgr-worker-\d+"),
+            },
+            "pids": set([]),
+            "threads": {},
+            "sorted": {},
+            "num_samples": 0,
+        },
+    }
+    METRICS = ["cpu", "mem"]
+    CPU_RANGE = {
+        "regex": re.compile(r"^(\d+)-(\d+)$"),
+        "min": 0,
+        "max": 0,
+    }
+
+    def __init__(self, options):
+        """
+        This class expects the required options
+        Filters the .json into a dict: keys are thread names (commands) and values are arrays of
+        metrics (cpu/mem), coalesced into an avg every DEFAULT_NUM_SAMPLES, which amounts to a single data point.
+        """
+        self.options = options
+        self.measurements = [
+            "percent_cpu",
+            "percent_mem",
+        ]
+
+        # This would be the result dictionary
+        self.proc_groups = {}
+        self.num_samples = 0
+        self.avg_cpu = {}
+
+    def init_avg_cpu(self):
+        """
+        Initialises the avg_cpu dictionary
+        """
+        for pg in self.PROC_INFO:
+            if pg not in self.avg_cpu:
+                self.avg_cpu.update({pg: {}})
+            if pg not in self.proc_groups:
+                self.proc_groups.update({pg: {}})
+            for m in self.METRICS:
+                if m not in self.avg_cpu[pg]:
+                    self.avg_cpu[pg].update({m: {"total": 0.0, "index": 0, "data": []}})
+
+    def _get_pname(self, pg, p):
+        """
+        Return the name to use as key in the dictionary for this sample
+        """
+        pgroup = self.PROC_INFO[pg]["regex"]
+        for pname in pgroup:
+            if pgroup[pname].search(p["command"]):
+                return pname
+        return p["command"]
+
+    def _is_p_in_pgroup(self, pg, p):
+        """
+        Returns True if the given p is a member of pgroup
+        """
+        a = set([p["parent_pid"], p["pid"]])
+        pdict = self.PROC_INFO[pg]
+        b = pdict["pids"]  # already a set set(pdict['pids'])
+        intersect = list(a & b)
+        return pdict["tname"].search(p["command"]) and intersect
+
+    def create_cpu_range(self):
+        """
+        Create the corresponding CPU range of interest.
+        At the moment ignored since jc does not support the CPU core view yet (PR in progress)
+        """
+        regex = self.CPU_RANGE["regex"]
+        m = regex.search(self.options.cpu)
+        if m:
+            self.CPU_RANGE["min"] = min([int(m.group(1)), int(m.group(2))])
+            self.CPU_RANGE["max"] = max([int(m.group(1)), int(m.group(2))])
+        logger.debug(f"CPU range: {self.CPU_RANGE}")
+
+    def update_pids(self, pg, p):
+        """
+        Update the self.proc_groups[pg]["pids"] with the PIDs of the sample
+        This is an array, we might want to use sets instead to avoid dupes
+        """
+        pid_set = self.PROC_INFO[pg]["pids"]
+        if p["parent_pid"] not in pid_set:
+            pid_set.add(p["parent_pid"])
+
+    def update_avg(self, num_samples: int):
+        """
+        Update the avg_cpu array
+        """
+        if ((num_samples + 1) % DEFAULT_NUM_SAMPLES) == 0:
+            if num_samples > 0:
+                for pg in self.PROC_INFO:  # proc_groups:
+                    for m in self.METRICS:
+                        avg_d = self.avg_cpu[pg][m]
+                        val = avg_d["total"] / DEFAULT_NUM_SAMPLES
+                        avg_d["data"].append(val)
+                        avg_d["index"] += 1  # prob redundant
+                        avg_d["total"] = 0.0
+
+    def aggregate_proc(self, index, pg, procs):
+        """
+        Aggregate the procs onto the corresponding pg under pdict
+        """
+        pdict = self.proc_groups[pg]
+        for p in procs:
+            if self._is_p_in_pgroup(pg, p):
+                # Find the corresp thread name to insert this sample, it can be "pure"
+                # or in a group, in which case it needs to be agglutinated
+                pname = self._get_pname(pg, p)
+                if pname not in pdict:
+                    pdict.update(
+                        {
+                            pname: {
+                                "cpu": [0.0] * self.num_samples,
+                                "mem": [0.0] * self.num_samples,
+                            }
+                        }
+                    )
+                    self.update_pids(pg, p)
+                for m in self.METRICS:
+                    # Agglutinate up to num samples
+                    pdict[pname][m][index] += p[f"percent_{m}"]
+                    self.avg_cpu[pg][m]["total"] += p[f"percent_{m}"]
+
+    def filter_metrics(self, samples):
+        """
+        Filter the (array of dicts) to the measurements we want,
+        of those threads names using the PID and PPID
+        """
+        self.num_samples = len(samples)
+        logger.debug(f"Got {self.num_samples}")
+        for _i, item in enumerate(samples):
+            self.update_avg(_i)
+            procs = item["processes"]  # list of dicts jobs
+            # Filter those PIDs we are interested
+            for pg in self.PROC_INFO:
+                self.aggregate_proc(_i, pg, procs)
+
+        logger.info(f"Parsed {self.num_samples} entries from {self.options.config}")
+        logger.debug(f"avg_cpu: {json.dumps(self.avg_cpu, indent=4)}")
+
+    def load_json(self, json_fname):
+        """
+        Load a .json file
+        Returns a dict
+        """
+        try:
+            with open(json_fname, "r") as json_data:
+                # Check for empty file
+                f_info = os.fstat(json_data.fileno())
+                if f_info.st_size == 0:
+                    logger.error(f"JSON input file {json_fname} is empty")
+                    # bail out
+                    sys.exit(1)
+                return json.load(json_data)
+        except IOError as e:
+            raise argparse.ArgumentTypeError(str(e))
+
+    def load_top_json(self, json_fname):
+        """
+        Load a .json file containing top metrics
+        Returns a dict with keys only those interested thread names
+        """
+        samples = self.load_json(json_fname)
+        self.filter_metrics(samples)
+        logger.debug(f"JSON {json_fname} top loaded")
+
+    def load_pid_json(self, json_fname):
+        """
+        Load a _pid.json file containing the PIDs for the processes
+        that need to be filtered
+        Returns a dict with keys only those interested thread names
+        """
+        pids_list = self.load_json(json_fname)
+        for pg in pids_list:
+            if pg in self.PROC_INFO:
+                self.PROC_INFO[pg]["pids"] = set(pids_list[pg])
+        logger.debug(f"JSON pid loaded: {pformat(self.PROC_INFO)}")
+
+    def get_job_stats(self, pg: str, metric: str):
+        """
+        Calculate the min, max and median of the metric (cpu,mem)
+        """
+        pdict = self.proc_groups[pg]
+        for pname in pdict:
+            _data = pdict[pname][metric]
+            nentries = len(_data)
+            sum_metric = sum(_data)
+            if nentries > 0:
+                avg_metric = sum_metric / nentries
+            else:
+                avg_metric = 0
+            pg_control = self.PROC_INFO[pg]["threads"]
+            if pname not in pg_control:
+                pg_control.update({pname: {metric: {}}})
+            else:
+                if metric not in pg_control[pname]:
+                    pg_control[pname].update({metric: {}})
+            pg_control[pname][metric].update(
+                {"avg": avg_metric, "min": min(_data), "max": max(_data)}
+            )
+
+    def sort_jobs(self, pg: str, metric: str):
+        """
+        Sort the list of threads by metric utilisation
+        """
+        d = {}
+        pg_control = self.PROC_INFO[pg]["threads"]
+        for comm, job in pg_control.items():
+            d[comm] = job[metric]["avg"]
+        # Alt: dsorted = {k: v for k, v in sorted(d.items(), key=lambda item: item[1])}
+        self.PROC_INFO[pg]["sorted"][metric] = sorted(d, key=d.get, reverse=True)
+
+    def get_top_procs_util(self):
+        """
+        Sort the list of threads from top (metric) utilisation
+        """
+        for pg in self.proc_groups:
+            for metric in self.METRICS:
+                self.get_job_stats(pg, metric)
+                self.sort_jobs(pg, metric)
+        logger.debug(f"Process group: {json.dumps(self.proc_groups, indent=4)}")
+
+    def gen_plots(self):
+        """
+        Generate the .dat, .plot files for pg at metric m
+        """
+        comm_sorted = {}
+        for pg in self.PROC_INFO:
+            for m in self.METRICS:
+                if pg not in comm_sorted:
+                    comm_sorted.update({pg: {m: {}}})
+                comm_sorted[pg][m] = self.PROC_INFO[pg]["sorted"][m]
+
+        plot = GnuplotTemplate(
+            self.options.config, self.proc_groups, comm_sorted, self.num_samples
+        )
+        for metric in self.METRICS:
+            for pg in self.proc_groups:
+                logger.debug(
+                    f"Generating output for Process group: {pg}, metric: {metric}"
+                )
+                plot.genPlot(metric, pg)
+
+    def save_json(self, json_out: str, pobject):
+        """
+        Save the given struct in a .json fname file
+        """
+        logger.debug(f"Writing: {json_out}")
+        with open(json_out, "w", encoding="utf-8") as f:
+            json.dump(pobject, f, indent=4, sort_keys=True, default=serialize_sets)
+            f.close()
+
+    def run(self):
+        """
+        Entry point
+        """
+        os.chdir(self.options.directory)
+        self.load_pid_json(self.options.pids)
+        self.init_avg_cpu()
+        self.load_top_json(self.options.config)
+        self.get_top_procs_util()
+        # Check whether the flag to skip plot gneration is on -- atm ignored
+        self.gen_plots()
+        self.save_json(self.options.avg, [self.avg_cpu])
+
+
+def main(argv):
+    examples = """
+    Examples:
+    # Produce _top.json from a _top.out:
+    # cat _top.out | jc --pretty --top  > _top.json
+    # Use that to produce the gnuplot charts:
+    # parse-top.py -c _top.json -p _pids.json -u "0-111" -a _avg.json 
+    # Use the _avg.json to combine in a FIO results table:
+    # fio-parse-jsons.py -c test_list -t test_title -a _avg.json 
+
+    """
+    parser = argparse.ArgumentParser(
+        description="""This tool is used to filter a _top.out into _top.json""",
+        epilog=examples,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        required=True,
+        help="Input _top.out file",
+        default=None,
+    )
+    parser.add_argument(
+        "-p",
+        "--pids",
+        type=str,
+        required=True,
+        help="Input _pids.json file",
+        default=None,
+    )
+    parser.add_argument(
+        "-u",
+        "--cpu",
+        type=str,
+        required=False,
+        help="Range of CPUs id to filter",
+        default="0-111",
+    )
+    parser.add_argument(
+        "-a",
+        "--avg",
+        type=str,
+        required=False,
+        help=".json output file of CPU avg to produce (cummulative if it already exists)",
+        default="",
+    )
+    parser.add_argument(
+        "-n",
+        "--num",
+        type=int,
+        required=False,
+        help=f"number of samples to use for a period (default {DEFAULT_NUM_SAMPLES})",
+        default=DEFAULT_NUM_SAMPLES,
+    )
+    parser.add_argument(
+        "-d", "--directory", type=str, help="Directory to examine", default="./"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="True to enable verbose logging mode",
+        default=False,
+    )
+
+    options = parser.parse_args(argv)
+
+    if options.verbose:
+        logLevel = logging.DEBUG
+    else:
+        logLevel = logging.INFO
+
+    with tempfile.NamedTemporaryFile(dir="/tmp", delete=False) as tmpfile:
+        logging.basicConfig(filename=tmpfile.name, encoding="utf-8", level=logLevel)
+
+    logger.debug(f"Got options: {options}")
+
+    top_meter = TopEntry(options)
+    top_meter.run()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tools/report_gen.py
+++ b/tools/report_gen.py
@@ -1,0 +1,257 @@
+#!/usr/bin/python
+"""
+This script traverses the dir tree to select .JSON entries to
+generate a report in .tex
+"""
+
+import argparse
+import logging
+import os
+import sys
+import json
+import glob
+import tempfile
+
+__author__ = 'Jose J Palacios-Perez'
+
+logger = logging.getLogger(__name__)
+
+class Reporter(object):
+    OSD_LIST = [1,3,8]
+    REACTOR_LIST = [1,2,4]
+    ALIEN_LIST = [7,14,21]
+    TBL_HEAD = r"""
+\begin{table}[h!]
+\centering
+\begin{tabular}[t]{|l*{6}{|c|}}
+   \hline 
+"""
+    
+    def __init__(self, jsonName:str=""):
+        """
+        This class expects a list of result files to process into a report
+        """
+        self.jsonName = jsonName
+        self.entries = {}
+        self.body = {}
+
+    def traverse_dir(self):
+        """
+        Traverse the given list (.JSON) use .tex template to generate document
+        """
+        pass
+
+    def find(name, path):
+        """
+        find a name file in path
+        """
+        for root, dirs, files in os.walk(path):
+            if name in files:
+                return os.path.join(root, name)
+
+    def start_fig_table(self, header:list[str]):
+        """
+        Instantiates the table template for the path and caption
+        """
+        head_table="""
+\\begin{table}\\sffamily
+\\begin{tabular}{l*2{C}@{}}
+\\toprule
+""" +  " & ".join(header) + "\\\\" + """
+\\midrule
+"""
+        #print(head_table)
+        return head_table
+
+    def end_fig_table(self, caption:str=""):
+        end_table=f"""
+\\bottomrule 
+\\end{{tabular}}
+\\caption{{{caption}}}
+\\end{{table}}
+"""
+        return end_table
+        #print(end_table)
+
+    def instance_fig(self, path:str):
+        """
+        Instantiates the figure template for the path and caption
+        """
+        add_pic=f"\\addpic{{{path}}}"
+        return add_pic
+        #print(add_pic) # replace to write to oputput file instead
+
+    def gen_table_row(self, dir_nm:str, proc:str):
+        """
+        Capture CPU,MEM charts for the current directory
+        """
+        utils = []
+        row = []
+        # CPU util on left, MEM util on right
+        for metric in [ "cpu", "mem" ]:
+            fn = glob.glob(f"{dir_nm}/{proc}_*_top_{metric}.png")
+            if fn:
+                #logger.info(f"found {fn[0]}")
+                row.append(self.instance_fig(fn[0]))
+                utils.append(f"{fn[0]}")
+        self.entries.update( { f"{dir_nm}": utils} )
+        return row
+
+    def get_iops_entry(self, osd_num, reactor_num):
+        """
+        Generate a IOPs table: columns are the .JSON dict keys,
+        row_index is the test stage (num alien threads, num reactors, num OSD)
+        """
+        entry = self.entries['OSD'][str(osd_num)]["reactors"][str(reactor_num)]
+        entry.update({ "aliens": {} })
+
+        for at_num in self.ALIEN_LIST:
+            entry["aliens"].update( {str(at_num): {} })
+            dir_nm = f"crimson_{osd_num}osd_{reactor_num}reactor_{at_num}at_8fio_lt_1procs_randread"
+            fn = glob.glob(f"{dir_nm}/fio_{dir_nm}.json")
+            if fn:
+                with open(fn[0], 'r') as f:
+                    entry["aliens"][str(at_num)] = json.load(f)
+                    f.close()
+
+    def gen_iops_table(self, osd_num, reactor_num):
+        """
+        Generate a results table: colums are measurements, row index is a test config 
+        index
+        """
+        TBL_TAIL =f"""
+   \\hline
+\\end{{tabular}}
+\\caption{{Performance on {osd_num} OSD, {reactor_num} reactors.}}
+\\label{{table:iops-{osd_num}osd-{reactor_num}reactor}}
+\\end{{table}}
+"""
+        table = ""
+        # This dict has keys measurements
+        # To generalise: need reduce (min-max/avg) into a dict
+        entry_table = self.entries['OSD'][str(osd_num)]["reactors"][str(reactor_num)]
+        body_table = self.body['OSD'][str(osd_num)]["reactors"][str(reactor_num)]
+        body_table.update({"table":""}) 
+        for at_num in self.ALIEN_LIST:
+            entry = entry_table["aliens"][str(at_num)]
+            if not table:
+                table = self.TBL_HEAD 
+                table += r"Alien\\Threads & "
+                table += " & ".join(map(lambda x: x.replace(r"_",r"\_"), list(entry.keys())))
+                table += r"\\" + "\n" + r"\hline" + "\n"
+            table += f" {at_num} & "
+            table += " & ".join(map("{:.2f}".format,list(entry.values())))
+            table += r"\\" + "\n"
+        table += TBL_TAIL
+        body_table["table"] = table 
+
+    def gen_charts_table(self, osd_num, reactor_num):
+        """
+        Generate a charts util table: colums are measurements, row index is a test config 
+        index
+        """
+        body_table = self.body['OSD'][str(osd_num)]["reactors"][str(reactor_num)]
+        body_table.update({"charts_table":""}) 
+        dt = ""
+        for proc in [ "OSD", "FIO" ]:
+            # identify the {FIO,OSD}*_top{cpu,mem}.png files to pass to the template
+            # One table per process
+            dt += self.start_fig_table([r"Alien\\threads", "CPU", "Mem"])
+            for at_num in self.ALIEN_LIST:
+                row=[]
+                # TEST_RESULT
+                # Pickup FIO_*.json out -- which can be a list
+                dir_nm = f"crimson_{osd_num}osd_{reactor_num}reactor_{at_num}at_8fio_lt_1procs_randread"
+                logger.info(f"examining {dir_nm}")
+                #os.chdir(dir_nm)
+                row.append(str(at_num))
+                row += self.gen_table_row(dir_nm, proc)
+                dt += r' & '.join(row) + r'\\' + "\n"
+                #print(r' & '.join(row) + r'\\')
+            dt += self.end_fig_table(
+                f"{osd_num} OSD, {reactor_num} Reactors, 4k Random read: {proc} utilisation")
+        body_table["charts_table"] = dt
+
+    def start(self):
+        """
+        Entry point
+        """
+        self.entries.update({'OSD': {}})
+        self.body.update({'OSD': {}})
+        # Ideally, load a .json with the file names ordered
+        for osd_num in self.OSD_LIST:
+            self.entries['OSD'].update({ str(osd_num): { "reactors": {} }})
+            self.body['OSD'].update({ str(osd_num): { "reactors": {} }})
+            # Chapter header
+            #self.body += f"\\chapter{{{osd_num} OSD, 4k Random read}}\n"
+            for reactor_num in self.REACTOR_LIST:
+                self.entries['OSD'][str(osd_num)]["reactors"].update({ str(reactor_num): {}})
+                self.body['OSD'][str(osd_num)]["reactors"].update({ str(reactor_num): {}})
+                # Section header: all alien threads in a single table
+                #self.body += f"\\section{{{reactor_num} Reactors}}\n"
+                self.get_iops_entry(osd_num, reactor_num)
+                self.gen_iops_table(osd_num, reactor_num)
+                self.gen_charts_table(osd_num, reactor_num)
+
+    def compile(self):
+        """
+        Compile the .tex document, twice to ensure the references are correct
+        """
+        for osd_num in self.OSD_LIST:
+            print(f"\\chapter{{{osd_num} OSD, 4k Random read}}")
+            for reactor_num in self.REACTOR_LIST:
+                #print(f"\\section{{{reactor_num} Reactors}}")
+                dt = self.body['OSD'][str(osd_num)]["reactors"][str(reactor_num)]
+                print(dt["table"])
+                #print(dt["charts_table"])
+            for reactor_num in self.REACTOR_LIST:
+                #print(f"\\section{{{reactor_num} Reactors}}")
+                dt = self.body['OSD'][str(osd_num)]["reactors"][str(reactor_num)]
+                #print(dt["table"])
+                print(dt["charts_table"])
+        #print(self.body)
+        if self.jsonName:
+            with open(self.jsonName, 'w', encoding='utf-8') as f:
+                json.dump(self.entries, f, indent=4 ) #, sort_keys=True, cls=TopEntryJSONEncoder)
+                f.close()
+
+def main(argv):
+    examples = """
+    Examples:
+    # Produce a performance test report from the current directory
+        %prog aprgOutput.log
+
+    # Produce a latency target report from the current directory:
+    #
+        %prog --latarget latency_target.log
+
+    """
+    parser = argparse.ArgumentParser(description="""This tool is used to parse output from the top command""",
+                                     epilog=examples, formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument("jsonName", type=str, default=None,
+                        help="JSON specifying the performance test results")
+    parser.add_argument("-l", "--latarget", action='store_true',
+                        help="True to assume latency target run", default=False)
+    parser.add_argument("-v", "--verbose", action='store_true',
+                        help="True to enable verbose logging mode", default=False)
+
+    options = parser.parse_args(argv)
+
+    if options.verbose:
+        logLevel = logging.DEBUG
+    else:
+        logLevel = logging.INFO
+
+    with tempfile.NamedTemporaryFile(dir='/tmp', delete=False) as tmpfile:
+        #print(f"logname: {tmpfile.name}")
+        logging.basicConfig(filename=tmpfile.name, encoding='utf-8',level=logLevel)
+
+    logger.debug(f"Got options: {options}")
+
+    report = Reporter(options.jsonName)
+    report.start()
+    report.compile()
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tools/test_run_spec.py
+++ b/tools/test_run_spec.py
@@ -1,0 +1,160 @@
+"""
+The intention of this class is to uniquely specify a Test run, this is normally via a name (str)
+that succintly describes the following sections of (preferential) information:
+
+* the cluster configuration: this encompasses
+- the OSD type being exercised, eg. Crimson (default Bluestore), Classic, Cyan, Seastore
+- the number of OSDs
+- the number of Seastar Reactors (only for Crimson)
+- the number of CPUs used for FIO clients (or other benchmark)
+
+* the workload: this is normally worked out by the client (eg. FIO)
+- whether it is a random (r/w, propotion), or sequential I/O, the blocksize
+- the iodepth
+- the number of jobs
+
+* intended type of postprocessing: Response Curves, Latency target, core CPU balance strategy, etc.
+
+Typically, other than timestamps, a partial order over a list of TestRunSpecs can be established
+by the scalars:
+* iodepth, and number of jobs.
+so that a table of TestRunSpecs can be sorted in increasing order of these values.
+Such a TestRunTable is normally used for Response Curves.
+
+A comparison among sets of Response Curves (TestRunTables) can take place over the same workload,
+only ranging a single parameter over the cluster configurations, or the sandbox used to compare
+performance impact of code changes.
+
+Constructor: expect a (string) seed, normally the "prefix" argument when executing a test plan in aprg, from
+this, work out a nested dictionary: the keys specify the different TestRuns (eg, for each typical workload)
+names, and values are dictionaries
+specifying a regex to use to encode/decode the TestRunSpec, as well some accessors and comparison.
+"""
+
+import logging
+import re
+
+__author__ = "Jose J Palacios-Perez"
+logger = logging.getLogger(__name__)
+
+
+class TestRunSpec(object):
+    # This is used to specify a dictionary with keys the names and values those
+    # cyan_8osd_5reactor_8fio_bal_osd_lt_1procs_randwrite.zip
+    # prefixed
+    RE_RUN_SPEC = re.compile(r"""^(?P<config>[^_]+)_
+            (?P<osd>\d+)osd_         # OSD num
+            (?P<reactor>\d+)reactor_ # Reactor num
+            (?P<FIO>\d+)fio_         # FIO CPU num
+            (bal_osd_|bal_socket_|default_)?
+            (lt_|mj_)?
+            (?P<proc>\d+)procs_
+            (randread|randwrite|seqread|seqwrite)
+    """)
+
+    _workloads = ["randread", "randwrite", "seqread", "seqwrite"]
+
+    # Split by '_' and parse each token individually
+    RE_OSD_TYPE = re.compile(r"^(crimson|cyan|classic)")
+    RE_OSD_NUM = re.compile(r"(\d+)osd")
+    RE_REACTOR_NUM = re.compile(r"(\d+)reactor")
+    RE_FIO_CPU_NUM = re.compile(r"(\d+)fio")
+    RE_FIO_PROC_NUM = re.compile(r"(\d+)procs")
+    RE_JOB_SPEC = re.compile(r"(bal_osd_|bal_socket_|default_)?(lt_|mj_)?")
+    RE_WORKLOAD = re.compile(r"(randread|randwrite|seqread|seqwrite)")
+
+    # We use these keys as attributes when populating the _dictionary
+    tr_spec_re = {
+        "osd_type": RE_OSD_TYPE,
+        "osd_num": RE_OSD_NUM,
+        "reactor_num": RE_REACTOR_NUM,
+        "fio_cpu_num": RE_FIO_CPU_NUM,
+        "fio_proc_num": RE_FIO_PROC_NUM,
+        "job_spec": RE_JOB_SPEC,
+        "workload": RE_WORKLOAD,
+    }
+
+    def __init__(self, prefix: str, dir: str, _d: dict = {}):
+        self.prefix = prefix
+        self.prefix = prefix
+        self.fio_proc_num = 1  # default
+        self.suite = {}
+        if _d:
+            for key, value in _d.items():
+                setattr(self, key, value)
+
+    def _parse_by_split(self, seed):
+        """
+        Parses a seed by splitting the seed on '_'
+        """
+        splitted = re.split("_", self.seed)
+        for x in splitted:
+            for k, v in self.tr_spec_re.items():
+                match = v.match(x)
+                if match:
+                    groups = match.groups()
+                    setattr(self, k, groups[0])
+                continue
+
+    def parse_test_run(self, string: str):
+        """
+        Applies the global regexes above to split the string into its known components
+        """
+        match = self.RE_RUN_SPEC.match(string)
+        if match:
+            groups = match.groups()
+            for i, key in enumerate(self.tr_spec_re.keys()):
+                setattr(self, key, groups[i])
+
+    def get_test_result(self, workload):
+        """
+        Generates a string according to the run_fio.sh convention
+        TEST_RESULT=${TEST_PREFIX}_${NUM_PROCS}procs_${map[${WORKLOAD}]}
+        """
+        return f"{self.prefix}_{self.fio_proc_num}procs_{workload}"
+
+    def get_test_run_filenames(self, test_result):
+        """
+        Produce the list of corresponding filenames produced by the fio-parse-jsons.py script
+        during postprocessing
+        The keys are used to indicate which data to compare
+
+        Note that the actual output from FIO has the following convention:
+        fio_cyan_8osd_5reactor_8fio_default_lt_16job_16io_4k_randread_p0.json
+        fio_${TEST_NAME}.json
+        where
+         TEST_NAME=${TEST_PREFIX}_${job}job_${io}io_${BLOCK_SIZE_KB}_${map[${WORKLOAD}]}_p${i}
+        """
+        return {
+            # params to jc to produce top_pid_json
+            "top_out": f"{test_result}_top.out",
+            "top_json": f"{test_result}_top.json",
+            # params to parse-top.py:
+            "top_pid_json": f"{test_result}_pid.json",
+            "cpu_avg_json": f"{test_result}_cpu_avg.json",  # aka OSD_CPU_AVG
+            # params to fio-parse-jsons:
+            "osd_test_list": f"{test_result}_list",
+            "tr_table_json": f"{test_result}.json",  # source for comparison
+            "disk_stat_json": f"{test_result}_diskstat.json",
+            "_dat": f"{test_result}.dat",
+        }
+
+    def gen_typical_suite(self):
+        """
+        Generates a dictionary with keys the test run specs for the four typical workloads
+        Can be used to traverse a given dir and examine the corresponding response Latency
+        data to produce a comparison chart
+        """
+        for wk in self._workloads:
+            tr = self.get_test_result(wk)
+            trd = self.get_test_run_filenames(tr)
+            self.suite[tr] = trd
+            # self.suite.update({tr: trd})
+
+            # For comparison: this is a TestRunTable:
+            # cyan_3osd_3react_unbal_1procs_randread_d/cyan_3osd_3react_unbal_1procs_randread.json
+            # This is the corresponding _dat:
+            # cyan_3osd_3react_unbal_1procs_randread.dat
+            # and these the indiv CPU/MEM (continuous in time for the response latency)
+            # FIO_cyan_3osd_3react_unbal_1procs_randread_top_cpu.dat
+            # OSD_cyan_3osd_3react_unbal_1procs_randread_top_cpu.dat


### PR DESCRIPTION
This PR introduces some new tools:

- `report_gen.py` - script that traverses the dir tree to select .JSON entries to produce a report in .tex (uses some existing templates with contents to add, like the header, table of contents, etc.)
- `diskstat_diff.py` - script to filter disk utilisation, producing a .JSON as result, ready to plot, etc.
- `top-parser.py` - script to filter .JSON files from top (translated by jc), calculating averages for CPU and MEM utilisation, used to combine this data with .JSON from FIO.
- `gnuplot_plate.py` - thin wrapper around gnuplot to generate Response latency curves (hockey stick performance charts). 
- `gen_json_xtractor.py, test_run_spec.py` - refactoring of fio-parse-jsons.py into modules that can be reused by other tools.

## Usage:

All the scripts have a --help option to provide guide of usage.
* parse-top.py:
```bash
    cat ${TEST_RESULT}_top.out | jc --top --pretty > ${TEST_RESULT}_top.json
    python3 /root/bin/parse-top.py --config=${TEST_RESULT}_top.json --cpu="${OSD_CORES}" --avg=${OSD_CPU_AVG} \
          --pids=${TOP_PID_JSON} 2>&1 > /dev/null
```
will produce a ${TEST_RESULT}_cpu_avg.json file as output (in the specified dir).

* diskstat_diff.py: the following snippet illustrates taking two samples, one before and one after the test execution, the script calculates the difference and produces the result updating the given file name as argument:

```bash
# Take diskstats measurements before FIO instances
      jc --$pretty /proc/diskstats > ${DISK_STAT}

# Measure the diskstats after the completion of FIO
      jc --pretty /proc/diskstats | python3 /root/bin/diskstat_diff.py -a ${DISK_STAT}

```
