### PR TITLE
Add tools and code to produce hockey stick curves for a test run from a PR 319 format json results file

### DIFF
--- a/plot_results.py
+++ b/plot_results.py
@@ -1,0 +1,119 @@
+"""
+A file containing the classes and code required to read a file stored in the common
+intermediate format introduced in PR 319 (https://github.com/ceph/cbt/pull/319) and produce a hockey-stick curve graph
+"""
+
+import json
+from logging import Logger, getLogger
+from pathlib import Path
+from typing import Dict, List, Union
+
+import matplotlib.pyplot as plotter
+
+log: Logger = getLogger("cbt")
+
+
+class PlotResults:
+    """
+    Read the intermediate data file in the common json format and produce a hockey-stick
+    curve plot that includes standard deviation error bars.
+    """
+
+    # A converted between the operation type in the intermediate file format
+    # and a human-readable string that can be used in the title for the plot.
+    TITLE_CONVERSION: Dict[str, str] = {
+        "read": "Sequential Read",
+        "write": "Sequential Write",
+        "randread": "Random Read",
+        "randwrite": "Random Write",
+        "readwrite": "Sequential Read/Write",
+        "randrw": "Random Read/Write",
+    }
+
+    def __init__(self, archive_directory: str) -> None:
+        self._data_directory: str = f"{archive_directory}/visualisation"
+
+        self._path: Path = Path(self._data_directory)
+
+    def draw_and_save(self) -> None:
+        """
+        Produce the plot files for each of the intermediate data files in the given directory.
+        """
+
+        for file_path in self._path.glob("*.json"):
+            file_data: Dict[str, Union[str, Dict[str, str]]] = self._read_intermediate_file(f"{file_path}")
+            output_file: str = f"{str(file_path)[:-4]}png"
+            plot_title: str = self._generate_plot_title(file_path.parts[-1])
+
+            keys: List[str] = [key for key in file_data.keys() if isinstance(file_data[key], dict)]
+            plot_data: Dict[str, Dict[str, str]] = {}
+            sorted_plot_data: Dict[str, Dict[str, str]] = {}
+            for key, data in file_data.items():
+                if isinstance(data, dict):
+                    plot_data[key] = data
+
+            sorted_keys: List[str] = sorted(keys, key=int)
+            for key in sorted_keys:
+                sorted_plot_data[key] = plot_data[key]
+
+            x_axis: List[Union[int, float]] = []
+            y_axis: List[Union[int, float]] = []
+            error_bars: List[float] = []
+
+            log.info("converting file %s", f"{file_path}")
+
+            for _, data in sorted_plot_data.items():
+                # for blocksize less than 64K we want to use the bandwidth to plot the graphs,
+                # otherwise we should use iops.
+                blocksize: int = int(int(data["blocksize"]) / 1024)
+                if blocksize < 64:
+                    # convert bytes to Mb, not Mib, so use 1000s rather than 1024
+                    x_axis.append(float(data["bandwidth_bytes"]) / (1000 * 1000))
+                    plotter.xlabel("Bandwidth (MB)")  # pyright: ignore[reportUnknownMemberType]
+                else:
+                    x_axis.append(float(data["iops"]))
+                    plotter.xlabel("IOps")  # pyright: ignore[reportUnknownMemberType]
+                    # The stored values are in ns, we want to convert to ms
+                y_axis.append(float(data["latency"]) / (1000 * 1000))
+                plotter.ylabel("Latency (ms)")  # pyright: ignore[reportUnknownMemberType]
+                error_bars.append(float(data["std_deviation"]) / (1000 * 1000))
+
+                plotter.title(plot_title)  # pyright: ignore[reportUnknownMemberType]
+                plotter.errorbar(x_axis, y_axis, error_bars, capsize=3, ecolor="red")  # pyright: ignore[reportUnknownMemberType]
+                plotter.savefig(output_file, format="png")  # pyright: ignore[reportUnknownMemberType]
+                # Now we have saved the file, clear the plot for the next file
+                plotter.clf()
+
+    def _read_intermediate_file(self, file_path: str) -> Dict[str, Union[str, Dict[str, str]]]:
+        """
+        Read the json data from the intermediate file and store it for processing.
+        """
+        data: Dict[str, Union[str, Dict[str, str]]] = {}
+        # We know the file encoding as we wrote it ourselves as part of
+        # common_output_format.py, so it is safe to specify here
+        with open(f"{file_path}", "r", encoding="utf8") as file_data:
+            data = json.load(file_data)
+
+        return data
+
+    def _generate_plot_title(self, source_file: str) -> str:
+        """
+        Given the Path object for the input file, generate the title for the
+        data plot
+        """
+        # Strip the .json from the file name as we don't need it
+        title_with_underscores: str = f"{source_file[:-5]}"
+        parts: List[str] = title_with_underscores.split("_")
+
+        # The filename is in one of 2 formats:
+        #    BLOCKSIZE_OPERATION.json
+        #    BLOCKSIZE_READ_WRITE_OPERATION.json
+        #
+        # The split on _ will mean that the last element [-1] will always be
+        # the operation, and the first part [0] will be the blocksize
+        title: str = f"{int(int(parts[0][:-1]) / 1024)}K "
+        if len(parts) > 2:
+            title += f"{parts[1]}/{parts[2]} "
+
+        title += f"{self.TITLE_CONVERSION[parts[-1]]}"
+        return title

