### PR TITLE
Improvements to the report generation

### DIFF
--- a/post_processing/common.py
+++ b/post_processing/common.py
@@ -49,7 +49,7 @@ def get_blocksize_percentage_operation_from_file_name(file_name: str) -> tuple[s
     # the operation, and the first part [0] will be the blocksize
     operation: str = f"{TITLE_CONVERSION[file_parts[-1]]}"
     blocksize: str = get_blocksize(f"{file_parts[0]}")
-    blocksize = f"{int(blocksize) / 1024}K"
+    blocksize = f"{int(int(blocksize) / 1024)}K"
     read_percent: str = ""
 
     if len(file_parts) > 2:

--- a/post_processing/plotter/common_format_plotter.py
+++ b/post_processing/plotter/common_format_plotter.py
@@ -208,8 +208,11 @@ class CommonFormatPlotter(ABC):
     def _save_plot(self, plotter: ModuleType, file_path: str) -> None:
         """
         save the plot to disk as a png file
+
+        The bbox_inches="tight" option makes sure that the legend is included
+        in the plot and not cut off
         """
-        plotter.savefig(file_path, format=f"{PLOT_FILE_EXTENSION}")
+        plotter.savefig(file_path, format=f"{PLOT_FILE_EXTENSION}", bbox_inches="tight")
 
     def _clear_plot(self, plotter: ModuleType) -> None:
         """

--- a/post_processing/plotter/common_format_plotter.py
+++ b/post_processing/plotter/common_format_plotter.py
@@ -139,8 +139,8 @@ class CommonFormatPlotter(ABC):
 
         return sorted_plot_data
 
-    def _add_single_file_data_with_errorbars(
-        self, plotter: ModuleType, file_data: COMMON_FORMAT_FILE_DATA_TYPE
+    def _add_single_file_data_with_optional_errorbars(
+        self, plotter: ModuleType, file_data: COMMON_FORMAT_FILE_DATA_TYPE, plot_error_bars: bool
     ) -> None:
         """
         Add the data from a single file to a plot. Include error bars. Each point
@@ -154,6 +154,7 @@ class CommonFormatPlotter(ABC):
         x_data: list[Union[int, float]] = []
         y_data: list[Union[int, float]] = []
         error_bars: list[float] = []
+        capsize: int = 0
 
         for _, data in sorted_plot_data.items():
             # for blocksize less than 64K we want to use the bandwidth to plot the graphs,
@@ -169,9 +170,14 @@ class CommonFormatPlotter(ABC):
                 # The stored values are in ns, we want to convert to ms
             y_data.append(float(data["latency"]) / (1000 * 1000))
             plotter.ylabel("Latency (ms)")
-            error_bars.append(float(data["std_deviation"]) / (1000 * 1000))
 
-        plotter.errorbar(x_data, y_data, error_bars, capsize=3, ecolor="red")
+            if plot_error_bars:
+                error_bars.append(float(data["std_deviation"]) / (1000 * 1000))
+                capsize = 3
+            else:
+                error_bars.append(0)
+
+        plotter.errorbar(x_data, y_data, error_bars, capsize=capsize, ecolor="red")
 
     def _add_single_file_data(self, plotter: ModuleType, file_data: COMMON_FORMAT_FILE_DATA_TYPE, label: str) -> None:
         """

--- a/post_processing/plotter/directory_comparison_plotter.py
+++ b/post_processing/plotter/directory_comparison_plotter.py
@@ -54,7 +54,7 @@ class DirectoryComparisonPlotter(CommonFormatPlotter):
             self._set_axis(plotter=plotter)
 
             # make sure we add the legend to the plot
-            plotter.legend()  # pyright: ignore[reportUnknownMemberType]
+            plotter.legend(bbox_to_anchor=(0.5, -0.1), loc="upper center", ncol=2)  # pyright: ignore[reportUnknownMemberType]
 
             self._save_plot(plotter=plotter, file_path=output_file_path)
             self._clear_plot(plotter=plotter)

--- a/post_processing/plotter/file_comparison_plotter.py
+++ b/post_processing/plotter/file_comparison_plotter.py
@@ -57,8 +57,8 @@ class FileComparisonPlotter(CommonFormatPlotter):
 
             self._add_single_file_data(plotter=plotter, file_data=file_data, label=label)
 
-        # make sure we add the legend to the plot
-        plotter.legend()  # pyright: ignore[reportUnknownMemberType]
+        # make sure we add the legend to the plot, below the chart
+        plotter.legend(bbox_to_anchor=(0.5, -0.1), loc="upper center", ncol=2)  # pyright: ignore[reportUnknownMemberType]
 
         self._add_title(plotter=plotter, source_files=self._comparison_files)
         self._set_axis(plotter=plotter)

--- a/post_processing/plotter/simple_plotter.py
+++ b/post_processing/plotter/simple_plotter.py
@@ -24,15 +24,18 @@ class SimplePlotter(CommonFormatPlotter):
     curve plot that includes standard deviation error bars.
     """
 
-    def __init__(self, archive_directory: str) -> None:
+    def __init__(self, archive_directory: str, plot_error_bars: bool) -> None:
         # A Path object for the directory where the data files are stored
         self._path: Path = Path(f"{archive_directory}/visualisation")
+        self._plot_error_bars: bool = plot_error_bars
 
     def draw_and_save(self) -> None:
         for file_path in self._path.glob(f"*{DATA_FILE_EXTENSION_WITH_DOT}"):
             file_data: COMMON_FORMAT_FILE_DATA_TYPE = read_intermediate_file(f"{file_path}")
             output_file_path: str = self._generate_output_file_name(files=[file_path])
-            self._add_single_file_data_with_errorbars(plotter=plotter, file_data=file_data)
+            self._add_single_file_data_with_optional_errorbars(
+                plotter=plotter, file_data=file_data, plot_error_bars=self._plot_error_bars
+            )
             self._add_title(plotter=plotter, source_files=[file_path])
             self._set_axis(plotter=plotter)
             self._save_plot(plotter=plotter, file_path=output_file_path)
@@ -40,4 +43,4 @@ class SimplePlotter(CommonFormatPlotter):
 
     def _generate_output_file_name(self, files: list[Path]) -> str:
         # we know we will only ever be passed a single file name
-        return f"{str(files[0])[:-len(DATA_FILE_EXTENSION)]}{PLOT_FILE_EXTENSION}"
+        return f"{str(files[0])[: -len(DATA_FILE_EXTENSION)]}{PLOT_FILE_EXTENSION}"

--- a/post_processing/reports/report_generator.py
+++ b/post_processing/reports/report_generator.py
@@ -37,7 +37,10 @@ class ReportGenerator(ABC):
     # tex header file location
     BASE_HEADER_FILE_PATH: str = "include/performance_report.tex"
 
-    def __init__(self, archive_directories: str, output_directory: str) -> None:
+    def __init__(self, archive_directories: str, output_directory: str, no_error_bars: bool = False) -> None:
+        self._plot_error_bars: bool = not no_error_bars
+        print(f"CHDEBUG: self._plot_error_bars is {self._plot_error_bars}")
+
         self._archive_directories: list[Path] = []
         self._data_directories: list[Path] = []
         self._build_strings: list[str] = []

--- a/post_processing/reports/report_generator.py
+++ b/post_processing/reports/report_generator.py
@@ -37,9 +37,11 @@ class ReportGenerator(ABC):
     # tex header file location
     BASE_HEADER_FILE_PATH: str = "include/performance_report.tex"
 
-    def __init__(self, archive_directories: str, output_directory: str, no_error_bars: bool = False) -> None:
+    def __init__(
+        self, archive_directories: str, output_directory: str, no_error_bars: bool = False, force_refresh: bool = False
+    ) -> None:
         self._plot_error_bars: bool = not no_error_bars
-        print(f"CHDEBUG: self._plot_error_bars is {self._plot_error_bars}")
+        self._force_refresh: bool = force_refresh
 
         self._archive_directories: list[Path] = []
         self._data_directories: list[Path] = []

--- a/post_processing/reports/simple_report_generator.py
+++ b/post_processing/reports/simple_report_generator.py
@@ -129,7 +129,7 @@ class SimpleReportGenerator(ReportGenerator):
 
             # If there are no plotfiles in the directory then we should create them
             if len(plot_files) == 0:
-                plotter = SimplePlotter(str(directory.parent))
+                plotter = SimplePlotter(str(directory.parent), self._plot_error_bars)
                 plotter.draw_and_save()
                 plot_files.extend(list(directory.glob(f"*{PLOT_FILE_EXTENSION_WITH_DOT}")))
 

--- a/post_processing/reports/simple_report_generator.py
+++ b/post_processing/reports/simple_report_generator.py
@@ -128,7 +128,7 @@ class SimpleReportGenerator(ReportGenerator):
             plot_files.extend(list(directory.glob(f"*{PLOT_FILE_EXTENSION_WITH_DOT}")))
 
             # If there are no plotfiles in the directory then we should create them
-            if len(plot_files) == 0:
+            if len(plot_files) == 0 or self._force_refresh:
                 plotter = SimplePlotter(str(directory.parent), self._plot_error_bars)
                 plotter.draw_and_save()
                 plot_files.extend(list(directory.glob(f"*{PLOT_FILE_EXTENSION_WITH_DOT}")))

--- a/tools/generate_comparison_performance_report.py
+++ b/tools/generate_comparison_performance_report.py
@@ -163,7 +163,7 @@ def main() -> int:
         "--force_refresh",
         action="store_true",
         required=False,
-        help="Regenerate the inetrmediate files and plots, even if they exist",
+        help="Regenerate the intermediate files and plots, even if they exist",
     )
 
     arguments: Namespace = parser.parse_args()

