### PR TITLE
Code quality improvements for workloads and post_processing

### DIFF
--- a/benchmark/cephtestrados.py
+++ b/benchmark/cephtestrados.py
@@ -47,7 +47,7 @@ class CephTestRados(Benchmark):
             self.weights['write'] = self.weights['write'] / 2
             self.weights['write_excl'] = self.weights['write']
 
-        self.run_dir = '%s/osd_ra-%08d/object_size-%08d' % (self.run_dir, int(self.osd_ra), int(self.variables['object_size']))
+        self.run_dir = '%sobject_size-%08d' % (self.run_dir, int(self.variables['object_size']))
         self.out_dir = '%s/osd_ra-%08d/object_size-%08d' % (self.archive_dir, int(self.osd_ra), int(self.variables['object_size']))
         self.pool_profile = config.get('pool_profile', 'default')
         self.cmd_path = config.get('cmd_path', '/usr/bin/ceph_test_rados')

--- a/benchmark/kvmrbdfio.py
+++ b/benchmark/kvmrbdfio.py
@@ -39,7 +39,7 @@ class KvmRbdFio(Benchmark):
         self.client_ra = config.get('client_ra', '128')
         self.fio_cmd = config.get('fio_cmd', '/usr/bin/fio')
         # FIXME there are too many permutations, need to put results in SQLITE3
-        self.run_dir = '%s/osd_ra-%08d/client_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.run_dir, int(self.osd_ra), int(self.client_ra), int(self.op_size), int(self.total_procs), int(self.iodepth), self.mode)
+        self.run_dir = '%sclient_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.run_dir, int(self.client_ra), int(self.op_size), int(self.total_procs), int(self.iodepth), self.mode)
         self.out_dir = '%s/osd_ra-%08d/client_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.archive_dir, int(self.osd_ra), int(self.client_ra), int(self.op_size), int(self.total_procs), int(self.iodepth), self.mode)
 
     def exists(self):

--- a/benchmark/radosbench.py
+++ b/benchmark/radosbench.py
@@ -30,7 +30,6 @@ class Radosbench(Benchmark):
         self.op_size = config.get('op_size', 4194304)
         self.object_set_id = config.get('object_set_id', '')
         self.run_dir = os.path.join(self.run_dir,
-                                    'osd_ra-{:0>8}'.format(self.osd_ra),
                                     'op_size-{:0>8}'.format(self.op_size),
                                     'concurrent_ops-{:0>8}'.format(self.concurrent_ops))
         self.out_dir = self.archive_dir

--- a/benchmark/rawfio.py
+++ b/benchmark/rawfio.py
@@ -34,7 +34,7 @@ class RawFio(Benchmark):
         self.vol_size = config.get('vol_size', 65536) * 0.9
         self.fio_cmd = config.get('fio_cmd', 'sudo /usr/bin/fio')
         # FIXME there are too many permutations, need to put results in SQLITE3
-        self.run_dir = '%s/raw_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.run_dir, int(self.osd_ra), int(self.op_size), int(self.total_procs), int(self.iodepth), self.mode)
+        self.run_dir = '%sraw_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.run_dir, int(self.osd_ra), int(self.op_size), int(self.total_procs), int(self.iodepth), self.mode)
         self.out_dir = '%s/raw_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.archive_dir, int(self.osd_ra), int(self.op_size), int(self.total_procs), int(self.iodepth), self.mode)
 
     # def exists(self):

--- a/benchmark/rbdfio.py
+++ b/benchmark/rbdfio.py
@@ -41,7 +41,7 @@ class RbdFio(Benchmark):
         self.direct = config.get('direct', 1)
         self.poolname = "cbt-kernelrbdfio"
 
-        self.run_dir = '%s/rbdfio/osd_ra-%08d/client_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.run_dir, int(self.osd_ra), int(self.client_ra), int(self.op_size), int(self.concurrent_procs), int(self.iodepth), self.mode)
+        self.run_dir = '%srbdfio/client_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.run_dir, int(self.client_ra), int(self.op_size), int(self.concurrent_procs), int(self.iodepth), self.mode)
         self.out_dir = '%s/rbdfio/osd_ra-%08d/client_ra-%08d/op_size-%08d/concurrent_procs-%03d/iodepth-%03d/%s' % (self.archive_dir, int(self.osd_ra), int(self.client_ra), int(self.op_size), int(self.concurrent_procs), int(self.iodepth), self.mode)
 
         # Make the file names string

--- a/command/command.py
+++ b/command/command.py
@@ -6,7 +6,7 @@ It will return the full executable string that can be used to run a
 cli command using whatever method the Benchmark chooses
 """
 
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from logging import Logger, getLogger
 from typing import Optional
 
@@ -15,7 +15,7 @@ from cli_options import CliOptions
 log: Logger = getLogger("cbt")
 
 
-class Command(metaclass=ABCMeta):
+class Command(ABC):
     """
     A class that encapsulates a single CLI command that can be run on a
     system

--- a/command/fio_command.py
+++ b/command/fio_command.py
@@ -10,7 +10,7 @@ options that are specific to a particular I/O engine e.g. rbd a subclass
 should be created that parses these options
 """
 
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from logging import Logger, getLogger
 from typing import Optional
 
@@ -20,7 +20,7 @@ from command.command import Command
 log: Logger = getLogger("cbt")
 
 
-class FioCommand(Command, metaclass=ABCMeta):
+class FioCommand(Command, ABC):
     """
     The FIO command class. This class represents a single FIO command
     line that can be run on a local or remote client system.

--- a/post_processing/formatter/benchmark_run_result.py
+++ b/post_processing/formatter/benchmark_run_result.py
@@ -5,28 +5,31 @@ Data from a test run in fio output files
 import json
 import re
 from logging import Logger, getLogger
-from math import sqrt
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from post_processing.common import get_blocksize
+from post_processing.common import get_blocksize, sum_standard_deviation_values
 from post_processing.types import (
-    INTERNAL_BLOCKSIZE_DATA_TYPE,
-    INTERNAL_FORMATTED_OUTPUT_TYPE,
-    IODEPTH_DETAILS_TYPE,
-    JOBS_DATA_TYPE,
+    InternalBlocksizeDataType,
+    InternalFormattedOutputType,
+    IodepthDataType,
+    JobsDataType,
 )
 
 log: Logger = getLogger("formatter")
 
 
-class TestRunResult:
+class BenchmarkRunResult:
+    """
+    Stores and processes the data from a benchmark run
+    """
+
     def __init__(self, directory: Path, file_name_root: str) -> None:
         self._path: Path = directory
         self._has_been_processed: bool = False
 
         self._files: list[Path] = self._find_files_for_testrun(file_name_root=file_name_root)
-        self._processed_data: INTERNAL_FORMATTED_OUTPUT_TYPE = {}
+        self._processed_data: InternalFormattedOutputType = {}
 
     def have_been_processed(self) -> bool:
         """
@@ -42,17 +45,14 @@ class TestRunResult:
         """
         number_of_volumes_for_test_run: int = len(self._files)
 
-        if number_of_volumes_for_test_run == 0:
-            log.warning("test run with directory %s has no files - not doing any conversion", self._path)
-            self._has_been_processed = True
-            return
-
-        else:
+        if number_of_volumes_for_test_run > 0:
             self._process_test_run_files()
+        else:
+            log.warning("test run with directory %s has no files - not doing any conversion", self._path)
 
         self._has_been_processed = True
 
-    def get(self) -> INTERNAL_FORMATTED_OUTPUT_TYPE:
+    def get(self) -> InternalFormattedOutputType:
         """
         Return the processed results
         """
@@ -70,7 +70,7 @@ class TestRunResult:
         for file_path in self._files:
             if not self._file_is_empty(file_path):
                 if not self._file_is_precondition(file_path):
-                    log.debug("Processing file %s" % file_path)
+                    log.debug("Processing file %s", file_path)
                     self._convert_file(file_path)
                 else:
                     log.warning("Not processing file %s as it is from a precondition operation", file_path)
@@ -96,34 +96,34 @@ class TestRunResult:
             iodepth: str = self._get_iodepth(f"{data['global options']['iodepth']}", str(file_path))
 
             blocksize: str = get_blocksize(f"{data['global options']['bs']}")