--- a/plotter/common_format_plotter.py
+++ b/plotter/common_format_plotter.py
@@ -1,0 +1,262 @@
+"""
+A file containing the classes and code required to read a file stored in the common
+intermediate format introduced in PR 319 (https://github.com/ceph/cbt/pull/319) and produce a hockey-stick curve graph
+"""
+
+import json
+import os
+from abc import ABC, abstractmethod
+from logging import Logger, getLogger
+from pathlib import Path
+from types import ModuleType
+from typing import Optional, Union
+
+plot_data_type = dict[str, dict[str, str]]
+common_format_data_type = dict[str, Union[str, dict[str, str]]]
+
+log: Logger = getLogger(f"{os.path.basename(__file__)}")
+
+
+class CommonFormatPlotter(ABC):
+    """ """
+
+    # A converted between the operation type in the intermediate file format
+    # and a human-readable string that can be used in the title for the plot.
+    TITLE_CONVERSION: dict[str, str] = {
+        "read": "Sequential Read",
+        "write": "Sequential Write",
+        "randread": "Random Read",
+        "randwrite": "Random Write",
+        "readwrite": "Sequential Read/Write",
+        "randrw": "Random Read/Write",
+    }
+
+    @abstractmethod
+    def draw_and_save(self) -> None:
+        """
+        Produce the plot file(s) for each of the intermediate data files in the
+        given directory and save them to disk
+        """
+
+    @abstractmethod
+    def _generate_output_file_name(self, files: list[Path]) -> str:
+        """
+        Generate the name for the file the plot will be saved to.
+        """
+
+    def _add_title(self, plotter: ModuleType, source_files: list[Path]) -> None:
+        """
+        Given the source file full path, generate the title for the
+        data plot and add it to the plot
+        """
+
+        title: str = ""
+
+        if len(source_files) == 1:
+            title = self._construct_title_from_file_name(source_files[0].parts[-1])
+        else:
+            title = self._construct_title_from_list_of_file_names(source_files)
+
+        plotter.title(title)
+
+    def _construct_title_from_list_of_file_names(self, file_paths: list[Path]) -> str:
+        """
+        Given a list of file paths construct a plot title.
+
+        If there is a common element then the title will be
+        '<common_element> comparison'
+        e.g if all files had a blocksize = 16K the title would be
+        '16k blocksize comparison'
+        """
+        titles: list[tuple[str, str, str]] = []
+        blocksizes: list[str] = []
+        read_percents: list[str] = []
+        operations: list[str] = []
+
+        for file in file_paths:
+            (blocksize, read_percent, operation) = self._get_blocksize_percentage_operation_from_file_name(
+                file.parts[-1]
+            )
+            titles.append((blocksize, read_percent, operation))
+
+            if blocksize not in blocksizes:
+                blocksizes.append(blocksize)
+            if read_percent not in read_percents:
+                read_percents.append(read_percent)
+            if operation not in operations:
+                operations.append(operation)
+
+        if len(blocksizes) == 1:
+            return f"{blocksizes[0]} blocksize comparison"
+
+        if len(operations) == 1 and len(read_percents) == 1:
+            return f"{read_percents[0]} {operations[0]} comparison"
+
+        if len(operations) == 1:
+            return f"{operations[0]} comparison"
+
+        title: str = " ".join(titles.pop(0))
+        for details in titles:
+            title += "\nVs "
+            title += " ".join(details)
+
+        return title
+
+    def _construct_title_from_file_name(self, file_name: str) -> str:
+        """
+        given a single file name construct a plot title from the blocksize,
+        read percent and operation contained in the title
+        """
+        (blocksize, read_percent, operation) = self._get_blocksize_percentage_operation_from_file_name(file_name)
+
+        return f"{blocksize} {read_percent} {operation}"
+
+    def _get_blocksize_percentage_operation_from_file_name(self, file_name: str) -> tuple[str, str, str]:
+        """
+        Return the blocksize from the filename
+        """
+        file_parts: list[str] = file_name[:-5].split("_")
+
+        # The filename is in one of 2 formats:
+        #    BLOCKSIZE_OPERATION.json
+        #    BLOCKSIZE_READ_WRITE_OPERATION.json
+        #
+        # The split on _ will mean that the last element [-1] will always be
+        # the operation, and the first part [0] will be the blocksize
+        operation: str = f"{self.TITLE_CONVERSION[file_parts[-1]]}"
+        blocksize: str = f"{int(int(file_parts[0][:-1]) / 1024)}K"
+        read_percent: str = ""
+
+        if len(file_parts) > 2:
+            read_percent = f"{file_parts[1]}/{file_parts[2]} "
+
+        return (blocksize, read_percent, operation)
+
+    def _set_axis(self, plotter: ModuleType, maximum_values: Optional[tuple[int, int]] = None) -> None:
+        """
+        Set the range for the plot axes.
+
+        maximum_values is a
+
+        This will start from 0, with a maximum
+        """
+        maximum_x: Optional[int] = None
+        maximum_y: Optional[int] = None
+
+        if maximum_values is not None:
+            maximum_x = maximum_values[0]
+            maximum_y = maximum_values[1]
+
+        plotter.xlim(0, maximum_x)
+        plotter.ylim(0, maximum_y)
+
+    def _sort_plot_data(self, unsorted_data: common_format_data_type) -> plot_data_type:
+        """
+        Sort the data read from the file by queue depth
+        """
+        keys: list[str] = [key for key in unsorted_data.keys() if isinstance(unsorted_data[key], dict)]
+        plot_data: plot_data_type = {}
+        sorted_plot_data: plot_data_type = {}
+        for key, data in unsorted_data.items():
+            if isinstance(data, dict):
+                plot_data[key] = data
+
+        sorted_keys: list[str] = sorted(keys, key=int)
+        for key in sorted_keys:
+            sorted_plot_data[key] = plot_data[key]
+
+        return sorted_plot_data
+
+    def _add_single_file_data_with_errorbars(self, plotter: ModuleType, file_data: common_format_data_type) -> None:
+        """
+        Add the data from a single file to a plot. Include error bars. Each point
+        in the plot is the latency vs IOPs or bandwidth for a given queue depth.
+
+        The plot will have red error bars with a blue plot line
+        """
+
+        sorted_plot_data: plot_data_type = self._sort_plot_data(file_data)
+
+        x_data: list[Union[int, float]] = []
+        y_data: list[Union[int, float]] = []
+        error_bars: list[float] = []
+
+        for _, data in sorted_plot_data.items():
+            # for blocksize less than 64K we want to use the bandwidth to plot the graphs,
+            # otherwise we should use iops.
+            blocksize: int = int(int(data["blocksize"]) / 1024)
+            if blocksize >= 64:
+                # convert bytes to Mb, not Mib, so use 1000s rather than 1024
+                x_data.append(float(data["bandwidth_bytes"]) / (1000 * 1000))
+                plotter.xlabel("Bandwidth (MB/s)")
+            else:
+                x_data.append(float(data["iops"]))
+                plotter.xlabel("IOps")
+                # The stored values are in ns, we want to convert to ms
+            y_data.append(float(data["latency"]) / (1000 * 1000))
+            plotter.ylabel("Latency (ms)")
+            error_bars.append(float(data["std_deviation"]) / (1000 * 1000))
+
+        plotter.errorbar(x_data, y_data, error_bars, capsize=3, ecolor="red")
+
+    def _add_single_file_data(self, plotter: ModuleType, file_data: common_format_data_type, label: str) -> None:
+        """
+        Add the data from a single file to a plot.
+
+        This will be a line of colour with data points marked by a small cross,
+        and no error bars.
+        """
+        sorted_plot_data: plot_data_type = self._sort_plot_data(file_data)
+
+        x_data: list[Union[int, float]] = []
+        y_data: list[Union[int, float]] = []
+
+        blocksize: int = 0
+
+        for _, data in sorted_plot_data.items():
+            # for blocksize less than 64K we want to use the bandwidth to plot the graphs,
+            # otherwise we should use iops.
+            blocksize = int(int(data["blocksize"]) / 1024)
+            if blocksize >= 64:
+                # convert bytes to Mb, not Mib, so use 1000s rather than 1024
+                x_data.append(float(data["bandwidth_bytes"]) / (1000 * 1000))
+                plotter.xlabel("Bandwidth (MB/s)")
+            else:
+                x_data.append(float(data["iops"]))
+                plotter.xlabel("IOps")
+                # The stored values are in ns, we want to convert to ms
+            y_data.append(float(data["latency"]) / (1000 * 1000))
+            plotter.ylabel("Latency (ms)")
+
+        # The "+-" here indicates a solid line with crosses at the data points
+        plotter.plot(x_data, y_data, "+-", label=label)
+
+    def _read_intermediate_file(self, file_path: str) -> common_format_data_type:
+        """
+        Read the json data from the common intermediate file and store it for processing.
+        """
+        data: common_format_data_type = {}
+        # We know the file encoding as we wrote it ourselves as part of
+        # common_output_format.py, so it is safe to specify here
+
+        try:
+            with open(f"{file_path}", "r", encoding="utf8") as file_data:
+                data = json.load(file_data)
+        except FileNotFoundError:
+            log.exception("File %s does not exist", file_path)
+        except IOError:
+            log.error("Error reading file %s", file_path)
+
+        return data
+
+    def _save_plot(self, plotter: ModuleType, file_path: str) -> None:
+        """
+        save the plot to disk as a png file
+        """
+        plotter.savefig(file_path, format="png")
+
+    def _clear_plot(self, plotter: ModuleType) -> None:
+        """
+        Clear the plot data
+        """
+        plotter.clf()

