### PR TITLE
Automatic report generation: common report modules

### DIFF
--- a/example/example-report_generation.yaml
+++ b/example/example-report_generation.yaml
@@ -1,0 +1,89 @@
+cluster:
+  user: 'perf'
+  head: "incerta01"
+  clients: ["incerta01"]
+  osds: ["incerta02"]
+  mons:
+    incerta01:
+      a: "10.0.10.101:6789"
+  mgrs:
+    incerta01:
+      a: ~
+  mdss:
+    incerta01:
+      a: ~
+  osds_per_node: 1 
+  fs: 'xfs'
+  mkfs_opts: '-f -i size=2048'
+  mount_opts: '-o inode64,noatime,logbsize=256k'
+  conf_file: '/home/perf/ceph_tests/ceph.conf.64.async'
+  iterations: 1
+  use_existing: False
+  clusterid: "ceph"
+  tmp_dir: "/tmp/cbt"
+  ceph-osd_cmd: "env -i TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728 /usr/local/bin/ceph-osd"
+  ceph-mon_cmd: "/usr/local/bin/ceph-mon"
+  ceph-run_cmd: "/usr/local/bin/ceph-run"
+  rados_cmd: "/usr/local/bin/rados"
+  ceph_cmd: "/usr/local/bin/ceph"
+  ceph-fuse_cmd: "/usr/local/bin/ceph-fuse"
+  rbd_cmd: "/usr/local/bin/rbd"
+  rbd-nbd_cmd: "/usr/local/bin/rbd-nbd"  
+  rbd-fuse_cmd: "/usr/local/bin/rbd-fuse"
+  ceph-mgr_cmd: "/usr/local/bin/ceph-mgr"
+  ceph-mds_cmd: "/usr/local/bin/ceph-mds"
+  osd_valgrind: "massif"
+  pool_profiles:
+    replication:
+      pg_size: 256
+      pgp_size: 256
+      replication: 1 
+    ec21:
+      pg_size: 2048 
+      pgp_size: 2048
+      replication: 'erasure'
+      erasure_profile: 'ec21'
+  erasure_profiles:
+    ec21:
+      erasure_k: 2
+      erasure_m: 1
+  cephfs_pools:
+    cephfs_data: replication
+    cephfs_metadata: replication
+
+client_endpoints:
+  fiotest:
+    driver: 'librbd'
+#    driver: 'rbd-kernel'
+#    driver: 'rbd-nbd'
+#    driver: 'rbd-fuse'
+#    driver: 'rbd-tcmu'
+#    driver: 'cephfs-kernel'
+#    driver: 'cephfs-fuse'
+    endpoints_per_client: 1
+    endpoint_size: 524288
+    pool_profile: replication
+
+benchmarks:
+  fio:
+    client_endpoints: 'fiotest'
+    time: 300
+    time_based: True
+    norandommap: True
+    size: 262144 
+    mode: ['read', 'write', 'randread','randwrite']
+    rwmixread: 50
+    op_size: [4194304, 131072, 4096]
+    procs_per_endpoint: [1]
+    iodepth: [32]
+    osd_ra: [4096]
+    cmd_path: '/home/perf/src/fio/fio'
+    log_avg_msec: 100
+
+report:
+    force_refresh: True
+    create_pdf: False
+    output_directory: "/home/perf/reports/"
+    results_file_root: "output"
+
+