--- a/tools/generate_comparison_performance_report.py
+++ b/tools/generate_comparison_performance_report.py
@@ -2,8 +2,10 @@
 """
 A script to automatically generate a report from a set of performance run data
 in the common intermediate format described in CBT PR 319.
-The archive should contain the 'visualisation' sub directory where all
-the .json and plot files reside.
+
+If the specified archive directories have not yet been converted into the common
+intermediate format (described in CBT PR319) that will be done as part of
+creating the report.
 
 tools/fio_common_output_wrapper.py will generate the .json files and the SimplePlotter
 module in CBT PR 321 can be used to generate the plot files
@@ -15,6 +17,7 @@ Usage:
                 --results_file_root="ch_json_result"
                 --output_directory=<full_path_to_directory_to_store_report>
                 --create_pdf
+                --force_refresh
 
 
 Input:
@@ -36,6 +39,9 @@ Input:
                                     file.
                                     This requires pandoc to be installed,
                                     and be on the path.
+
+        --force_refresh         [Optional] Generate the intermediate and plot files
+                                    from the raw data, even if they already exist
 
 Examples:
 
@@ -81,10 +87,8 @@ def generate_intermediate_files(arguments: Namespace) -> None:
     for directory in directories_of_interest:
         output_directory: str = f"{directory}/visualisation/"
 
-        if not os.path.exists(output_directory) or not os.listdir(output_directory):
+        if not os.path.exists(output_directory) or not os.listdir(output_directory) or arguments.force_refresh:
             # directory doesn't exist so we need o post-process the CBT results files first
-            os.makedirs(output_directory, exist_ok=True)
-
             log.debug("Creating directory %s" % output_directory)
             os.makedirs(output_directory, exist_ok=True)
 
@@ -155,6 +159,13 @@ def main() -> int:
         help="The filename root of all the CBT output json files",
     )
 
+    parser.add_argument(
+        "--force_refresh",
+        action="store_true",
+        required=False,
+        help="Regenerate the inetrmediate files and plots, even if they exist",
+    )
+
     arguments: Namespace = parser.parse_args()
 
     # will only create the output directory if it does not already exist
@@ -166,6 +177,7 @@ def main() -> int:
         report_generator = ComparisonReportGenerator(
             archive_directories=f"{arguments.baseline},{arguments.archives}",
             output_directory=arguments.output_directory,
+            force_refresh=arguments.force_refresh,
         )
         report_generator.create_report()
 

--- a/tools/generate_performance_report.py
+++ b/tools/generate_performance_report.py
@@ -13,6 +13,8 @@ Usage:
                                         --output_directory=<full_path_to_directory_to_store_report>
                                         --results_file_root="ch_json_result"
                                         --create_pdf
+                                        --no_error_bars
+                                        --force_refresh
 
 
 Input:
@@ -35,10 +37,13 @@ Input:
         --no_error_bars         [Optional] Do not draw error bars on the plots
                                     included in the report
 
+        --force_refresh         [Optional] Generate the intermediate and plot files
+                                    from the raw data, even if they already exist
+
 Examples:
 
     Generate a markdown report file for the results in '/tmp/squid_main' directory
-    ans sabve it in the '/tmp/main_results' directory:
+    ans save it in the '/tmp/main_results' directory:
 
     generate_performance_report.py  --archive=/tmp/squid_main
                                     --output_directory =/tmp/main_results
@@ -67,10 +72,8 @@ def generate_intermediate_files(arguments: Namespace) -> None:
     """ """
     output_directory: str = f"{arguments.archive}/visualisation/"
 
-    if not os.path.exists(output_directory) or not os.listdir(output_directory):
-        # directory doesn't exist so we need o post-process the CBT results files first
-        os.makedirs(output_directory, exist_ok=True)
-
+    if not os.path.exists(output_directory) or not os.listdir(output_directory) or arguments.force_refresh:
+        # directory doesn't exist so we need to post-process the CBT results files first
         log.debug("Creating directory %s" % output_directory)
         os.makedirs(output_directory, exist_ok=True)
 
@@ -140,6 +143,13 @@ def main() -> int:
         help="Do not generate error bars for the plots",
     )
 
+    parser.add_argument(
+        "--force_refresh",
+        action="store_true",
+        required=False,
+        help="Regenerate the inetrmediate files and plots, even if they exist",
+    )
+
     arguments: Namespace = parser.parse_args()
 
     # will only create the output directory if it does not already exist
@@ -153,6 +163,7 @@ def main() -> int:
             archive_directories=arguments.archive,
             output_directory=arguments.output_directory,
             no_error_bars=arguments.no_error_bars,
+            force_refresh=arguments.force_refresh,
         )
         report_generator.create_report()
 

--- a/tools/generate_performance_report.py
+++ b/tools/generate_performance_report.py
@@ -147,7 +147,7 @@ def main() -> int:
         "--force_refresh",
         action="store_true",
         required=False,
-        help="Regenerate the inetrmediate files and plots, even if they exist",
+        help="Regenerate the intermediate files and plots, even if they exist",
     )
 
     arguments: Namespace = parser.parse_args()

--- a/tools/generate_performance_report.py
+++ b/tools/generate_performance_report.py
@@ -32,6 +32,9 @@ Input:
                                     This requires pandoc to be installed,
                                     and be on the path.
 
+        --no_error_bars         [Optional] Do not draw error bars on the plots
+                                    included in the report
+
 Examples:
 
     Generate a markdown report file for the results in '/tmp/squid_main' directory
@@ -130,6 +133,13 @@ def main() -> int:
         help="The filename root of all the CBT output json files",
     )
 
+    parser.add_argument(
+        "--no_error_bars",
+        action="store_true",
+        required=False,
+        help="Do not generate error bars for the plots",
+    )
+
     arguments: Namespace = parser.parse_args()
 
     # will only create the output directory if it does not already exist
@@ -138,9 +148,11 @@ def main() -> int:
 
     try:
         generate_intermediate_files(arguments)
-        # sleep(10)
+
         report_generator = SimpleReportGenerator(
-            archive_directories=arguments.archive, output_directory=arguments.output_directory
+            archive_directories=arguments.archive,
+            output_directory=arguments.output_directory,
+            no_error_bars=arguments.no_error_bars,
         )
         report_generator.create_report()
 


### PR DESCRIPTION
A few quality of life improvements to the report generation added in #320 #321 and #322.

1. Move the plot legends outside of the graph axes so that it doesn't cover the data. 
         The automatic placement was good in most cases, but there were odd cases where data was obscured
2. Some plot titles were given to 1 decimal place - change this back to 0 decimal places
        e.g. **1024K** instead of **1024.0K**
3. An option to not draw error bars on the plots in a report.
        It was found that some error bars were so big that they ended up distorting the axes and stretching the plot
4. An option to force the regeneration of the intermediate data and plots from the raw data

In 3, and 4 above the current behaviour will remain the default. For 1 and 2 this will become the new default as it makes the charts look better.