-            operation: str = f"{data['global options']['rw']}".split(":")[0]
-            global_details: IODEPTH_DETAILS_TYPE = self._get_global_options(data["global options"])
-            blocksize_details: INTERNAL_BLOCKSIZE_DATA_TYPE = {blocksize: {}}
-            iodepth_details: dict[str, IODEPTH_DETAILS_TYPE] = {iodepth: global_details}
+            operation: str = f"{data['global options']['rw']}"
+            global_details: IodepthDataType = self._get_global_options(data["global options"])
+            blocksize_details: InternalBlocksizeDataType = {blocksize: {}}
+            iodepth_details: dict[str, IodepthDataType] = {iodepth: global_details}
 
-            io_details: IODEPTH_DETAILS_TYPE = {}
+            io_details: IodepthDataType = {}
 
-            if "percentage_reads" in global_details.keys():
+            if global_details.get("percentage_reads", None):
                 operation = f"{global_details['percentage_reads']}_{global_details['percentage_writes']}_{operation}"
 
-            if operation in self._processed_data.keys():
-                if blocksize in self._processed_data[operation].keys():
-                    if iodepth in self._processed_data[operation][blocksize].keys():
+            if self._processed_data.get(operation, None):
+                if self._processed_data[operation].get(blocksize, None):
+                    if self._processed_data[operation][blocksize].get(iodepth, None):
                         # we already have data here, so use it
-                        log.debug("We have details for iodepth %s so using them" % iodepth)
+                        log.debug("We have details for iodepth %s so using them", iodepth)
                         io_details = self._sum_io_details(
                             self._processed_data[operation][blocksize][iodepth],
                             self._get_io_details(all_jobs=data["jobs"]),
                         )
 
-            if io_details == {}:
+            if not io_details:
                 io_details = self._get_io_details(all_jobs=data["jobs"])
 
             iodepth_details[iodepth].update(io_details)
             blocksize_details[blocksize].update(iodepth_details)
 
-            if operation in self._processed_data.keys():
-                if blocksize in self._processed_data[operation].keys():
+            if self._processed_data.get(operation, None):
+                if self._processed_data[operation].get(blocksize, None):
                     self._processed_data[operation][blocksize].update(iodepth_details)
                 else:
                     self._processed_data[operation].update(blocksize_details)
@@ -142,20 +142,21 @@ class TestRunResult:
         }
 
         # if rwmixread exists in the output then so does rwmixwrite
-        if "rwmixread" in fio_global_options.keys():
+        if fio_global_options.get("rwmixread", None):
+            # if "rwmixread" in fio_global_options.keys():
             global_options_details["percentage_reads"] = f"{fio_global_options['rwmixread']}"
             global_options_details["percentage_writes"] = f"{fio_global_options['rwmixwrite']}"
 
         return global_options_details
 
     def _sum_io_details(
-        self, existing_values: Union[str, IODEPTH_DETAILS_TYPE], new_values: IODEPTH_DETAILS_TYPE
-    ) -> IODEPTH_DETAILS_TYPE:
+        self, existing_values: Union[str, IodepthDataType], new_values: IodepthDataType
+    ) -> IodepthDataType:
         """
         sum the existing_values with new_values and return the result
         """
         assert isinstance(existing_values, dict)
-        combined_data: IODEPTH_DETAILS_TYPE = {}
+        combined_data: IodepthDataType = {}
 
         simple_sum_values: list[str] = ["io_bytes", "iops", "bandwidth_bytes"]
 
@@ -174,7 +175,7 @@ class TestRunResult:
             int(combined_data["total_ios"]),
         )
 
