### PR TITLE
CHange post processing to work with other operation types in CBT

### DIFF
--- a/post_processing/formatter/test_run_result.py
+++ b/post_processing/formatter/test_run_result.py
@@ -82,6 +82,13 @@ class TestRunResult:
         """
         convert the contents of a single output file from the benchmark into the
         JSON format we want for writing the graphs
+
+        The operation specified in ['global options']['rw'] can be of the format
+        <operation>
+        or
+        <operation:blocksize>
+
+        so it must be trimmed o get the actual name (read, write etc) for the operation perfomend
         """
 
         with open(str(file_path), "r", encoding="utf8") as file:
@@ -89,7 +96,7 @@ class TestRunResult:
             iodepth: str = self._get_iodepth(f"{data['global options']['iodepth']}", str(file_path))
 
             blocksize: str = get_blocksize(f"{data['global options']['bs']}")
-            operation: str = f"{data['global options']['rw']}"
+            operation: str = f"{data['global options']['rw']}".split(":")[0]
             global_details: IODEPTH_DETAILS_TYPE = self._get_global_options(data["global options"])
             blocksize_details: INTERNAL_BLOCKSIZE_DATA_TYPE = {blocksize: {}}
             iodepth_details: dict[str, IODEPTH_DETAILS_TYPE] = {iodepth: global_details}


### PR DESCRIPTION
Previously it was believed that the operation given in the FIO output files was a single word, but through testing we have found that it can also be of the format <operation>:<blocksize>. the TestRunResult class does not cope with this, but it should.

In this case the write operation was given the name "write:4092K" rather than the expected "write"

We can cope with this fairly simply by splitting the field in the FIO output file on the ":" character, and only returning the details before the ":"

### Testing:

Before fix
```
INFO - log_configuration: === Starting Post Processing of CBT results ===
INFO - generate_performance_report: Attempting to create directory /home/jakes/perftests/25th_Sep_4gap_6+2_tentacle_append_results
ERROR - generate_performance_report: Encountered an error plotting results
Traceback (most recent call last):
  File "/cbt.ch2/cbt/tools/generate_performance_report.py", line 145, in main
    report_generator.create_report()
  File "/cbt.ch2/cbt/post_processing/reports/report_generator.py", line 76, in create_report
    self._copy_images()
  File "/cbt.ch2/cbt/post_processing/reports/simple_report_generator.py", line 133, in _copy_images
    plotter.draw_and_save()
  File "/cbt.ch2/cbt/post_processing/plotter/simple_plotter.py", line 36, in draw_and_save
    self._add_title(plotter=plotter, source_files=[file_path])
  File "/cbt.ch2/cbt/post_processing/plotter/common_format_plotter.py", line 49, in _add_title
    title = self._construct_title_from_file_name(source_files[0].parts[-1])
  File "/cbt.ch2/cbt/post_processing/plotter/common_format_plotter.py", line 101, in _construct_title_from_file_name
    (blocksize, read_percent, operation) = get_blocksize_percentage_operation_from_file_name(
  File "/cbt.ch2/cbt/post_processing/common.py", line 50, in get_blocksize_percentage_operation_from_file_name
    operation: str = f"{TITLE_CONVERSION[file_parts[-1]]}"
KeyError: 'write:4092k'
```

After fix:
```
INFO - log_configuration: === Starting Post Processing of CBT results ===
INFO - generate_performance_report: Attempting to create directory /home/jakes/perftests/25th_Sep_4gap_6+2_tentacle_append_results
INFO - generate_performance_report: Generating intermediate files for /home/jakes/perftests/25th_Sep_4gap_6+2_tentacle_append_copied in directory /home/jakes/perftests/25th_Sep_4gap_6+2_tentacle_append_copied/visualisation/
INFO - common_output_formatter: Converting all files with name /home/jakes/perftests/25th_Sep_4gap_6+2_tentacle_append_copied in directory json_output
INFO - common_output_formatter: test_run_directories are: [PosixPath('/home/jakes/perftests/25th_Sep_4gap_6+2_tentacle_append_copied/results/00000000/id-bbe06be6')]
WARNING - test_run_result: test run with directory /home/jakes/perftests/25th_Sep_4gap_6+2_tentacle_append_copied/results/00000000/id-bbe06be6/idle_monitoring.o01.front.sepia.ceph.com has no files - not doing any conversion
WARNING - test_run_result: test run with directory /home/jakes/perftests/25th_Sep_4gap_6+2_tentacle_append_copied/results/00000000/id-bbe06be6/osd_ra-00004096.o01.front.sepia.ceph.com has no files - not doing any conversion
INFO - common_output_formatter: writing new format files to /home/jakes/perftests/25th_Sep_4gap_6+2_tentacle_append_copied/visualisation/
INFO - common_output_formatter: Writing formatted results to destination file /home/jakes/perftests/25th_Sep_4gap_6+2_tentacle_append_copied/visualisation/4096_write.json
INFO - simple_report_generator: Generating summary table
```