--- a/plotter/directory_comparison_plotter.py
+++ b/plotter/directory_comparison_plotter.py
@@ -1,0 +1,74 @@
+"""
+A file containing the classes and code required to read two files stored in the common
+intermediate format introduced in CBT PR #319 (https://github.com/ceph/cbt/pull/319)
+and produce a plot of both the files on the same axes.
+"""
+
+from logging import Logger, getLogger
+from pathlib import Path
+
+import matplotlib.pyplot as plotter
+
+from plotter.common_format_plotter import CommonFormatPlotter, common_format_data_type
+
+log: Logger = getLogger("cbt")
+
+
+class DirectoryComparisonPlotter(CommonFormatPlotter):
+    """
+    Read the intermediate data files in the common json format and produce a
+    curve plot of both sets of data on the same axes. Error bars are not included
+    as they seem to make the plot harder to read and compare.
+    """
+
+    def __init__(self, output_directory: str, directories: list[str]) -> None:
+        self._output_directory: str = f"{output_directory}"
+        self._comparison_directories: list[Path] = [Path(f"{directory}/visualisation") for directory in directories]
+
+    def draw_and_save(self) -> None:
+        # output_file_path: str = self._generate_output_file_name(files=self._comparison_directories)
+
+        # We will only compare data for files with the same name, so find all
+        # the file names that are common across all directories. Not sure this
+        # is the right way though
+        common_file_names: list[str] = self._find_common_file_names()
+
+        for file_name in common_file_names:
+            output_file_path: str = self._generate_output_file_name(files=[Path(file_name)])
+            for directory in self._comparison_directories:
+                file_data: common_format_data_type = self._read_intermediate_file(f"{directory}/{file_name}")
+                # we choose the last directory name for the label to apply to the data
+                self._add_single_file_data(
+                    plotter=plotter,
+                    file_data=file_data,
+                    label=f"{directory.parts[-2]}",
+                )
+
+            self._add_title(plotter=plotter, source_files=[Path(file_name)])
+            self._set_axis(plotter=plotter)
+
+            # make sure we add the legend to the plot
+            plotter.legend()  # pyright: ignore[reportUnknownMemberType]
+
+            self._save_plot(plotter=plotter, file_path=output_file_path)
+            self._clear_plot(plotter=plotter)
+
+    def _generate_output_file_name(self, files: list[Path]) -> str:
+        # we know we will only ever be passed a single file name
+        output_file: str = f"{self._output_directory}/Comparison_{files[0].parts[-1][:-4]}png"
+
+        return output_file
+
+    def _find_common_file_names(self) -> list[str]:
+        """
+        Find a list of file names that are common to all directories in
+        a list of directories.
+        """
+        common_files: set[str] = set(path.parts[-1] for path in self._comparison_directories[0].glob("*.json"))
+
+        # first find all the common paths between all the directories
+        for index in range(1, (len(self._comparison_directories) - 1)):
+            files: set[str] = set(path.parts[-1] for path in self._comparison_directories[index].glob("*.json"))
+            common_files = common_files.intersection(files)
+
+        return list(common_files)