--- a/post_processing/report.py
+++ b/post_processing/report.py
@@ -1,0 +1,131 @@
+"""
+Code used to generate a full performance report. This includes post processing
+any results into an intermediate format, plotting the curves for the report,
+and generating the report file.
+
+This is called from both the script files in /tools to manually generate a
+performance report, and from within the CBT code if we have been told to
+"""
+
+import os
+from argparse import Namespace
+from logging import Logger, getLogger
+from typing import NamedTuple
+
+from post_processing.formatter.common_output_formatter import CommonOutputFormatter
+from post_processing.log_configuration import setup_logging
+from post_processing.reports.comparison_report_generator import ComparisonReportGenerator
+from post_processing.reports.simple_report_generator import SimpleReportGenerator
+
+setup_logging()
+log: Logger = getLogger("reports")
+
+
+class ReportOptions(NamedTuple):
+    archives: list[str]
+    output_directory: str
+    results_file_root: str
+    create_pdf: bool
+    force_refresh: bool
+    no_error_bars: bool
+    comparison: bool
+
+
+def parse_namespace_to_options(arguments: Namespace, comparison_report: bool = False) -> ReportOptions:
+    no_error_bars: bool = False
+    archives: list[str] = []
+    output_directory: str = arguments.output_directory
+
+    if comparison_report:
+        archives.append(arguments.baseline)
+        for directory in arguments.archives.split(","):
+            archives.append(directory)
+    else:
+        archives.append(arguments.archive)
+
+    if hasattr(arguments, "no_error_bars"):
+        no_error_bars = arguments.no_error_bars
+
+    return ReportOptions(
+        archives=archives,
+        output_directory=output_directory,
+        create_pdf=arguments.create_pdf,
+        results_file_root=arguments.results_file_root,
+        force_refresh=arguments.force_refresh,
+        no_error_bars=no_error_bars,
+        comparison=comparison_report,
+    )
+
+class Report:
+    def __init__(self, options: ReportOptions) -> None:
+        self._options: ReportOptions = options
+
+        self._result_code: int = 0
+
+    @property
+    def result_code(self) -> int:
+        return self._result_code
+
+    def generate(self) -> None:
+        """
+        Do all the steps necessary to create the report file
+        """
+        log.info("Creating directory %s to contain the reports" % self._options.output_directory)
+        os.makedirs(f"{self._options.output_directory}", exist_ok=True)
+
+        try:
+            self._generate_intermediate_files()
+
+            if self._options.comparison:
+                report_generator = ComparisonReportGenerator(
+                    archive_directories=self._options.archives,
+                    output_directory=self._options.output_directory,
+                    force_refresh=self._options.force_refresh,
+                )
+            else:
+                report_generator = SimpleReportGenerator(
+                    archive_directories=self._options.archives,
+                    output_directory=self._options.output_directory,
+                    no_error_bars=self._options.no_error_bars,
+                    force_refresh=self._options.force_refresh,
+                )
+
+            report_generator.create_report()
+
+            if self._options.create_pdf:
+                report_generator.save_as_pdf()
+
+        except Exception as e:
+            self._result_code = 1
+            raise (e)
+
+    def _generate_intermediate_files(self) -> None:
+        """
+        If the raw fio results have not yet been post-processed then we need to do
+        that now before trying to produce the report
+        """
+
+        for directory in self._options.archives:
+            output_directory: str = f"{directory}/visualisation/"
+
+            if not os.path.exists(output_directory) or not os.listdir(output_directory) or self._options.force_refresh:
+                # Either the directory doesn't exists, or is empty, or the user has told us to regenerate the files
+
+                log.debug("Creating directory %s" % output_directory)
+                os.makedirs(output_directory, exist_ok=True)
+
+                log.info("Generating intermediate files for %s in directory %s" % (directory, output_directory))
+                formatter: CommonOutputFormatter = CommonOutputFormatter(
+                    archive_directory=directory, filename_root=self._options.results_file_root
+                )
+
+                try:
+                    formatter.convert_all_files()
+                    formatter.write_output_file()
+                except Exception as e:
+                    log.error(
+                        "Encountered an error parsing results in directory %s with name %s"
+                        % (directory, self._options.results_file_root)
+                    )
+                    log.exception(e)
+                    raise e

--- a/post_processing/reports/report_generator.py
+++ b/post_processing/reports/report_generator.py
@@ -38,7 +38,11 @@ class ReportGenerator(ABC):
     BASE_HEADER_FILE_PATH: str = "include/performance_report.tex"
 
     def __init__(
-        self, archive_directories: str, output_directory: str, no_error_bars: bool = False, force_refresh: bool = False
+        self,
+        archive_directories: list[str],
+        output_directory: str,
+        no_error_bars: bool = False,
+        force_refresh: bool = False,
     ) -> None:
         self._plot_error_bars: bool = not no_error_bars
         self._force_refresh: bool = force_refresh
@@ -48,7 +52,7 @@ class ReportGenerator(ABC):
         self._build_strings: list[str] = []
         self._data_files: dict[str, list[Path]] = {}
 
-        for archive_directory in archive_directories.split(","):
+        for archive_directory in archive_directories:
             archive_path: Path = Path(archive_directory)
             self._archive_directories.append(archive_path)
             data_directory: Path = Path(f"{archive_directory}/visualisation")


### PR DESCRIPTION
Currently the report generation scripts:
- generate_performance_report.py
 - generate_comparison_performance_report.py 

use methods within the script to generate a report. This change moves away from that and uses a common module to generate the report. 

This is the first step to generating reports as part of a CBT run, if the correct options are set in the yaml file.

### Testing
Manually generated a single performance report and a comparison performance report using the new code. Verified that these had the same content as ones generated using the previous method