-        combined_std_dev: float = self._sum_standard_deviation_values(
+        combined_std_dev: float = sum_standard_deviation_values(
             std_deviations, operations, latencies, int(combined_data["total_ios"]), combined_latency
         )
 
@@ -193,7 +194,7 @@ class TestRunResult:
         return [
             path
             for path in self._path.glob(f"**/{file_name_root}.*")
-            if re.search(f"{file_name_root}.\d+$", f"{path}")  # pyright: ignore[reportInvalidStringEscapeSequence]
+            if re.search(rf"{file_name_root}.\d+$", f"{path}")
         ]
 
     def _file_is_empty(self, file_path: Path) -> bool:
@@ -208,7 +209,8 @@ class TestRunResult:
         """
         return "precond" in str(file_path)
 
-    def _get_io_details(self, all_jobs: JOBS_DATA_TYPE) -> IODEPTH_DETAILS_TYPE:
+    # pylint: disable=[too-many-locals]
+    def _get_io_details(self, all_jobs: JobsDataType) -> IodepthDataType:
         """
         Get all the required details for the total I/O submitted by fio.
 
@@ -254,7 +256,7 @@ class TestRunResult:
 
         combined_mean_latency = self._sum_mean_values(latencies, operations, total_ios)
 
-        latency_standard_deviation = self._sum_standard_deviation_values(
+        latency_standard_deviation = sum_standard_deviation_values(
             std_deviations, operations, latencies, total_ios, combined_mean_latency
         )
 
@@ -289,37 +291,6 @@ class TestRunResult:
 
         return combined_mean_latency
 
-    def _sum_standard_deviation_values(
-        self,
-        std_deviations: list[float],
-        operations: list[int],
-        latencies: list[float],
-        total_ios: int,
-        combined_latency: float,
-    ) -> float:
-        """
-        Sum the standard deviations from a number of test runs
-
-        For each run we need to calculate:
-        weighted_stddev = sum ((num_ops - 1) * std_dev^2 + num_ops1 * mean_latency1^2)
-
-        sqrt( (weighted_stddev - (total_ios)*combined_latency^2) / total_ios - 1)
-        """
-        weighted_stddev: float = 0
-
-        # For standard deviation this is more complex. For each job we need to calculate:
-        #    (num_ops - 1) * std_dev^2 + num_ops1 * mean_latency1^2
-        for index, stddev in enumerate(std_deviations):
-            weighted_stddev += (operations[index] - 1) * stddev * stddev + operations[index] * (
-                latencies[index] * latencies[index]
-            )
-
-        latency_standard_deviation: float = sqrt(
-            (weighted_stddev - total_ios * combined_latency * combined_latency) / (total_ios - 1)
-        )
-
-        return latency_standard_deviation
-
     def _get_iodepth(self, iodepth_value: str, logfile_name: Optional[str]) -> str:
         """
         Checks to see if the iodepth encoded in the logfile name matches
@@ -327,7 +298,7 @@ class TestRunResult:
         from the file, otherwise return the iodepth parsed from the
         log file path
         """
-        log.debug("Getting iodepth from %s and %s" % (iodepth_value, logfile_name))
+        log.debug("Getting iodepth from %s and %s", iodepth_value, logfile_name)
         iodepth: int = int(iodepth_value)
         if logfile_name is not None:
             # We need to cope with both the separate workload class directory structure
@@ -351,11 +322,7 @@ class TestRunResult:
                     iodepth_string: str = logfile_name[iodepth_end_index + 1 : numjobs_start_index - 1]
                     logfile_iodepth = int(iodepth_string)
 
-            if logfile_iodepth > iodepth:
-                iodepth = logfile_iodepth
+            iodepth = max(iodepth, logfile_iodepth)
 
-        log.debug("iodepth value is %s" % iodepth)
+        log.debug("iodepth value is %s", iodepth)
         return str(iodepth)
-
-
-__test__ = False

--- a/post_processing/log_configuration.py
+++ b/post_processing/log_configuration.py
@@ -7,7 +7,7 @@ import os
 from logging import Logger, getLogger
 from typing import Any
 
-HANDLER_TYPE = dict[str, dict[str, str]]
+from post_processing.types import HandlerType
 
 LOGFILE_LOCATION: str = os.getenv("CBT_PP_LOGFILE_LOCATION", "/tmp")
 LOGFILE_NAME_BASE: str = f"{LOGFILE_LOCATION}/cbt/post_processing"
@@ -15,10 +15,12 @@ LOGFILE_EXTENSION: str = ".log"
 
 LOGGERS: list[str] = ["formatter", "plotter", "reports"]
 
-LOGGING_CONFIGURATION_TYPE = dict[str, Any]
-
 
 def setup_logging() -> None:
+    """
+    Set up the logging for the post processing. This should be called before
+    trying to post-process any results
+    """
     os.makedirs(f"{LOGFILE_LOCATION}/cbt/", exist_ok=True)
     logging.config.dictConfig(_get_configuration())
     log: Logger = getLogger("formatter")
@@ -26,8 +28,8 @@ def setup_logging() -> None:
     log.info("=== Starting Post Processing of CBT results ===")
 
 
-def _get_handlers_configuration() -> HANDLER_TYPE:
-    handlers: HANDLER_TYPE = {
+def _get_handlers_configuration() -> HandlerType:
+    handlers: HandlerType = {
         "console": {
             "class": "logging.StreamHandler",
             "formatter": "console",
@@ -88,7 +90,7 @@ def _get_configuration() -> dict[str, Any]:
         }
         logging_config["loggers"][logger_name] = new_logger
 
-    handler_entry: HANDLER_TYPE = _get_handlers_configuration()
+    handler_entry: HandlerType = _get_handlers_configuration()
     logging_config["handlers"] = handler_entry
 
     return logging_config

--- a/post_processing/plotter/common_format_plotter.py
+++ b/post_processing/plotter/common_format_plotter.py
@@ -6,7 +6,10 @@ intermediate format introduced in PR 319 (https://github.com/ceph/cbt/pull/319) 
 from abc import ABC, abstractmethod
 from logging import Logger, getLogger
 from pathlib import Path
-from types import ModuleType
+
+# the ModuleType does exists in the types module, so no idea why pylint is
+# flagging this
+from types import ModuleType  # pylint: disable=[no-name-in-module]
 from typing import Optional, Union
 
 from post_processing.common import (
@@ -14,11 +17,12 @@ from post_processing.common import (
     PLOT_FILE_EXTENSION,
     get_blocksize_percentage_operation_from_file_name,
 )
-from post_processing.types import COMMON_FORMAT_FILE_DATA_TYPE, PLOT_DATA_TYPE
+from post_processing.types import CommonFormatDataType, PlotDataType
 
 log: Logger = getLogger("plotter")
 
 
+# pylint: disable=too-few-public-methods
 class CommonFormatPlotter(ABC):
     """
     The base class for plotting results curves
@@ -122,13 +126,13 @@ class CommonFormatPlotter(ABC):
         plotter.xlim(0, maximum_x)
         plotter.ylim(0, maximum_y)
 
-    def _sort_plot_data(self, unsorted_data: COMMON_FORMAT_FILE_DATA_TYPE) -> PLOT_DATA_TYPE:
+    def _sort_plot_data(self, unsorted_data: CommonFormatDataType) -> PlotDataType:
         """
         Sort the data read from the file by queue depth
         """
         keys: list[str] = [key for key in unsorted_data.keys() if isinstance(unsorted_data[key], dict)]
-        plot_data: PLOT_DATA_TYPE = {}
-        sorted_plot_data: PLOT_DATA_TYPE = {}
+        plot_data: PlotDataType = {}
+        sorted_plot_data: PlotDataType = {}
         for key, data in unsorted_data.items():
             if isinstance(data, dict):
                 plot_data[key] = data
@@ -140,7 +144,7 @@ class CommonFormatPlotter(ABC):
         return sorted_plot_data
 
     def _add_single_file_data_with_optional_errorbars(
-        self, plotter: ModuleType, file_data: COMMON_FORMAT_FILE_DATA_TYPE, plot_error_bars: bool
+        self, plotter: ModuleType, file_data: CommonFormatDataType, plot_error_bars: bool
     ) -> None:
         """
         Add the data from a single file to a plot. Include error bars. Each point
@@ -149,7 +153,7 @@ class CommonFormatPlotter(ABC):
         The plot will have red error bars with a blue plot line
         """
 
-        sorted_plot_data: PLOT_DATA_TYPE = self._sort_plot_data(file_data)
+        sorted_plot_data: PlotDataType = self._sort_plot_data(file_data)
 
         x_data: list[Union[int, float]] = []
         y_data: list[Union[int, float]] = []
@@ -179,14 +183,14 @@ class CommonFormatPlotter(ABC):
 
         plotter.errorbar(x_data, y_data, error_bars, capsize=capsize, ecolor="red")
 
-    def _add_single_file_data(self, plotter: ModuleType, file_data: COMMON_FORMAT_FILE_DATA_TYPE, label: str) -> None:
+    def _add_single_file_data(self, plotter: ModuleType, file_data: CommonFormatDataType, label: str) -> None:
         """
         Add the data from a single file to a plot.
 
         This will be a line of colour with data points marked by a small cross,
         and no error bars.
         """
-        sorted_plot_data: PLOT_DATA_TYPE = self._sort_plot_data(file_data)
+        sorted_plot_data: PlotDataType = self._sort_plot_data(file_data)
 
         x_data: list[Union[int, float]] = []
         y_data: list[Union[int, float]] = []

--- a/post_processing/plotter/directory_comparison_plotter.py
+++ b/post_processing/plotter/directory_comparison_plotter.py
@@ -15,11 +15,12 @@ from post_processing.common import (
     read_intermediate_file,
 )
 from post_processing.plotter.common_format_plotter import CommonFormatPlotter
-from post_processing.types import COMMON_FORMAT_FILE_DATA_TYPE
+from post_processing.types import CommonFormatDataType
 
 log: Logger = getLogger("plotter")
 
 
+# pylint: disable=[too-few-public-methods]
 class DirectoryComparisonPlotter(CommonFormatPlotter):
     """
     Read the intermediate data files in the common json format and produce a
@@ -42,7 +43,7 @@ class DirectoryComparisonPlotter(CommonFormatPlotter):
         for file_name in common_file_names:
             output_file_path: str = self._generate_output_file_name(files=[Path(file_name)])
             for directory in self._comparison_directories:
-                file_data: COMMON_FORMAT_FILE_DATA_TYPE = read_intermediate_file(f"{directory}/{file_name}")
+                file_data: CommonFormatDataType = read_intermediate_file(f"{directory}/{file_name}")
                 # we choose the last directory name for the label to apply to the data
                 self._add_single_file_data(
                     plotter=plotter,
@@ -54,7 +55,9 @@ class DirectoryComparisonPlotter(CommonFormatPlotter):
             self._set_axis(plotter=plotter)
 
             # make sure we add the legend to the plot
-            plotter.legend(bbox_to_anchor=(0.5, -0.1), loc="upper center", ncol=2)  # pyright: ignore[reportUnknownMemberType]
+            plotter.legend(  # pyright: ignore[reportUnknownMemberType]
+                bbox_to_anchor=(0.5, -0.1), loc="upper center", ncol=2
+            )
 
             self._save_plot(plotter=plotter, file_path=output_file_path)
             self._clear_plot(plotter=plotter)

--- a/post_processing/plotter/file_comparison_plotter.py
+++ b/post_processing/plotter/file_comparison_plotter.py
@@ -17,7 +17,7 @@ from post_processing.common import (
     read_intermediate_file,
 )
 from post_processing.plotter.common_format_plotter import CommonFormatPlotter
-from post_processing.types import COMMON_FORMAT_FILE_DATA_TYPE
+from post_processing.types import CommonFormatDataType
 
 log: Logger = getLogger("plotter")
 
@@ -29,7 +29,7 @@ class FileComparisonPlotter(CommonFormatPlotter):
     as they seem to make the plot harder to read and compare.
     """
 
-    def __init__(self, output_directory: str, files: list[str], labels: Optional[list[str]] = None) -> None:
+    def __init__(self, output_directory: str, files: list[str]) -> None:
         self._output_directory: str = f"{output_directory}"
         self._comparison_files: list[Path] = [Path(file) for file in files]
         self._labels: Optional[list[str]] = None
@@ -39,7 +39,7 @@ class FileComparisonPlotter(CommonFormatPlotter):
 
         for file_path in self._comparison_files:
             index: int = self._comparison_files.index(file_path)
-            file_data: COMMON_FORMAT_FILE_DATA_TYPE = read_intermediate_file(f"{file_path}")
+            file_data: CommonFormatDataType = read_intermediate_file(f"{file_path}")
 
             operation_details: tuple[str, str, str] = get_blocksize_percentage_operation_from_file_name(
                 file_name=file_path.stem
@@ -58,7 +58,9 @@ class FileComparisonPlotter(CommonFormatPlotter):
             self._add_single_file_data(plotter=plotter, file_data=file_data, label=label)
 
         # make sure we add the legend to the plot, below the chart
-        plotter.legend(bbox_to_anchor=(0.5, -0.1), loc="upper center", ncol=2)  # pyright: ignore[reportUnknownMemberType]
+        plotter.legend(  # pyright: ignore[reportUnknownMemberType]
+            bbox_to_anchor=(0.5, -0.1), loc="upper center", ncol=2
+        )
 
         self._add_title(plotter=plotter, source_files=self._comparison_files)
         self._set_axis(plotter=plotter)

--- a/post_processing/plotter/simple_plotter.py
+++ b/post_processing/plotter/simple_plotter.py
@@ -15,9 +15,10 @@ from post_processing.common import (
     read_intermediate_file,
 )
 from post_processing.plotter.common_format_plotter import CommonFormatPlotter
-from post_processing.types import COMMON_FORMAT_FILE_DATA_TYPE
+from post_processing.types import CommonFormatDataType
 
 
+# pylint: disable=too-few-public-methods
 class SimplePlotter(CommonFormatPlotter):
     """
     Read the intermediate data file in the common json format and produce a hockey-stick
@@ -31,7 +32,7 @@ class SimplePlotter(CommonFormatPlotter):
 
     def draw_and_save(self) -> None:
         for file_path in self._path.glob(f"*{DATA_FILE_EXTENSION_WITH_DOT}"):
-            file_data: COMMON_FORMAT_FILE_DATA_TYPE = read_intermediate_file(f"{file_path}")
+            file_data: CommonFormatDataType = read_intermediate_file(f"{file_path}")
             output_file_path: str = self._generate_output_file_name(files=[file_path])
             self._add_single_file_data_with_optional_errorbars(
                 plotter=plotter, file_data=file_data, plot_error_bars=self._plot_error_bars

--- a/post_processing/report.py
+++ b/post_processing/report.py
@@ -22,6 +22,10 @@ log: Logger = getLogger("reports")
 
 
 class ReportOptions(NamedTuple):
+    """
+    This class is used to store the options required to create a report.
+    """
+
     archives: list[str]
     output_directory: str
     results_file_root: str
@@ -32,6 +36,9 @@ class ReportOptions(NamedTuple):
 
 
 def parse_namespace_to_options(arguments: Namespace, comparison_report: bool = False) -> ReportOptions:
+    """
+    Parse a namespace as used by argparse into our internal NamedTuple representation
+    """
     no_error_bars: bool = False
     archives: list[str] = []
     output_directory: str = arguments.output_directory
@@ -56,7 +63,15 @@ def parse_namespace_to_options(arguments: Namespace, comparison_report: bool = F
         comparison=comparison_report,
     )
 
+
 class Report:
+    """
+    Represents a report that will be created from a CBT fio run.
+
+    It will perform all the necessary steps to convert the raw data into a
+    report
+    """
+
     def __init__(self, options: ReportOptions) -> None:
         self._options: ReportOptions = options
 
@@ -64,13 +79,17 @@ class Report:
 
     @property
     def result_code(self) -> int:
+        """
+        The return code from creating the reports. This is used when creating
+        reports using the helper scripts
+        """
         return self._result_code
 
     def generate(self) -> None:
         """
         Do all the steps necessary to create the report file
         """
-        log.info("Creating directory %s to contain the reports" % self._options.output_directory)
+        log.info("Creating directory %s to contain the reports", self._options.output_directory)
         os.makedirs(f"{self._options.output_directory}", exist_ok=True)
 
         try:
@@ -97,7 +116,7 @@ class Report:
 
         except Exception as e:
             self._result_code = 1
-            raise (e)
+            raise e
 
     def _generate_intermediate_files(self) -> None:
         """
@@ -111,10 +130,10 @@ class Report:
             if not os.path.exists(output_directory) or not os.listdir(output_directory) or self._options.force_refresh:
                 # Either the directory doesn't exists, or is empty, or the user has told us to regenerate the files
 
-                log.debug("Creating directory %s" % output_directory)
+                log.debug("Creating directory %s", output_directory)
                 os.makedirs(output_directory, exist_ok=True)
 
-                log.info("Generating intermediate files for %s in directory %s" % (directory, output_directory))
+                log.info("Generating intermediate files for %s in directory %s", directory, output_directory)
                 formatter: CommonOutputFormatter = CommonOutputFormatter(
                     archive_directory=directory, filename_root=self._options.results_file_root
                 )
@@ -124,8 +143,9 @@ class Report:
                     formatter.write_output_file()
                 except Exception as e:
                     log.error(
-                        "Encountered an error parsing results in directory %s with name %s"
-                        % (directory, self._options.results_file_root)
+                        "Encountered an error parsing results in directory %s with name %s",
+                        directory,
+                        self._options.results_file_root,
                     )
                     log.exception(e)
                     raise e

--- a/post_processing/reports/comparison_report_generator.py
+++ b/post_processing/reports/comparison_report_generator.py
@@ -33,6 +33,15 @@ log: Logger = getLogger("reports")
 
 
 class ComparisonReportGenerator(ReportGenerator):
+    """
+    The class responsible for generating a comparison report. That is a single report that
+    compares one or more sets of test data, and creates plots that have data from multiple
+    runs on a single plot
+
+    This can either be a comparison of two idividual files, or multiple test run directories
+    containing several individual FIO runs
+    """
+
     def _generate_report_title(self) -> str:
         title: str = f"Comparitive Performance Report for {' vs '.join(self._build_strings)}"
         return title
@@ -65,11 +74,11 @@ class ComparisonReportGenerator(ReportGenerator):
 
         # Create the correct sections and add a table for each section to the report
 
-        for section in image_tables.keys():
+        for section, data in image_tables.items():
             # We don't want to display a section if it doesn't contain any plots
-            if len(image_tables[section]) > len(empty_table_header):
+            if len(data) > len(empty_table_header):
                 self._report.new_header(level=2, title=section)
-                table_images = image_tables[section]
+                table_images = data
 
                 # We need to calculate the rumber of rows, but new_table() requires the
                 # exact number of items to fill the table, so we may need to add a dummy
@@ -94,12 +103,12 @@ class ComparisonReportGenerator(ReportGenerator):
         (table_header, table_justfication_string) = self._generate_table_headers()
         self._generate_table_rows(data_tables)
 
-        for operation in data_tables.keys():
-            if data_tables[operation]:
+        for operation, data in data_tables.items():
+            if data:
                 self._report.new_line(text=f"|{operation}|{table_header}")
                 self._report.new_line(text=table_justfication_string)
 
-            for line in data_tables[operation]:
+            for line in data:
                 self._report.new_line(text=line)
             self._report.new_line()
 
@@ -237,7 +246,11 @@ class ComparisonReportGenerator(ReportGenerator):
                     latency_percentage_difference: str = calculate_percent_difference_to_baseline(
                         baseline=baseline_latency_ms, comparison=latency_ms
                     )
-                    data_string += f"{max_throughput}@{latency_ms}ms|{throughput_percentage_difference}|{latency_percentage_difference}|"
+                    data_string += (
+                        f"{max_throughput}@{latency_ms}ms|"
+                        + f"{throughput_percentage_difference}|"
+                        + f"{latency_percentage_difference}|"
+                    )
                 else:
                     data_string += f"{max_throughput.split(' ')[0]}@{latency_ms}|{throughput_percentage_difference}|"
 

--- a/post_processing/reports/report_generator.py
+++ b/post_processing/reports/report_generator.py
@@ -25,6 +25,7 @@ from post_processing.common import (
 log: Logger = getLogger("reports")
 
 
+# pylint: disable=too-many-instance-attributes
 class ReportGenerator(ABC):
     """
     The base class for all classes responsible for generating a markdown and
@@ -279,13 +280,12 @@ class ReportGenerator(ABC):
 
         tex_output_path: Path = Path(f"{self._output_directory}/perf_report.tex")
 
-        # TODO: What do we want to actually do here????
         build_string: str = " vs ".join(self._build_strings)
 
         try:
-            tex_contents: str = base_header_file.read_text()
+            tex_contents: str = base_header_file.read_text(encoding="utf-8")
             tex_contents = tex_contents.replace("BUILD", build_string)
-            tex_output_path.write_text(tex_contents)
+            tex_output_path.write_text(tex_contents, encoding="utf-8")
         except FileNotFoundError:
             log.error("Unable to read from %s", base_header_file)
         except PermissionError:

--- a/post_processing/reports/simple_report_generator.py
+++ b/post_processing/reports/simple_report_generator.py
@@ -31,6 +31,12 @@ log: Logger = getLogger("reports")
 
 
 class SimpleReportGenerator(ReportGenerator):
+    """
+    The class responsible for generating a report from a single FIO run
+
+    Typically this is run using a Workload.
+    """
+
     def _generate_report_title(self) -> str:
         title: str = f"Performance Report for {''.join(self._build_strings)}"
         return title
@@ -60,9 +66,11 @@ class SimpleReportGenerator(ReportGenerator):
         for _, operation in TITLE_CONVERSION.items():
             data_tables[operation] = []
 
-        for file_name in self._data_files.keys():
-            for file_path in self._data_files[file_name]:
-                log.debug("Looking at file %s" % file_path)
+        for _, file_data in self._data_files.items():
+            for file_path in file_data:
+                # for file_name in self._data_files.keys():
+                #    for file_path in self._data_files[file_name]:
+                log.debug("Looking at file %s", file_path)
                 (max_throughput, latency_ms) = get_latency_throughput_from_file(file_path)
 
                 (_, _, operation) = get_blocksize_percentage_operation_from_file_name(file_path.stem)
@@ -70,8 +78,9 @@ class SimpleReportGenerator(ReportGenerator):
 
                 data_tables[operation].append(data)
 
-        for operation in data_tables.keys():
-            for line in data_tables[operation]:
+        # for operation in data_tables.keys():
+        for _, operation_data in data_tables.items():
+            for line in operation_data:
                 self._report.new_line(text=line)
 
     def _add_plots(self) -> None:
@@ -97,11 +106,12 @@ class SimpleReportGenerator(ReportGenerator):
 
         # Create the correct sections and add a table for each section to the report
 
-        for section in image_tables.keys():
+        # for section in image_tables.keys():
+        for section_name, section_data in image_tables.items():
             # We don't want to display a section if it doesn't contain any plots
-            if len(image_tables[section]) > len(empty_table_header):
-                self._report.new_header(level=2, title=section)
-                table_images = image_tables[section]
+            if len(section_data) > len(empty_table_header):
+                self._report.new_header(level=2, title=section_name)
+                table_images = section_data
 
                 # We need to calculate the rumber of rows, but new_table() requires the
                 # exact number of items to fill the table, so we may need to add a dummy

--- a/post_processing/types.py
+++ b/post_processing/types.py
@@ -4,16 +4,19 @@ A file to contain common type definitions for use in the post-processing
 
 from typing import Union
 
+# Log setup types
+HandlerType = dict[str, dict[str, str]]
+
 # FIO json file data types
-JOBS_DATA_TYPE = list[dict[str, Union[str, dict[str, Union[int, float, dict[str, Union[int, float]]]]]]]
+JobsDataType = list[dict[str, Union[str, dict[str, Union[int, float, dict[str, Union[int, float]]]]]]]
 
 # Common formatter data types
-IODEPTH_DETAILS_TYPE = dict[str, str]
-COMMON_FORMAT_FILE_DATA_TYPE = dict[str, Union[str, IODEPTH_DETAILS_TYPE]]
+IodepthDataType = dict[str, str]
+CommonFormatDataType = dict[str, Union[str, IodepthDataType]]
 
 # Common formatter internal data types
-INTERNAL_BLOCKSIZE_DATA_TYPE = dict[str, COMMON_FORMAT_FILE_DATA_TYPE]
-INTERNAL_FORMATTED_OUTPUT_TYPE = dict[str, INTERNAL_BLOCKSIZE_DATA_TYPE]
+InternalBlocksizeDataType = dict[str, CommonFormatDataType]
+InternalFormattedOutputType = dict[str, InternalBlocksizeDataType]
 
 # Plotter types
-PLOT_DATA_TYPE = dict[str, dict[str, str]]
+PlotDataType = dict[str, dict[str, str]]

--- a/tests/test_bm_cephtestrados.py
+++ b/tests/test_bm_cephtestrados.py
@@ -16,7 +16,7 @@ class TestBenchmarkcephtestrados(unittest.TestCase):
     cl_name = "tools/invariant.yaml"
     bl_name = "tools/baseline.json"
     bl_json = {}
-    bl_md5 = 'e6b6fcd2be74bd08939c64a249ab2125'
+    bl_md5 = 'b62e2394b5bac4dea01cceace04d0359'
     md5_returned = None
 
     @classmethod

--- a/tests/test_bm_fio.py
+++ b/tests/test_bm_fio.py
@@ -16,7 +16,7 @@ class TestBenchmarkfio(unittest.TestCase):
     cl_name = "tools/invariant.yaml"
     bl_name = "tools/baseline.json"
     bl_json = {}
-    bl_md5 = 'e6b6fcd2be74bd08939c64a249ab2125'
+    bl_md5 = 'b62e2394b5bac4dea01cceace04d0359'
     md5_returned = None
 
     @classmethod

--- a/tests/test_bm_getput.py
+++ b/tests/test_bm_getput.py
@@ -16,7 +16,7 @@ class TestBenchmarkgetput(unittest.TestCase):
     cl_name = "tools/invariant.yaml"
     bl_name = "tools/baseline.json"
     bl_json = {}
-    bl_md5 = 'e6b6fcd2be74bd08939c64a249ab2125'
+    bl_md5 = 'b62e2394b5bac4dea01cceace04d0359'
     md5_returned = None
 
     @classmethod

--- a/tests/test_bm_hsbench.py
+++ b/tests/test_bm_hsbench.py
@@ -16,7 +16,7 @@ class TestBenchmarkhsbench(unittest.TestCase):
     cl_name = "tools/invariant.yaml"
     bl_name = "tools/baseline.json"
     bl_json = {}
-    bl_md5 = 'e6b6fcd2be74bd08939c64a249ab2125'
+    bl_md5 = 'b62e2394b5bac4dea01cceace04d0359'
     md5_returned = None
 
     @classmethod

--- a/tests/test_bm_kvmrbdfio.py
+++ b/tests/test_bm_kvmrbdfio.py
@@ -16,7 +16,7 @@ class TestBenchmarkkvmrbdfio(unittest.TestCase):
     cl_name = "tools/invariant.yaml"
     bl_name = "tools/baseline.json"
     bl_json = {}
-    bl_md5 = 'e6b6fcd2be74bd08939c64a249ab2125'
+    bl_md5 = 'b62e2394b5bac4dea01cceace04d0359'
     md5_returned = None
 
     @classmethod

--- a/tests/test_bm_librbdfio.py
+++ b/tests/test_bm_librbdfio.py
@@ -16,7 +16,7 @@ class TestBenchmarklibrbdfio(unittest.TestCase):
     cl_name = "tools/invariant.yaml"
     bl_name = "tools/baseline.json"
     bl_json = {}
-    bl_md5 = 'e6b6fcd2be74bd08939c64a249ab2125'
+    bl_md5 = 'b62e2394b5bac4dea01cceace04d0359'
     md5_returned = None
 
     @classmethod
@@ -93,12 +93,6 @@ class TestBenchmarklibrbdfio(unittest.TestCase):
         b = benchmarkfactory.get_object(self.archive_dir,
                                             self.cluster, 'librbdfio', self.iteration)
         self.assertEqual(self.bl_json['librbdfio']['fio_out_format'], b.__dict__['fio_out_format'])
-
-    def test_valid_global_fio_options(self):
-        """ Basic sanity attribute identity global_fio_options check"""
-        b = benchmarkfactory.get_object(self.archive_dir,
-                                            self.cluster, 'librbdfio', self.iteration)
-        self.assertEqual(self.bl_json['librbdfio']['global_fio_options'], b.__dict__['global_fio_options'])
 
     def test_valid_idle_monitor_sleep(self):
         """ Basic sanity attribute identity idle_monitor_sleep check"""
@@ -333,12 +327,6 @@ class TestBenchmarklibrbdfio(unittest.TestCase):
         b = benchmarkfactory.get_object(self.archive_dir,
                                             self.cluster, 'librbdfio', self.iteration)
         self.assertEqual(self.bl_json['librbdfio']['wait_pgautoscaler_timeout'], b.__dict__['wait_pgautoscaler_timeout'])
-
-    def test_valid_workloads(self):
-        """ Basic sanity attribute identity workloads check"""
-        b = benchmarkfactory.get_object(self.archive_dir,
-                                            self.cluster, 'librbdfio', self.iteration)
-        self.assertEqual(self.bl_json['librbdfio']['workloads'], b.__dict__['workloads'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bm_nullbench.py
+++ b/tests/test_bm_nullbench.py
@@ -16,7 +16,7 @@ class TestBenchmarknullbench(unittest.TestCase):
     cl_name = "tools/invariant.yaml"
     bl_name = "tools/baseline.json"
     bl_json = {}
-    bl_md5 = 'e6b6fcd2be74bd08939c64a249ab2125'
+    bl_md5 = 'b62e2394b5bac4dea01cceace04d0359'
     md5_returned = None
 
     @classmethod

--- a/tests/test_bm_radosbench.py
+++ b/tests/test_bm_radosbench.py
@@ -16,7 +16,7 @@ class TestBenchmarkradosbench(unittest.TestCase):
     cl_name = "tools/invariant.yaml"
     bl_name = "tools/baseline.json"
     bl_json = {}
-    bl_md5 = 'e6b6fcd2be74bd08939c64a249ab2125'
+    bl_md5 = 'b62e2394b5bac4dea01cceace04d0359'
     md5_returned = None
 
     @classmethod

--- a/tests/test_bm_rawfio.py
+++ b/tests/test_bm_rawfio.py
@@ -16,7 +16,7 @@ class TestBenchmarkrawfio(unittest.TestCase):
     cl_name = "tools/invariant.yaml"
     bl_name = "tools/baseline.json"
     bl_json = {}
-    bl_md5 = 'e6b6fcd2be74bd08939c64a249ab2125'
+    bl_md5 = 'b62e2394b5bac4dea01cceace04d0359'
     md5_returned = None
 
     @classmethod

--- a/tests/test_bm_rbdfio.py
+++ b/tests/test_bm_rbdfio.py
@@ -16,7 +16,7 @@ class TestBenchmarkrbdfio(unittest.TestCase):
     cl_name = "tools/invariant.yaml"
     bl_name = "tools/baseline.json"
     bl_json = {}
-    bl_md5 = 'e6b6fcd2be74bd08939c64a249ab2125'
+    bl_md5 = 'b62e2394b5bac4dea01cceace04d0359'
     md5_returned = None
 
     @classmethod

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -54,16 +54,6 @@ class TestCliOptions(unittest.TestCase):
 
         self._test_update(self.DEFAULT_NEW_DATA, expected_options)
 
-    def test_update_value_already_exists(self) -> None:
-        """
-        Validate that the values in the CliOptions are not overwritten
-        when a set of new values is passed
-        """
-        expected_options: dict[str, str] = self.DEFAULT_DATA
-        update_data: dict[str, str] = {"iodepth": "22"}
-
-        self._test_update(update_data, expected_options)
-
     def test_add_new_value(self) -> None:
         """
         Validate adding a key/value pair to the CliOptions works
@@ -72,16 +62,6 @@ class TestCliOptions(unittest.TestCase):
         value: str = "value"
         expected_options: dict[str, str] = {key: value}
         expected_options.update(self.DEFAULT_DATA)
-        self._test_add(key, value, expected_options)
-
-    def test_add_value_already_exists(self) -> None:
-        """
-        Validate adding a key that already exists in the CliOptions
-        does not update the existing value for that key
-        """
-        key: str = "mode"
-        value: str = "bob"
-        expected_options: dict[str, str] = self.DEFAULT_DATA
         self._test_add(key, value, expected_options)
 
     def test_get_item_that_exists(self) -> None:

--- a/tests/test_common_output_formatter.py
+++ b/tests/test_common_output_formatter.py
@@ -3,10 +3,11 @@ Unit tests for the CommonOutputFormatter class
 """
 
 import unittest
+from pathlib import Path
 from typing import Dict, List, Union
 
-from post_processing.formatter.common_output_formatter import CommonOutputFormatter
 from post_processing.formatter.benchmark_run_result import BenchmarkRunResult
+from post_processing.formatter.common_output_formatter import CommonOutputFormatter
 
 
 # pyright: ignore[reportPrivateUsage]
@@ -52,7 +53,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
     def setUp(self) -> None:
         print("setting up tests")
         self.formatter = CommonOutputFormatter("/tmp")
-        self.test_run_results = BenchmarkRunResult("/tmp", "unit_tests", "output")
+        self.test_run_results = BenchmarkRunResult(Path("/tmp"), "output")
 
     def test_do_nothing(self) -> None:
         """

--- a/tests/test_common_output_formatter.py
+++ b/tests/test_common_output_formatter.py
@@ -6,7 +6,7 @@ import unittest
 from typing import Dict, List, Union
 
 from post_processing.formatter.common_output_formatter import CommonOutputFormatter
-from post_processing.formatter.test_run_result import TestRunResult
+from post_processing.formatter.benchmark_run_result import BenchmarkRunResult
 
 
 # pyright: ignore[reportPrivateUsage]
@@ -52,7 +52,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
     def setUp(self) -> None:
         print("setting up tests")
         self.formatter = CommonOutputFormatter("/tmp")
-        self.test_run_results = TestRunResult("/tmp", "unit_tests", "output")
+        self.test_run_results = BenchmarkRunResult("/tmp", "unit_tests", "output")
 
     def test_do_nothing(self) -> None:
         """

--- a/tools/baseline.json
+++ b/tools/baseline.json
@@ -1,5 +1,17 @@
 {
     "cephtestrados": {
+        "_workloads": {
+            "_base_run_directory": "/tmp/cbt.XYZ/00000000/CephTestRados/osd_ra-00000000/",
+            "_benchmark_configuration": {
+                "iteration": 0
+            },
+            "_benchmark_type": "",
+            "_executable": "",
+            "_global_options": {
+                "iteration": "0"
+            },
+            "_workloads": []
+        },
         "acceptable": {},
         "archive_dir": "/tmp/results/00000000/id-83a653b5",
         "bools": {
@@ -145,6 +157,18 @@
         }
     },
     "fio": {
+        "_workloads": {
+            "_base_run_directory": "/tmp/cbt.XYZ/00000000/Fio/osd_ra-00000000/",
+            "_benchmark_configuration": {
+                "iteration": 0
+            },
+            "_benchmark_type": "",
+            "_executable": "",
+            "_global_options": {
+                "iteration": "0"
+            },
+            "_workloads": []
+        },
         "acceptable": {},
         "archive_dir": "/tmp/results/00000000/id-83a653b5",
         "bs": null,
@@ -287,7 +311,7 @@
         "random_distribution": null,
         "rate_iops": null,
         "recov_test_type": "blocking",
-        "run_dir": "/tmp/cbt.XYZ/00000000/Fio",
+        "run_dir": "/tmp/cbt.XYZ/00000000/Fio/osd_ra-00000000/",
         "rwmixread": 50,
         "rwmixwrite": 50,
         "size": 4096,
@@ -297,6 +321,18 @@
         "valgrind": null
     },
     "getput": {
+        "_workloads": {
+            "_base_run_directory": "/tmp/cbt.XYZ/00000000/Getput/osd_ra-00000000/",
+            "_benchmark_configuration": {
+                "iteration": 0
+            },
+            "_benchmark_type": "",
+            "_executable": "",
+            "_global_options": {
+                "iteration": "0"
+            },
+            "_workloads": []
+        },
         "acceptable": {},
         "archive_dir": "/tmp/results/00000000/id-83a653b5",
         "auth_urls": [],
@@ -429,7 +465,7 @@
         "out_dir": "/tmp/results/00000000/id-83a653b5/osd_ra-00000000/op_size-04194304/procs-00000001/p/None",
         "pool_profile": "default",
         "procs": 1,
-        "run_dir": "/tmp/cbt.XYZ/00000000/Getput/osd_ra-00000000/op_size-04194304/procs-00000001/p/None",
+        "run_dir": "/tmp/cbt.XYZ/00000000/Getput/osd_ra-00000000//osd_ra-00000000/op_size-04194304/procs-00000001/p/None",
         "runtime": null,
         "subuser": "cbt:swift",
         "test": "p",
@@ -438,6 +474,18 @@
         "valgrind": null
     },
     "hsbench": {
+        "_workloads": {
+            "_base_run_directory": "/tmp/cbt.XYZ/00000000/Hsbench/osd_ra-00000000/",
+            "_benchmark_configuration": {
+                "iteration": 0
+            },
+            "_benchmark_type": "",
+            "_executable": "",
+            "_global_options": {
+                "iteration": "0"
+            },
+            "_workloads": []
+        },
         "acceptable": {},
         "archive_dir": "/tmp/results/00000000/id-83a653b5",
         "bucket_prefix": null,
@@ -572,13 +620,25 @@
         "prefill_modes": "cxip",
         "region": null,
         "report_intervals": null,
-        "run_dir": "/tmp/cbt.XYZ/00000000/Hsbench",
+        "run_dir": "/tmp/cbt.XYZ/00000000/Hsbench/osd_ra-00000000/",
         "size": null,
         "threads": null,
         "tmp_conf": "/tmp/cbt.XYZ/ceph/ceph.conf",
         "valgrind": null
     },
     "kvmrbdfio": {
+        "_workloads": {
+            "_base_run_directory": "/tmp/cbt.XYZ/00000000/KvmRbdFio/osd_ra-00000000/",
+            "_benchmark_configuration": {
+                "iteration": 0
+            },
+            "_benchmark_type": "",
+            "_executable": "",
+            "_global_options": {
+                "iteration": "0"
+            },
+            "_workloads": []
+        },
         "acceptable": {},
         "archive_dir": "/tmp/results/00000000/id-83a653b5",
         "block_device_list": "/dev/vdb",
@@ -727,9 +787,24 @@
         "vol_size": 58982.4
     },
     "librbdfio": {
+        "_iodepth_per_volume": {
+            "0": 16
+        },
+        "_workloads": {
+            "_base_run_directory": "/tmp/cbt.XYZ/00000000/LibrbdFio/osd_ra-00000000/",
+            "_benchmark_configuration": {
+                "iteration": 0
+            },
+            "_benchmark_type": "",
+            "_executable": "",
+            "_global_options": {
+                "iteration": "0"
+            },
+            "_workloads": []
+        },
         "acceptable": {},
         "archive_dir": "/tmp/results/00000000/id-83a653b5",
-        "base_run_dir": "/tmp/cbt.XYZ/00000000/LibrbdFio",
+        "base_run_dir": "/tmp/cbt.XYZ/00000000/LibrbdFio/osd_ra-00000000/op_size-04194304/concurrent_procs-001/iodepth-016/write",
         "cluster": {
             "archive_dir": "/tmp/ceph",
             "auth_urls": [],
@@ -846,7 +921,6 @@
         "data_pool_profile": null,
         "end_fsync": 0,
         "fio_out_format": "json,normal",
-        "global_fio_options": {},
         "idle_monitor_sleep": 60,
         "iodepth": 16,
         "log_avg_msec": null,
@@ -854,7 +928,7 @@
         "log_iops": true,
         "log_lat": true,
         "mode": "write",
-        "names": "--name=cbt-librbdfio-`hostname -f`-file-0 ",
+        "names": "--name=cbt-rbdfio-`hostname -f`-file-0 ",
         "no_sudo": false,
         "norandommap": false,
         "numjobs": 1,
@@ -874,10 +948,10 @@
         "random_distribution": null,
         "rate_iops": null,
         "rbdname": "",
-        "recov_pool_name": "cbt-librbdfio-recov",
+        "recov_pool_name": "cbt-rbdfio-recov",
         "recov_pool_profile": "default",
         "recov_test_type": "blocking",
-        "run_dir": "/tmp/cbt.XYZ/00000000/LibrbdFio/osd_ra-00000000/op_size-04194304/concurrent_procs-001/iodepth-016/write",
+        "run_dir": "/tmp/cbt.XYZ/00000000/LibrbdFio/osd_ra-00000000/op_size-04194304/concurrent_procs-001/iodepth-016/write/osd_ra-00000000/op_size-04194304/concurrent_procs-001/iodepth-016/write",
         "rwmixread": 50,
         "rwmixwrite": 50,
         "time": null,
@@ -888,10 +962,21 @@
         "vol_object_size": 22,
         "vol_size": 65536,
         "volumes_per_client": 1,
-        "wait_pgautoscaler_timeout": -1,
-        "workloads": {}
+        "wait_pgautoscaler_timeout": -1
     },
     "nullbench": {
+        "_workloads": {
+            "_base_run_directory": "/tmp/cbt.XYZ/00000000/Nullbench/osd_ra-00000000/",
+            "_benchmark_configuration": {
+                "iteration": 0
+            },
+            "_benchmark_type": "",
+            "_executable": "",
+            "_global_options": {
+                "iteration": "0"
+            },
+            "_workloads": []
+        },
         "acceptable": [
             1,
             2,
@@ -1015,10 +1100,22 @@
         "log_lat": true,
         "osd_ra": "0",
         "osd_ra_changed": true,
-        "run_dir": "/tmp/cbt.XYZ/00000000/Nullbench",
+        "run_dir": "/tmp/cbt.XYZ/00000000/Nullbench/osd_ra-00000000/",
         "valgrind": null
     },
     "radosbench": {
+        "_workloads": {
+            "_base_run_directory": "/tmp/cbt.XYZ/00000000/Radosbench/osd_ra-00000000/",
+            "_benchmark_configuration": {
+                "iteration": 0
+            },
+            "_benchmark_type": "",
+            "_executable": "",
+            "_global_options": {
+                "iteration": "0"
+            },
+            "_workloads": []
+        },
         "acceptable": {},
         "archive_dir": "/tmp/results/00000000/id-83a653b5",
         "cluster": {
@@ -1161,6 +1258,18 @@
         "write_time": "300"
     },
     "rawfio": {
+        "_workloads": {
+            "_base_run_directory": "/tmp/cbt.XYZ/00000000/RawFio/osd_ra-00000000/",
+            "_benchmark_configuration": {
+                "iteration": 0
+            },
+            "_benchmark_type": "",
+            "_executable": "",
+            "_global_options": {
+                "iteration": "0"
+            },
+            "_workloads": []
+        },
         "acceptable": {},
         "archive_dir": "/tmp/results/00000000/id-83a653b5",
         "block_device_list": "/dev/vdb",
@@ -1296,7 +1405,7 @@
         "out_dir": "/tmp/results/00000000/id-83a653b5/raw_ra-00000000/op_size-04194304/concurrent_procs-001/iodepth-016/write",
         "ramp": "0",
         "rate_iops": null,
-        "run_dir": "/tmp/cbt.XYZ/00000000/RawFio/raw_ra-00000000/op_size-04194304/concurrent_procs-001/iodepth-016/write",
+        "run_dir": "/tmp/cbt.XYZ/00000000/RawFio/osd_ra-00000000/raw_ra-00000000/op_size-04194304/concurrent_procs-001/iodepth-016/write",
         "rwmixread": 50,
         "rwmixwrite": 50,
         "startdelay": null,
@@ -1306,6 +1415,18 @@
         "vol_size": 58982.4
     },
     "rbdfio": {
+        "_workloads": {
+            "_base_run_directory": "/tmp/cbt.XYZ/00000000/RbdFio/osd_ra-00000000/",
+            "_benchmark_configuration": {
+                "iteration": 0
+            },
+            "_benchmark_type": "",
+            "_executable": "",
+            "_global_options": {
+                "iteration": "0"
+            },
+            "_workloads": []
+        },
         "acceptable": {},
         "archive_dir": "/tmp/results/00000000/id-83a653b5",
         "client_ra": 128,
@@ -1443,7 +1564,7 @@
         "random_distribution": null,
         "rbdadd_mons": null,
         "rbdadd_options": "share",
-        "run_dir": "/tmp/cbt.XYZ/00000000/RbdFio/rbdfio/osd_ra-00000000/client_ra-00000128/op_size-04194304/concurrent_procs-001/iodepth-016/write",
+        "run_dir": "/tmp/cbt.XYZ/00000000/RbdFio/osd_ra-00000000/rbdfio/client_ra-00000128/op_size-04194304/concurrent_procs-001/iodepth-016/write",
         "rwmixread": 50,
         "rwmixwrite": 50,
         "time": "None",

--- a/tools/serialise_benchmark.py
+++ b/tools/serialise_benchmark.py
@@ -4,38 +4,43 @@
 # and automated creation of unit tests for them.
 #
 import argparse
-import os, sys
-import pprint
-import json
-from json import JSONEncoder
-import yaml
 import hashlib
+import json
+import os
+import pprint
+import sys
+from json import JSONEncoder
+
+import yaml
+
 import benchmarkfactory
 import settings
 from cluster.ceph import Ceph
 from log_support import setup_loggers
 
-log_fname = '/tmp/cbt-utest.log'
+log_fname = "/tmp/cbt-utest.log"
+
 
 class BenchGenerator(object):
     """
     Class used for the serialisation of the benchmark classes
     and automated generation or unit tests
     """
+
     all_benchmarks = [
-        'nullbench',
-        'fio',
-        'hsbench',
-        'radosbench',
-        'kvmrbdfio',
-        'rawfio',
-        'librbdfio',
-        'cephtestrados',
-        'rbdfio',
-        'getput'
-        ]
+        "nullbench",
+        "fio",
+        "hsbench",
+        "radosbench",
+        "kvmrbdfio",
+        "rawfio",
+        "librbdfio",
+        "cephtestrados",
+        "rbdfio",
+        "getput",
+    ]
     archive_dir = "/tmp"
-    iteration = {'acceptable': [1,2,3], 'iteration': 0}
+    iteration = {"acceptable": [1, 2, 3], "iteration": 0}
     cluster = {}
     bl_name = "tools/baseline.json"
     bl_md5 = None
@@ -45,33 +50,32 @@ class BenchGenerator(object):
     current = {}
 
     def __init__(self):
-        """ Init using mock constructors for a fixed cluster """
+        """Init using mock constructors for a fixed cluster"""
         settings.mock_initialize(config_file=BenchGenerator.cl_name)
         BenchGenerator.cluster = Ceph.mockinit(settings.cluster)
 
     def get_md5_bl(self):
-        """ Calculate the MD5sum from baseline contents """
-        with open(self.bl_name, 'rb') as f:
+        """Calculate the MD5sum from baseline contents"""
+        with open(self.bl_name, "rb") as f:
             data = f.read()
             f.close()
         return hashlib.md5(data).hexdigest()
-        #bl_md5 = hashlib.md5(data.encode("utf-8")).hexdigest()
+        # bl_md5 = hashlib.md5(data.encode("utf-8")).hexdigest()
 
     def gen_json(self):
-        """ Serialise the object into a json file"""
+        """Serialise the object into a json file"""
         result = {}
         for bm in self.all_benchmarks:
-            b = benchmarkfactory.get_object(self.archive_dir,
-                                            self.cluster, bm, self.iteration)
+            b = benchmarkfactory.get_object(self.archive_dir, self.cluster, bm, self.iteration)
             result[bm] = b.__dict__
-        with open(self.bl_name, 'w', encoding='utf-8') as f:
+        with open(self.bl_name, "w", encoding="utf-8") as f:
             json.dump(result, f, sort_keys=True, indent=4, cls=BenchJSONEncoder)
             f.close()
         # data from json.dump() does not support buffer API
         self.bl_md5 = self.get_md5_bl()
 
     def verify_md5(self):
-        """ Verify the MD5SUM of the baseline.json is correct """
+        """Verify the MD5SUM of the baseline.json is correct"""
         md5_returned = self.get_md5_bl()
         if self.bl_md5 == md5_returned:
             print("MD5 verified.")
@@ -81,13 +85,12 @@ class BenchGenerator(object):
             return False
 
     def verify_json(self):
-        """ Verify the baseline json against the current benchmark classes """
-        with open(self.bl_name, 'r') as f:
+        """Verify the baseline json against the current benchmark classes"""
+        with open(self.bl_name, "r") as f:
             self.djson = json.load(f)
             f.close()
         for bm in self.all_benchmarks:
-            b = benchmarkfactory.get_object(self.archive_dir,
-                                            self.cluster, bm, self.iteration)
+            b = benchmarkfactory.get_object(self.archive_dir, self.cluster, bm, self.iteration)
             self.current[bm] = b.__dict__
         # This loop verifies that the active classes have the same attributes
         # as the baseline: no complains would happen if new attributes have been
@@ -99,7 +102,8 @@ class BenchGenerator(object):
                     # We need to skip _iodepth_per_volume here as the json file format
                     # cannot cope with a dictionary that does not use a str as the key.
                     # _iodepth_per_volume is intentionally a dict[int,int]
-                    if k == "cluster" or k == "acceptable" or k == "_iodepth_per_volume":
+                    # _workloads is also a class, so needs to be skipped
+                    if k in ("cluster", "acceptable", "_iodepth_per_volume", "_workloads"):
                         continue
                     if not self.djson[bm][k] == self.current[bm][k]:
                         if isinstance(self.djson[bm][k], dict):
@@ -111,7 +115,7 @@ class BenchGenerator(object):
                             print(f"{bm}[{k}]: {self.djson[bm][k]} vs {self.current[bm][k]}")
 
     def gen_utests(self):
-        """ Generate the unit tests from baseline json against the self.current benchmark classes """
+        """Generate the unit tests from baseline json against the self.current benchmark classes"""
         djson = self.djson
         for bm in djson.keys():
             if isinstance(djson[bm], dict):
@@ -119,12 +123,16 @@ class BenchGenerator(object):
                 input = "tools/test_bm_template.py"
                 out = f"tests/test_bm_{bm}.py"
                 cmd = f"{subst} {input} > {out}"
-                #print(cmd)
+                # print(cmd)
                 os.system(cmd)
                 with open(out, "a") as f:
                     for k in djson[bm].keys():
-                        # Skip Cluster since its a Ceph object, and acceptable is removed
-                        if k == "cluster" or k == "acceptable":
+                        # Skip Cluster since its a Ceph object, and acceptable was removed
+                        # We need to skip _iodepth_per_volume here as the json file format
+                        # cannot cope with a dictionary that does not use a str as the key.
+                        # _iodepth_per_volume is intentionally a dict[int,int]
+                        # _workloads is also a class, so needs to be skipped
+                        if k in ("cluster", "acceptable", "_iodepth_per_volume", "_workloads"):
                             continue
                         ut = f"""
     def test_valid_{k}(self):
@@ -146,8 +154,9 @@ class BenchJSONEncoder(JSONEncoder):
     def default(self, obj):
         return obj.__dict__
 
+
 def main(argv):
-    setup_loggers(log_fname='/tmp/cbt-utest.log')
+    setup_loggers(log_fname="/tmp/cbt-utest.log")
     bg = BenchGenerator()
     bg.gen_json()
     bg.verify_json()
@@ -155,5 +164,6 @@ def main(argv):
     bg.gen_utests()
     return 0
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     exit(main(sys.argv))

--- a/workloads/workload_types.py
+++ b/workloads/workload_types.py
@@ -1,0 +1,9 @@
+"""
+Type definitions for the workloads classes
+"""
+
+from typing import Union
+
+WorkloadType = dict[str, Union[str, list[str]]]
+WorkloadYamlType = dict[str, WorkloadType]
+BenchmarkConfigurationType = dict[str, WorkloadYamlType]


### PR DESCRIPTION
A number of new python classes have been added to CBT in #340 #333 and #320 Although these have been checked by Ruff and mypy for compliance with PEP8, and formatted with Black, pylint had not yet been run.

Therefore pylint was run against all the python files in the post_processing directory, and the workloads directory in the source tree. This highlighted areas where the code could be improved, and places where a more pythonic way of doing things could be employed. These changes were made so that a 10/10 result from pylint was achieved for each file.

The unit tests were run again, and this also exposed some issues that needed fixing.

# Testing

As well as running the unit tests and pylint, the following was tested:
- post process the same set of data before the changes and after the changes. Make sure the report produced is identical
- Run a workload using the same config YAML file and make sure that the same FIO commands were invoked.

## Pylint

### post_processing directory
```
for file in `find post_processing -name "*.py" | grep -v __init__`; do echo $file; PYTHONPATH=. pylint --rcfile pyproject.toml $file; done

post_processing/formatter/common_output_formatter.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/formatter/benchmark_run_result.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/plotter/simple_plotter.py
-------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/plotter/file_comparison_plotter.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/plotter/directory_comparison_plotter.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/plotter/common_format_plotter.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/reports/comparison_report_generator.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/reports/simple_report_generator.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/reports/report_generator.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/common.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/report.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/types.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

post_processing/log_configuration.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

### workloads directory
```
for file in `find workloads -name "*.py" | grep -v __init__`; do echo $file; PYTHONPATH=. pylint --rcfile pyproject.toml $file; done`

workloads/workload.py
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

workloads/workload_types.py
------------------------------------
Your code has been rated at 10.00/10

workloads/workloads.py
-------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 9.87/10, +0.13)
```

## Unit Tests
The Unit Tests now all pass without error.

```
============================= slowest 5 durations ==============================
0.01s setup    tests/test_bm_cephtestrados.py::TestBenchmarkcephtestrados::test_valid_archive_dir
0.01s setup    tests/test_bm_fio.py::TestBenchmarkfio::test_valid_archive_dir
0.01s setup    tests/test_bm_rawfio.py::TestBenchmarkrawfio::test_valid_archive_dir
0.01s call     tests/test_bm_kvmrbdfio.py::TestBenchmarkkvmrbdfio::test_valid_archive_dir
0.01s setup    tests/test_bm_kvmrbdfio.py::TestBenchmarkkvmrbdfio::test_valid_archive_dir
======================== 329 passed, 3 skipped in 0.41s ========================
Finished running tests!
```