--- a/plotter/file_comparison_plotter.py
+++ b/plotter/file_comparison_plotter.py
@@ -1,0 +1,78 @@
+"""
+A file containing the classes and code required to read two files stored in the common
+intermediate format introduced in CBT PR #319 (https://github.com/ceph/cbt/pull/319)
+and produce a plot of both the files on the same axes.
+"""
+
+from logging import Logger, getLogger
+from pathlib import Path
+from typing import Optional
+
+import matplotlib.pyplot as plotter
+
+from plotter.common_format_plotter import CommonFormatPlotter, common_format_data_type
+
+log: Logger = getLogger("cbt")
+
+
+class FileComparisonPlotter(CommonFormatPlotter):
+    """
+    Read the intermediate data files in the common json format and produce a
+    curve plot of both sets of data on the same axes. Error bars are not included
+    as they seem to make the plot harder to read and compare.
+    """
+
+    def __init__(self, output_directory: str, files: list[str], labels: Optional[list[str]] = None) -> None:
+        self._output_directory: str = f"{output_directory}"
+        self._comparison_files: list[Path] = [Path(file) for file in files]
+        self._labels: Optional[list[str]] = None
+
+    def draw_and_save(self) -> None:
+        output_file_path: str = self._generate_output_file_name(files=self._comparison_files)
+
+        for file_path in self._comparison_files:
+            index: int = self._comparison_files.index(file_path)
+            file_data: common_format_data_type = self._read_intermediate_file(f"{file_path}")
+
+            operation_details: tuple[str, str, str] = self._get_blocksize_percentage_operation_from_file_name(
+                file_name=file_path.parts[-1]
+            )
+
+            # If we have a label use it, otherwise set the label from the
+            # filename. We can reliably do this as we create the file name when
+            # we save the intermediate file.
+            label: str = ""
+            if self._labels is not None:
+                label = self._labels[index]
+
+            if label == "":
+                label = " ".join(operation_details)
+
+            self._add_single_file_data(plotter=plotter, file_data=file_data, label=label)
+
+        # make sure we add the legend to the plot
+        plotter.legend()  # pyright: ignore[reportUnknownMemberType]
+
+        self._add_title(plotter=plotter, source_files=self._comparison_files)
+        self._set_axis(plotter=plotter)
+        self._save_plot(plotter=plotter, file_path=output_file_path)
+        self._clear_plot(plotter=plotter)
+
+    def set_labels(self, labels: list[str]) -> None:
+        """
+        Set the labels for the plot lines
+        """
+        self._labels = labels
+
+    def _generate_output_file_name(self, files: list[Path]) -> str:
+        output_file: str = f"{self._output_directory}/Comparison"
+
+        for file_path in files:
+            # get the actual file name - this will be the last part of the path
+            file_name = file_path.parts[-1]
+            # strip off the .json extension from each file
+            file: str = file_name[:-5]
+
+            output_file += f"_{file}"
+
+        return f"{output_file}.png"

