### PR TITLE
Fixes for post_processing code for the total_iodepth feature

### DIFF
--- a/post_processing/formatter/test_run_result.py
+++ b/post_processing/formatter/test_run_result.py
@@ -330,3 +330,5 @@ class TestRunResult:
                 iodepth = logfile_iodepth
 
         return str(iodepth)
+
+    __test__ = False

--- a/post_processing/formatter/test_run_result.py
+++ b/post_processing/formatter/test_run_result.py
@@ -320,10 +320,11 @@ class TestRunResult:
         # the logfile name is of the format:
         #  /tmp/cbt/00000000/LibrbdFio/randwrite_1048576/iodepth-001/numjobs-001/output.0
         iodepth_start_index: int = logfile_name.find("iodepth")
+        numjobs_start_index: int = logfile_name.find("numjobs")
         # an index of -1 is no match found, so do nothing
-        if iodepth_start_index != -1:
+        if iodepth_start_index != -1 and numjobs_start_index != -1:
             iodepth_end_index: int = iodepth_start_index + len("iodepth")
-            iodepth_string: str = logfile_name[iodepth_end_index + 1 : iodepth_end_index + 4]
+            iodepth_string: str = logfile_name[iodepth_end_index + 1 : numjobs_start_index - 1]
             logfile_iodepth: int = int(iodepth_string)
 
             if logfile_iodepth > iodepth:


### PR DESCRIPTION
With the inclusion of the total_iodepth feature in [PR324](https://github.com/ceph/cbt/pull/324) the post_processing modules now give eratic results. 
This is because currently the code uses the iodepth value from the fio logs, and not the total_iodepth value set as that is never passed to fio.

The temporary fix is to parse the total_iodepth number from the file path used for the fio results run via CBT (taken from the write_iops_log value stored in the fio output file.

A better fix can be done when the workloads code is split into its own module, and we can write the total_iodepth value somewhere that the post_processing code can read, or we have a better way to cnnect the fio results to the workload that ran it. Until then, this code will allow the post processing to work with the total_iodepth feature