### PR TITLE
Add pre_condtime for preconditioning and allow multiple randrw workloads within the same YAML

### DIFF
--- a/tests/test_bm_librbdfio.py
+++ b/tests/test_bm_librbdfio.py
@@ -16,7 +16,7 @@ class TestBenchmarklibrbdfio(unittest.TestCase):
     cl_name = "tools/invariant.yaml"
     bl_name = "tools/baseline.json"
     bl_json = {}
-    bl_md5 = 'e6b6fcd2be74bd08939c64a249ab2125'
+    bl_md5 = '84dd2f3a66eab442cc3825e0d57a9e3f'
     md5_returned = None
 
     @classmethod
@@ -39,6 +39,12 @@ class TestBenchmarklibrbdfio(unittest.TestCase):
     def test_valid_baseline(self):
         """ Verify the baseline has not been compromised """
         self.assertEqual( self.bl_md5, str(self.md5_returned) )
+
+    def test_valid__ioddepth_per_volume(self):
+        """ Basic sanity attribute identity _ioddepth_per_volume check"""
+        b = benchmarkfactory.get_object(self.archive_dir,
+                                            self.cluster, 'librbdfio', self.iteration)
+        self.assertEqual(self.bl_json['librbdfio']['_ioddepth_per_volume'], b.__dict__['_ioddepth_per_volume'])
 
     def test_valid_archive_dir(self):
         """ Basic sanity attribute identity archive_dir check"""
@@ -207,6 +213,12 @@ class TestBenchmarklibrbdfio(unittest.TestCase):
         b = benchmarkfactory.get_object(self.archive_dir,
                                             self.cluster, 'librbdfio', self.iteration)
         self.assertEqual(self.bl_json['librbdfio']['pool_profile'], b.__dict__['pool_profile'])
+
+    def test_valid_precond_time(self):
+        """ Basic sanity attribute identity precond_time check"""
+        b = benchmarkfactory.get_object(self.archive_dir,
+                                            self.cluster, 'librbdfio', self.iteration)
+        self.assertEqual(self.bl_json['librbdfio']['precond_time'], b.__dict__['precond_time'])
 
     def test_valid_prefill_vols(self):
         """ Basic sanity attribute identity prefill_vols check"""

--- a/tools/baseline.json
+++ b/tools/baseline.json
@@ -727,6 +727,7 @@
         "vol_size": 58982.4
     },
     "librbdfio": {
+        "_ioddepth_per_volume": {},
         "acceptable": {},
         "archive_dir": "/tmp/results/00000000/id-83a653b5",
         "base_run_dir": "/tmp/cbt.XYZ/00000000/LibrbdFio",
@@ -865,6 +866,7 @@
         "pgs": 2048,
         "pool_name": "cbt-librbdfio",
         "pool_profile": "default",
+        "precond_time": null,
         "prefill_vols": {
             "blocksize": "4M",
             "numjobs": "1"


### PR DESCRIPTION
This PR only changes the functionality of workloads.

If workloads are in use, and there is a preconditioning step within the YAML, often users will want to run preconditioning for say 10 minutes, where as each other workload will run for a shorter period of time, this PR allows the user to override **time** with **precond_time** and specify **precond** within the preconditioning step to use the different time attribute.

Additionally, workloads with randrw only let you specify 1 mixed workload within a YAML as the same directory name was used for the subsequent randrw workloads, thus overwriting all the previous results in the archive directory with the later tests. This PR adds the readwrite ratio into the directory name if the mode is randrw.

The directory name for 100% read and 100% write tests are unaffected.