--- a/plotter/simple_plotter.py
+++ b/plotter/simple_plotter.py
@@ -1,0 +1,36 @@
+"""
+A file containing the classes and code required to read a file stored in the common
+intermediate format introduced in PR 319 (https://github.com/ceph/cbt/pull/319) and
+produce a hockey-stick curve graph
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plotter
+
+from plotter.common_format_plotter import CommonFormatPlotter, common_format_data_type
+
+
+class SimplePlotter(CommonFormatPlotter):
+    """
+    Read the intermediate data file in the common json format and produce a hockey-stick
+    curve plot that includes standard deviation error bars.
+    """
+
+    def __init__(self, archive_directory: str) -> None:
+        # A Path object for the directory where the data files are stored
+        self._path: Path = Path(f"{archive_directory}/visualisation")
+
+    def draw_and_save(self) -> None:
+        for file_path in self._path.glob("*.json"):
+            file_data: common_format_data_type = self._read_intermediate_file(f"{file_path}")
+            output_file_path: str = self._generate_output_file_name(files=[file_path])
+            self._add_single_file_data_with_errorbars(plotter=plotter, file_data=file_data)
+            self._add_title(plotter=plotter, source_files=[file_path])
+            self._set_axis(plotter=plotter)
+            self._save_plot(plotter=plotter, file_path=output_file_path)
+            self._clear_plot(plotter=plotter)
+
+    def _generate_output_file_name(self, files: list[Path]) -> str:
+        # we know we will only ever be passed a single file name
+        return f"{str(files[0])[:-4]}png"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml
 lxml
+matplotlib

--- a/tools/plot_comparison.py
+++ b/tools/plot_comparison.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env -S python3 -B
+
+"""
+Draws a plot on a single set of axes of data from the two or more files specified
+by --files, or all the common files between the directories specified by
+--directories.
+The resulting plot(s) are saved in the specified output directory.
+The files must be in the correct json format, as described by CBT PR 319 
+(https://github.com/ceph/cbt/pull/319)
+
+Optionally a label for each file can be specified which is used to generate the
+legend for the plot.
+
+Usage:
+        plot_comparison.py  --files=<comma_separated_list_of_files_to_compare>
+                            --directories=<comma_separated_list_of_directories_to_compare>
+                            --output_directory=<full_path_to_directory_to_store_plot>
+                            --labels="<comma_separated_list_of_labels>
+
+    Both files must be in the intermediate format generated from
+    fio_common_output_wrapper.py
+
+
+Input:
+        --output_directory  [Required] The directory to write the comparison plot
+                                to. If this does not exists it will be created.
+                                
+        --files         [Optional] A comma separated list of the full path to
+                            the files, in the correct format, to plot on a
+                            single set of axes. 
+
+        --directories   [Optional] A comma separated list of directories that
+                            contain a set of files, in the correct format, to
+                            plot. Any files that have a common name in all the
+                            directories will be plotted on a single set of axes.
+
+
+            One of --files or --directories must be provided
+
+        --labels        [Optional] The labels to use on the comparison plot for
+                            the data from the corresponding file in --files. 
+                            The labels are applied to the files in the order
+                            they are given, so the first label would be applied
+                            to the data from the first file.
+        
+Examples:
+
+    Plot the results from two files, /tmp/ch_cbt_main_run/16384B_randread.json and
+    /tmp/ch_cbt_sb_run/16384B_randread.json on the same axes, applying label
+    'Main 2024/12/18' to the data from /tmp/ch_cbt_main_run/16384B_randread.json
+    and 'ch_wip_graphing sandbox' to the data from /tmp/ch_cbt_sb_run/16384B_randread.json
+         
+        plot_comparison.py  --files="/tmp/ch_cbt_main_run/16384B_randread.json," \
+                                    "/tmp/ch_cbt_sb_run/16384B_randread.json" \
+                            --output_directory="/tmp/comparisons" \
+                            --labels="Main 2024/12/18,ch_wip_graphing sandbox"
+
+    Plot a comparison on a single axes for each common file in directories 
+    /tmp/ch_cbt_main_run/visualisation and /tmp/ch_cbt_sb_run/visualisation.
+    The labels used for each directory will be ch_cbt_main_run and ch_cbt_main_run
+
+        plot_comparison.py  --directories="/tmp/ch_cbt_main_run,/tmp/ch_cbt_main_run"
+                            --output_directory="/tmp/main_sb_comparisons"
+
+    Plot a comparison between two files on the same axes, using the default
+    labels
+
+        plot_comparison.py  --files="/tmp/ch_cbt_main_run/16384B_randread.json," \
+                                    "/tmp/ch_cbt_sb_run/4096B_randread.json" \
+                            --output_directory="/tmp/bs_comparisons"
+"""
+
+import os
+import subprocess
+from argparse import ArgumentParser, Namespace
+from logging import INFO, Logger, basicConfig, getLogger
+
+from plotter.common_format_plotter import CommonFormatPlotter
+from plotter.directory_comparison_plotter import DirectoryComparisonPlotter
+from plotter.file_comparison_plotter import FileComparisonPlotter
+
+log: Logger = getLogger(f"{os.path.basename(__file__)}")
+
+
+def main() -> int:
+    """
+    Main routine for the script
+    """
+
+    result: int = 0
+
+    description: str = "Draws a plot on a single set of axes of data from the two or more files specified\n"
+    description += "by --files, or all the common files between the directories specified by\n"
+    description += "--directories.\n\n"
+    description += "The resulting plot(s) are saved in the specified output directory.\n"
+    description += "The files must be in the correct json format, as described by CBT PR 319\n"
+    description += "(https://github.com/ceph/cbt/pull/319)"
+
+    parser: ArgumentParser = ArgumentParser(description=description)
+
+    parser.add_argument(
+        "--output_directory",
+        type=str,
+        required=True,
+        help="The directory to store the comparison plot file(s)",
+    )
+    parser.add_argument(
+        "--files",
+        type=str,
+        required=False,
+        default=None,
+        help="A comma separated list of two or more file paths to compare",
+    )
+    parser.add_argument(
+        "--directories",
+        type=str,
+        required=False,
+        help="A comma separated list of two or more directories containing the files to compare",
+    )
+    parser.add_argument(
+        "--labels",
+        type=str,
+        required=False,
+        default="",
+        help="A comma separated list of labels to use for the plots.\nMust be in the same order as the files in --files"
+        + "Not used with the --direectories option",
+    )
+
+    arguments: Namespace = parser.parse_args()
+
+    check_arguments(arguments)
+    # will only create the directory if it does not already exist
+    subprocess.run(f"mkdir -p -m0755 {arguments.output_directory}", shell=True)
+
+    plotter: CommonFormatPlotter
+
+    if arguments.files:
+        comparison_files: list[str] = arguments.files.split(",")
+
+        plotter = FileComparisonPlotter(arguments.output_directory, comparison_files)
+
+        if arguments.labels:
+            labels: list[str] = arguments.labels.split(",")
+            plotter.set_labels(labels)
+
+    if arguments.directories:
+        comparison_directories: list[str] = arguments.directories.split(",")
+
+        plotter = DirectoryComparisonPlotter(arguments.output_directory, comparison_directories)
+
+    assert isinstance(plotter, CommonFormatPlotter)  # pyright: ignore[reportPossiblyUnboundVariable]
+    try:
+        plotter.draw_and_save()
+    except Exception:
+        log.exception("Encountered an error plotting results")
+        result = 1
+
+    return result
+
+
+def check_arguments(arguments: Namespace) -> None:
+    """
+    Validate that the correct arguments have been passed to the script
+    """
+    if arguments.files and arguments.directories:
+        log.error("Both --files and --directories has been specified")
+        exit(1)
+
+    if arguments.labels and not arguments.files:
+        log.error("--labels has been specified without --files")
+        exit(1)
+
+
+def initialise_logging() -> None:
+    """
+    Set up all the logging for the
+    """
+    basicConfig(level=INFO, format="%(name)-20s: %(levelname)-8s %(message)s")
+
+
+if __name__ == "__main__":
+    initialise_logging()
+    main()


### PR DESCRIPTION
This PR is the second piece of work to get to the point where we can automatically produce plots from a CBT run.
At the moment it will only work with fio test runs, but the plan is to extend it in future to work with any set of CBT results

It follows on from [PR 319](https://github.com/ceph/cbt/pull/319) and uses the common format file as a basis for each plot.

The code is structured in such a way that it can be called from existing CBT code, or run as a stand-alone python script, which is included in this PR.

### New dependencies
The code uses the [matplotlib.pyplot](https://matplotlib.org/) library to generate the graphs, so this has been added to the requirements.txt file

The included python script can be used to plot multiple curves on a single image.
This can be 2 or more specified json files in the PR 319 format, in which case a comparison of the individual runs will be plotted.
If 2 or more directories of results are specified then a plot will be created for each common set of data in the given directories.
e.g. The 4K random read data from each directory will be plotted on a single curve.

## Example single plots
| | |
|-|-|
|![4096B_randwrite](https://github.com/user-attachments/assets/8161312f-af9c-4e1d-8b6a-69f019c5121b) | ![65536B_70_30_randrw](https://github.com/user-attachments/assets/94888072-e6b4-4cf3-9bf4-7268e363b251) |

## Example comparison plots
|Script Invocation |Generated Plot |
|-|-|
|~/cbt/tools/plot_comparison.py --files="/tmp/main_2024_06_19/visualisation/16384B_70_30_randrw.json,/tmp/main_2024_06_19/visualisation/65536B_70_30_randrw.json" --labels="test_branch,main squid" --output_directory="/tmp/graph_examples"|![Comparison_4096B_randwrite_8192B_randwrite](https://github.com/user-attachments/assets/711ad669-e90b-44d0-b228-1e5a0122f56f)|
|~/cbt/tools/plot_comparison.py --files="/tmp/main_2024_06_19/visualisation/16384B_70_30_randrw.json,/tmp/main_2024_06_19/visualisation/65536B_70_30_randrw.json" --labels="16K test_branch,64K main squid" --output_directory="/tmp/graph_examples"|![Comparison_16384B_70_30_randrw_65536B_70_30_randrw](https://github.com/user-attachments/assets/5a130efc-a02d-4aa3-969f-c67a9e9f90c7)|
|~/cbt/tools/plot_comparison.py --files="/tmp/main_2024_06_19/visualisation/32768B_read.json,/tmp/main_2024_06_19/visualisation/32768B_write.json" --labels="32K read test,32K write test" --output_directory="/tmp/graph_examples"|![Comparison_32768B_read_32768B_write](https://github.com/user-attachments/assets/8d450752-04f9-4510-84c8-d329d2eeadd8)| |

## Example directory comparison plots
script invocation: 
`~/cbt/tools/plot_comparison.py --directories="/tmp/cbt_10thNov_256kstripsize_lee-sanders4,/tmp/cbt_13thNov_256kstripsize_lee-sanders4_rerun,/tmp/cbt_15thNov_256kstripsize_main" --output_directory="/tmp/graph_examples"`
| | |
|-|-|
|![Comparison_4096B_read](https://github.com/user-attachments/assets/467ea8f3-4641-4b36-a3de-c52df1ade67e)|![Comparison_8192B_read](https://github.com/user-attachments/assets/502706ed-44f7-41a9-8dee-a94696f9038c)|
|![Comparison_65536B_read](https://github.com/user-attachments/assets/db1a7031-9639-414a-8b68-fd67e8fd2bc9)| |

## Testing
In addition to generating plots, examples of which are given above, a teuthology run of perf-basic using the code in this PR. Results links below

perf-basic
https://pulpito.ceph.com/harriscr-2024-12-16_11:14:02-perf-basic-wip-harriscr-cbt-refactor-2024-10-17-0839-distro-default-smithi/
All passed

rados/perf:
https://pulpito.ceph.com/harriscr-2024-12-16_11:31:31-rados:perf-wip-harriscr-cbt-refactor-2024-10-17-0839-distro-default-smithi/
3 failed with: cluster [WRN] Health check failed: 1 OSD(s) experiencing slow operations in BlueStore (BLUESTORE_SLOW_OP_ALERT)" in cluster log

crimson-rados/perf:
https://pulpito.ceph.com/harriscr-2024-12-16_11:40:54-crimson-rados:perf-wip-harriscr-cbt-refactor-2024-10-17-0839-distro-default-smithi/
All passed
