### PR TITLE
Post Processing: Refactor of result modules

### DIFF
--- a/benchmark/librbdfio.py
+++ b/benchmark/librbdfio.py
@@ -186,7 +186,8 @@ class LibrbdFio(Benchmark):
                 create_pdf = report_config.get("create_pdf", False),
                 force_refresh = report_config.get("force_refresh", False),
                 no_error_bars = report_config.get("no_error_bars", False),
-                comparison = False
+                comparison = False,
+                plot_resources = report_config.get("plot_resource", False)
             )
             report: Report = Report(report_options)
             report.generate()

--- a/post_processing/common.py
+++ b/post_processing/common.py
@@ -11,7 +11,7 @@ from math import sqrt
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from post_processing.types import CommonFormatDataType
+from post_processing.post_processing_types import CommonFormatDataType
 
 log: Logger = getLogger("cbt")
 
@@ -273,3 +273,17 @@ def sum_standard_deviation_values(
     )
 
     return latency_standard_deviation
+
+
+def file_is_empty(file_path: Path) -> bool:
+    """
+    returns true if the input file contains no data
+    """
+    return file_path.stat().st_size == 0
+
+
+def file_is_precondition(file_path: Path) -> bool:
+    """
+    Check if a file is from a precondition part of a test run
+    """
+    return "precond" in str(file_path)

--- a/post_processing/common.py
+++ b/post_processing/common.py
@@ -70,7 +70,7 @@ def read_intermediate_file(file_path: str) -> CommonFormatDataType:
             data = json.load(file_data)
     except FileNotFoundError:
         log.exception("File %s does not exist", file_path)
-    except IOError:
+    except OSError:
         log.error("Error reading file %s", file_path)
 
     return data
@@ -287,3 +287,19 @@ def file_is_precondition(file_path: Path) -> bool:
     Check if a file is from a precondition part of a test run
     """
     return "precond" in str(file_path)
+
+
+def get_resource_details_from_file(file_path: Path) -> tuple[str, str]:
+    """
+    Return the max CPU and max memory value from an intermnediate file
+
+    :param file_path: Description
+    :type file_path: Path
+    :return: The CPU and memory usage figures for this
+    :rtype: tuple[str, str]
+    """
+    data: CommonFormatDataType = read_intermediate_file(file_path=f"{file_path}")
+
+    max_cpu: float = float(f"{data.get('maximum_cpu_usage', '0')}")
+    max_memory: float = float(f"{data.get('maximum_memory_usage', '0')}")
+    return f"{max_cpu:.2f}", f"{max_memory:.2f}"

--- a/post_processing/formatter/common_output_formatter.py
+++ b/post_processing/formatter/common_output_formatter.py
@@ -19,9 +19,7 @@ The output is a JSON file of the format:
                     runtime_seconds:
                     std_deviation:
                     total_ios:
-                    fio_cpu
-                    osd_cpu
-                    total_cpu
+                    cpu
 
     }
     ...
@@ -32,6 +30,8 @@ The output is a JSON file of the format:
     latency_at_max_bandwidth:
     maximum_iops:
     latency_at_max_iops:
+    maximum_cpu_usage:
+    maximum_memory_usage:
 }
 
 The queue depth details are the sum of the details for write operation
@@ -122,16 +122,21 @@ class CommonOutputFormatter:
                         else:
                             self._formatted_output.update(results.get())
 
+            # add the resource usage class parsing calls here
+
         # get the max bandwidth and associated latency for each test run
         for _, operation_data in self._formatted_output.items():
             for _, blocksize_data in operation_data.items():
                 max_bandwidth, max_bandwidth_latency, max_iops, max_iops_latency = (
                     self._find_maximum_bandwidth_and_iops_with_latency(blocksize_data)
                 )
+                max_cpu, max_memory = self._find_max_resource_usage(blocksize_data)
                 blocksize_data["maximum_bandwidth"] = max_bandwidth
                 blocksize_data["latency_at_max_bandwidth"] = max_bandwidth_latency
                 blocksize_data["maximum_iops"] = max_iops
                 blocksize_data["latency_at_max_iops"] = max_iops_latency
+                blocksize_data["maximum_cpu_usage"] = max_cpu
+                blocksize_data["maximum_memory_usage"] = max_memory
 
     def write_output_file(self) -> None:
         """
@@ -222,11 +227,25 @@ class CommonOutputFormatter:
 
         return (f"{max_bandwidth}", f"{bandwidth_latency_ms}", f"{max_iops}", f"{iops_latency_ms}")
 
-    def _find_unique_results_directories(self) -> list[Path]:
+    def _find_max_resource_usage(self, test_run_data: CommonFormatDataType) -> tuple[str, str]:
         """
-        Find all the unique results directories that contain data for a single
-        run
+        Record the maxumum CPU usage and maximum memory usage for this workload
         """
-        unique_directories: list[Path] = []
+        max_cpu: float = 0
+        max_memory: float = 0
 
-        return unique_directories
+        for _, data in test_run_data.items():
+            if isinstance(data, dict):
+                max_cpu = max(max_cpu, float(data["cpu"]))
+                # max memory here, when we start recording it
+
+        return f"{max_cpu}", f"{max_memory}"
+
+    # def _find_unique_results_directories(self) -> list[Path]:
+    #    """
+    #    Find all the unique results directories that contain data for a single
+    #    run
+    #    """
+    #    unique_directories: list[Path] = []
+
+    #    return unique_directories

--- a/post_processing/formatter/common_output_formatter.py
+++ b/post_processing/formatter/common_output_formatter.py
@@ -93,13 +93,14 @@ class CommonOutputFormatter:
             # When calling from CBT itself this archive dir already includes the testrun directory
             # so we should handle this case here
             testrun_directories: list[Path] = [self._path]
+            results: BenchmarkRunResult
             if "id-" not in f"{self._path}":
                 testrun_directories = list(self._path.glob(f"**/{testrun_id}"))
             if len(testrun_directories) > 1:
                 log.debug(
                     "We have more than one directory for test run %s so using the compatibility method", testrun_id
                 )
-                results: BenchmarkRunResult = BenchmarkRunResult(Path(self._directory), self._filename_root)
+                results = BenchmarkRunResult(Path(self._directory), self._filename_root)
 
                 results.process()
                 self._formatted_output.update(results.get())
@@ -111,9 +112,7 @@ class CommonOutputFormatter:
                     directory for directory in testrun_directory_path.iterdir() if directory.is_dir()
                 ]:
                     log.debug("Looking at results for directory %s", io_pattern_directory)
-                    results: BenchmarkRunResult = BenchmarkRunResult(
-                        directory=io_pattern_directory, file_name_root=self._filename_root
-                    )
+                    results = BenchmarkRunResult(directory=io_pattern_directory, file_name_root=self._filename_root)
                     results.process()
                     processed_results: InternalFormattedOutputType = results.get()
                     for run_type, run_data in processed_results.items():

--- a/post_processing/formatter/common_output_formatter.py
+++ b/post_processing/formatter/common_output_formatter.py
@@ -19,6 +19,10 @@ The output is a JSON file of the format:
                     runtime_seconds:
                     std_deviation:
                     total_ios:
+                    fio_cpu
+                    osd_cpu
+                    total_cpu
+
     }
     ...
     queue_depth_n {
@@ -40,10 +44,9 @@ from logging import Logger, getLogger
 from pathlib import Path
 from typing import Optional
 
-# pylint: disable=[no-name-in-module]
 from common import pdsh  # pyright: ignore[reportUnknownVariableType]
-from post_processing.formatter.benchmark_run_result import BenchmarkRunResult
-from post_processing.types import CommonFormatDataType, InternalFormattedOutputType
+from post_processing.post_processing_types import CommonFormatDataType, InternalFormattedOutputType
+from post_processing.run_result.benchmark import BenchmarkRunResult
 
 log: Logger = getLogger("formatter")
 

--- a/post_processing/log_configuration.py
+++ b/post_processing/log_configuration.py
@@ -7,7 +7,7 @@ import os
 from logging import Logger, getLogger
 from typing import Any
 
-from post_processing.types import HandlerType
+from post_processing.post_processing_types import HandlerType
 
 LOGFILE_LOCATION: str = os.getenv("CBT_PP_LOGFILE_LOCATION", "/tmp")
 LOGFILE_NAME_BASE: str = f"{LOGFILE_LOCATION}/cbt/post_processing"

--- a/post_processing/plotter/axis_plotter.py
+++ b/post_processing/plotter/axis_plotter.py
@@ -1,0 +1,96 @@
+"""
+A base class for recording data points for a plot axis, and plotting the axis.
+the x-axis data is fixed for all sub-types, only the y-data changes
+"""
+
+from abc import ABC, abstractmethod
+from logging import Logger, getLogger
+
+from matplotlib.axes import Axes
+
+log: Logger = getLogger("plotter")
+
+
+class AxisPlotter(ABC):
+    """
+    A class to add the resource use measurements to a plot as separate axes
+    """
+
+    def __init__(self, main_axis: Axes) -> None:
+        """
+        Docstring for __init__
+
+        :param main_axis: The main axis for this plot
+        :type main_axis: Axes
+        :param main_axis: The main axis for this plot
+        :type main_axis: Axes
+        """
+        self._main_axes = main_axis
+        self._y_data: list[float] = []
+        self._y_label: str = ""
+        self._label: str = ""
+
+    @property
+    def y_label(self) -> str:
+        """
+        Return the value for the y_label that is set.
+        This is currently not called, but is required for the corresponding
+        setter to function
+
+        :return: The value stored for the y label
+        :rtype: str
+        """
+        return self._y_label
+
+    @y_label.setter
+    def y_label(self, label: str) -> None:
+        if self._y_label:
+            log.warning("Y label value already set to %s, changing to %s", self._y_label, label)
+        self._y_label = label
+
+    @property
+    def plot_label(self) -> str:
+        """
+        return the value of the label set for this particular plot, as used
+        in the legend to the plot.
+
+        :return: The label that is currently set
+        :rtype: str
+        """
+        return self._label
+
+    @plot_label.setter
+    def plot_label(self, label: str) -> None:
+        if self._label:
+            log.warning("Plot label value already set to %s, changing to %s", self._label, label)
+        self._label = label
+
+    @abstractmethod
+    def plot(self, x_data: list[float], colour: str = "") -> None:
+        """
+        Plot the data for the axis
+
+        :param x_data: The data for the x-axis
+        :type x_data: list[Union[int, float]]
+        :param colour: The colour for the axis and plot line
+        :type colour: str
+        """
+
+    @abstractmethod
+    def add_y_data(self, data_value: str) -> None:
+        """
+        Add a point of data to the y axis
+
+        :param data_value:The value to add to the plot
+        :type data_value: str
+        """
+
+    def _plot(self, x_data: list[float], axis: Axes, colour: str) -> None:
+        """
+        Plot this axis
+        """
+        axis.set_ylabel(self._y_label)  # pyright: ignore[reportUnknownMemberType]
+        axis.tick_params(axis="y", colors=colour)  # pyright: ignore[reportUnknownMemberType]
+        axis.plot(  # pyright: ignore[reportUnknownMemberType]
+            x_data, self._y_data, "+-", color=colour, label=self._label
+        )

--- a/post_processing/plotter/common_format_plotter.py
+++ b/post_processing/plotter/common_format_plotter.py
@@ -17,7 +17,7 @@ from post_processing.common import (
     PLOT_FILE_EXTENSION,
     get_blocksize_percentage_operation_from_file_name,
 )
-from post_processing.types import CommonFormatDataType, PlotDataType
+from post_processing.post_processing_types import CommonFormatDataType, PlotDataType
 
 log: Logger = getLogger("plotter")
 

--- a/post_processing/plotter/cpu_plotter.py
+++ b/post_processing/plotter/cpu_plotter.py
@@ -1,0 +1,35 @@
+"""
+A file containing the classes and code required to add a resource usage
+data line to a plot
+"""
+
+from logging import Logger, getLogger
+
+from post_processing.plotter.axis_plotter import AxisPlotter
+
+log: Logger = getLogger("plotter")
+
+CPU_PLOT_DEFAULT_COLOUR: str = "#5ca904"
+CPU_Y_LABEL: str = "System CPU use (%)"
+CPU_PLOT_LABEL: str = "CPU use"
+
+
+class CPUPlotter(AxisPlotter):
+    """
+    A class to add the resource use measurements to a plot as separate axes
+    """
+
+    def add_y_data(self, data_value: str) -> None:
+        """
+        Add a point of CPU data for this plot
+
+        :param cpu_value: A single value for CPU usage
+        :type cpu_value: str
+        """
+        self._y_data.append(float(data_value))
+
+    def plot(self, x_data: list[float], colour: str = "") -> None:
+        cpu_axis = self._main_axes.twinx()
+        self._label = CPU_PLOT_LABEL
+        self._y_label = CPU_Y_LABEL
+        self._plot(x_data=x_data, axis=cpu_axis, colour=CPU_PLOT_DEFAULT_COLOUR)

--- a/post_processing/plotter/directory_comparison_plotter.py
+++ b/post_processing/plotter/directory_comparison_plotter.py
@@ -31,6 +31,7 @@ class DirectoryComparisonPlotter(CommonFormatPlotter):
     def __init__(self, output_directory: str, directories: list[str]) -> None:
         self._output_directory: str = f"{output_directory}"
         self._comparison_directories: list[Path] = [Path(f"{directory}/visualisation") for directory in directories]
+        super().__init__(plotter)
 
     def draw_and_save(self) -> None:
         # output_file_path: str = self._generate_output_file_name(files=self._comparison_directories)
@@ -45,22 +46,23 @@ class DirectoryComparisonPlotter(CommonFormatPlotter):
             for directory in self._comparison_directories:
                 file_data: CommonFormatDataType = read_intermediate_file(f"{directory}/{file_name}")
                 # we choose the last directory name for the label to apply to the data
-                self._add_single_file_data(
-                    plotter=plotter,
+                self._add_single_file_data_with_optional_errorbars(
                     file_data=file_data,
                     label=f"{directory.parts[-2]}",
+                    plot_error_bars=False,
+                    plot_resource_usage=False,
                 )
 
-            self._add_title(plotter=plotter, source_files=[Path(file_name)])
-            self._set_axis(plotter=plotter)
+            self._add_title(source_files=[Path(file_name)])
+            self._set_axis()
 
             # make sure we add the legend to the plot
             plotter.legend(  # pyright: ignore[reportUnknownMemberType]
                 bbox_to_anchor=(0.5, -0.1), loc="upper center", ncol=2
             )
 
-            self._save_plot(plotter=plotter, file_path=output_file_path)
-            self._clear_plot(plotter=plotter)
+            self._save_plot(file_path=output_file_path)
+            self._clear_plot()
 
     def _generate_output_file_name(self, files: list[Path]) -> str:
         # we know we will only ever be passed a single file name

--- a/post_processing/plotter/directory_comparison_plotter.py
+++ b/post_processing/plotter/directory_comparison_plotter.py
@@ -15,7 +15,7 @@ from post_processing.common import (
     read_intermediate_file,
 )
 from post_processing.plotter.common_format_plotter import CommonFormatPlotter
-from post_processing.types import CommonFormatDataType
+from post_processing.post_processing_types import CommonFormatDataType
 
 log: Logger = getLogger("plotter")
 

--- a/post_processing/plotter/file_comparison_plotter.py
+++ b/post_processing/plotter/file_comparison_plotter.py
@@ -33,6 +33,7 @@ class FileComparisonPlotter(CommonFormatPlotter):
         self._output_directory: str = f"{output_directory}"
         self._comparison_files: list[Path] = [Path(file) for file in files]
         self._labels: Optional[list[str]] = None
+        super().__init__(plotter=plotter)
 
     def draw_and_save(self) -> None:
         output_file_path: str = self._generate_output_file_name(files=self._comparison_files)
@@ -55,17 +56,19 @@ class FileComparisonPlotter(CommonFormatPlotter):
             if label == "":
                 label = " ".join(operation_details)
 
-            self._add_single_file_data(plotter=plotter, file_data=file_data, label=label)
+            self._add_single_file_data_with_optional_errorbars(
+                file_data=file_data, label=label, plot_error_bars=False, plot_resource_usage=False
+            )
 
         # make sure we add the legend to the plot, below the chart
         plotter.legend(  # pyright: ignore[reportUnknownMemberType]
             bbox_to_anchor=(0.5, -0.1), loc="upper center", ncol=2
         )
 
-        self._add_title(plotter=plotter, source_files=self._comparison_files)
-        self._set_axis(plotter=plotter)
-        self._save_plot(plotter=plotter, file_path=output_file_path)
-        self._clear_plot(plotter=plotter)
+        self._add_title(source_files=self._comparison_files)
+        self._set_axis()
+        self._save_plot(file_path=output_file_path)
+        self._clear_plot()
 
     def set_labels(self, labels: list[str]) -> None:
         """

--- a/post_processing/plotter/file_comparison_plotter.py
+++ b/post_processing/plotter/file_comparison_plotter.py
@@ -17,7 +17,7 @@ from post_processing.common import (
     read_intermediate_file,
 )
 from post_processing.plotter.common_format_plotter import CommonFormatPlotter
-from post_processing.types import CommonFormatDataType
+from post_processing.post_processing_types import CommonFormatDataType
 
 log: Logger = getLogger("plotter")
 

--- a/post_processing/plotter/io_plotter.py
+++ b/post_processing/plotter/io_plotter.py
@@ -1,0 +1,53 @@
+"""
+A file containing the classes and code required to add an IO usage
+data line to a plot
+"""
+
+from logging import Logger, getLogger
+
+from post_processing.plotter.axis_plotter import AxisPlotter
+
+log: Logger = getLogger("plotter")
+
+IO_PLOT_DEFAULT_COLOUR: str = "#5ca904"
+IO_Y_LABEL: str = "CPU use (%)"
+IO_PLOT_LABEL: str = "CPU use"
+
+
+class IOPlotter(AxisPlotter):
+    """
+    A class to add the resource use measurements to a plot as separate axes
+    """
+
+    def add_y_data(self, data_value: str) -> None:
+        """
+        Add a point of CPU data for this plot
+
+        :param cpu_value: A single value for CPU usage
+        :type cpu_value: str
+        """
+        self._y_data.append(float(data_value) / (1000 * 1000))
+
+    def plot(self, x_data: list[float], colour: str = "") -> None:
+        """
+        This should never be called for an IO plot, so assert if it is
+        """
+        raise NotImplementedError
+
+    def plot_with_error_bars(self, x_data: list[float], error_data: list[float], cap_size: int) -> None:
+        """
+        Docstring for plot_with_error_bars
+
+        :param x_data: The data for the x-axis
+        :type x_data: list[float]
+        :param error_data: the error bar data
+        :type error_data: list[float]
+        :param colour: The colour for the I/O line
+        :type colour: str
+        """
+        io_axis = self._main_axes
+        io_axis.set_ylabel(self._y_label)  # pyright: ignore[reportUnknownMemberType]
+        # io_axis.tick_params(axis="y")  # pyright: ignore[reportUnknownMemberType]
+        io_axis.errorbar(  # pyright: ignore[reportUnknownMemberType]
+            x_data, self._y_data, yerr=error_data, fmt="+-", capsize=cap_size, ecolor="red", label=self._label
+        )

--- a/post_processing/plotter/memory_plotter.py
+++ b/post_processing/plotter/memory_plotter.py
@@ -1,0 +1,36 @@
+"""
+A file containing the classes and code required to add a memory usage
+data line to a plot
+"""
+
+from logging import Logger, getLogger
+from typing import Union
+
+from post_processing.plotter.axis_plotter import AxisPlotter
+
+log: Logger = getLogger("plotter")
+
+MEMORY_PLOT_DEFAULT_COLOUR: str = "#4b006e"
+MEMORY_Y_LABEL: str = "Memory use (Mb)"
+MEMORY_PLOT_LABEL: str = "Memory use"
+
+
+class MemoryPlotter(AxisPlotter):
+    """
+    A class to add the resource use measurements to a plot as separate axes
+    """
+
+    def add_y_data(self, data_value: str) -> None:
+        """
+        Add a point of memory usage data for this plot
+
+        :param memory_value: A single value for memory usage
+        :type memory_value: str
+        """
+        self._y_data.append(float(data_value))
+
+    def plot(self, x_data: list[Union[int, float]], colour: str = "") -> None:
+        memory_axis = self._main_axes.twinx()
+        self._label = MEMORY_PLOT_LABEL
+        self._y_label = MEMORY_Y_LABEL
+        self._plot(x_data=x_data, axis=memory_axis, colour=MEMORY_PLOT_DEFAULT_COLOUR)

--- a/post_processing/plotter/simple_plotter.py
+++ b/post_processing/plotter/simple_plotter.py
@@ -15,7 +15,7 @@ from post_processing.common import (
     read_intermediate_file,
 )
 from post_processing.plotter.common_format_plotter import CommonFormatPlotter
-from post_processing.types import CommonFormatDataType
+from post_processing.post_processing_types import CommonFormatDataType
 
 
 # pylint: disable=too-few-public-methods

--- a/post_processing/plotter/simple_plotter.py
+++ b/post_processing/plotter/simple_plotter.py
@@ -7,6 +7,7 @@ produce a hockey-stick curve graph
 from pathlib import Path
 
 import matplotlib.pyplot as plotter
+from matplotlib.figure import Figure
 
 from post_processing.common import (
     DATA_FILE_EXTENSION,
@@ -25,22 +26,32 @@ class SimplePlotter(CommonFormatPlotter):
     curve plot that includes standard deviation error bars.
     """
 
-    def __init__(self, archive_directory: str, plot_error_bars: bool) -> None:
+    def __init__(self, archive_directory: str, plot_error_bars: bool, plot_resources: bool) -> None:
         # A Path object for the directory where the data files are stored
         self._path: Path = Path(f"{archive_directory}/visualisation")
         self._plot_error_bars: bool = plot_error_bars
+        self._plot_resources: bool = plot_resources
+        super().__init__(plotter)
 
     def draw_and_save(self) -> None:
         for file_path in self._path.glob(f"*{DATA_FILE_EXTENSION_WITH_DOT}"):
             file_data: CommonFormatDataType = read_intermediate_file(f"{file_path}")
             output_file_path: str = self._generate_output_file_name(files=[file_path])
-            self._add_single_file_data_with_optional_errorbars(
-                plotter=plotter, file_data=file_data, plot_error_bars=self._plot_error_bars
+            figure: Figure = self._add_single_file_data_with_optional_errorbars(
+                file_data=file_data, plot_error_bars=self._plot_error_bars, plot_resource_usage=self._plot_resources
             )
-            self._add_title(plotter=plotter, source_files=[file_path])
-            self._set_axis(plotter=plotter)
-            self._save_plot(plotter=plotter, file_path=output_file_path)
-            self._clear_plot(plotter=plotter)
+            self._add_title(source_files=[file_path])
+            self._set_axis()
+
+            # make sure we add the legend to the plot
+            figure.legend(  # pyright: ignore[reportUnknownMemberType]
+                bbox_to_anchor=(0.5, -0.1),
+                loc="upper center",
+                ncol=2,
+            )
+
+            self._save_plot(file_path=output_file_path)
+            self._clear_plot()
 
     def _generate_output_file_name(self, files: list[Path]) -> str:
         # we know we will only ever be passed a single file name

--- a/post_processing/post_processing_types.py
+++ b/post_processing/post_processing_types.py
@@ -7,6 +7,10 @@ from typing import NamedTuple, Union
 
 
 class CPUPlotType(Enum):
+    """
+    The different options for producing a plot of CPU data.
+    """
+
     NOCPU = 0
     OVERALL = auto()
     OSD = auto()
@@ -26,7 +30,7 @@ class ReportOptions(NamedTuple):
     force_refresh: bool
     no_error_bars: bool
     comparison: bool
-    cpu_plot: CPUPlotType = CPUPlotType.NOCPU
+    plot_resources: bool
 
 
 # Log setup types

--- a/post_processing/post_processing_types.py
+++ b/post_processing/post_processing_types.py
@@ -2,7 +2,32 @@
 A file to contain common type definitions for use in the post-processing
 """
 
-from typing import Union
+from enum import Enum, auto
+from typing import NamedTuple, Union
+
+
+class CPUPlotType(Enum):
+    NOCPU = 0
+    OVERALL = auto()
+    OSD = auto()
+    FIO = auto()
+    NODES = auto()
+
+
+class ReportOptions(NamedTuple):
+    """
+    This class is used to store the options required to create a report.
+    """
+
+    archives: list[str]
+    output_directory: str
+    results_file_root: str
+    create_pdf: bool
+    force_refresh: bool
+    no_error_bars: bool
+    comparison: bool
+    cpu_plot: CPUPlotType = CPUPlotType.NOCPU
+
 
 # Log setup types
 HandlerType = dict[str, dict[str, str]]

--- a/post_processing/report.py
+++ b/post_processing/report.py
@@ -11,29 +11,16 @@ import os
 import traceback
 from argparse import Namespace
 from logging import Logger, getLogger
-from typing import NamedTuple
 
 from post_processing.formatter.common_output_formatter import CommonOutputFormatter
 from post_processing.log_configuration import setup_logging
+from post_processing.post_processing_types import ReportOptions
 from post_processing.reports.comparison_report_generator import ComparisonReportGenerator
+from post_processing.reports.report_generator import ReportGenerator
 from post_processing.reports.simple_report_generator import SimpleReportGenerator
 
 setup_logging()
 log: Logger = getLogger("reports")
-
-
-class ReportOptions(NamedTuple):
-    """
-    This class is used to store the options required to create a report.
-    """
-
-    archives: list[str]
-    output_directory: str
-    results_file_root: str
-    create_pdf: bool
-    force_refresh: bool
-    no_error_bars: bool
-    comparison: bool
 
 
 def parse_namespace_to_options(arguments: Namespace, comparison_report: bool = False) -> ReportOptions:
@@ -95,6 +82,7 @@ class Report:
 
         try:
             self._generate_intermediate_files()
+            report_generator: ReportGenerator
 
             if self._options.comparison:
                 report_generator = ComparisonReportGenerator(

--- a/post_processing/reports/comparison_report_generator.py
+++ b/post_processing/reports/comparison_report_generator.py
@@ -177,7 +177,16 @@ class ComparisonReportGenerator(ReportGenerator):
         file_paths: list[Path] = []
 
         for directory in self._archive_directories:
-            file_paths.extend([path for path in directory.parents if f"{path}".endswith("/results")])
+            # Because this can either be called ruring a run, or separately afterwards the
+            # archive directory passed may be at a different point in the directory tree.
+            # We therefore need to search both above and below the current directory for
+            # the config yaml
+            paths: list[Path] = [path for path in directory.parents if f"{path}".endswith("/results")]
+            if len(paths) == 0:
+                paths = [path for path in directory.iterdir() if f"{path}".endswith("/results")]
+
+            for path in paths:
+                file_paths.extend(path.glob("**/cbt_config.yaml"))
 
         return file_paths
 

--- a/post_processing/reports/report_generator.py
+++ b/post_processing/reports/report_generator.py
@@ -44,9 +44,11 @@ class ReportGenerator(ABC):
         output_directory: str,
         no_error_bars: bool = False,
         force_refresh: bool = False,
+        plot_resources: bool = False,
     ) -> None:
         self._plot_error_bars: bool = not no_error_bars
         self._force_refresh: bool = force_refresh
+        self._plot_resources: bool = plot_resources
 
         self._archive_directories: list[Path] = []
         self._data_directories: list[Path] = []

--- a/post_processing/reports/simple_report_generator.py
+++ b/post_processing/reports/simple_report_generator.py
@@ -155,6 +155,13 @@ class SimpleReportGenerator(ReportGenerator):
         file_paths: list[Path] = [
             path for path in self._archive_directories[0].parents if f"{path}".endswith("/results")
         ]
+        # Because this can either be called ruring a run, or separately afterwards the
+        # archive directory passed may be at a different point in the directory tree.
+        # We therefore need to search both above and below the current directory for
+        # the config yaml
+        if len(file_paths) == 0:
+            file_paths = [path for path in self._archive_directories[0].iterdir() if f"{path}".endswith("/results")]
+
         yaml_file_path: list[Path] = list(file_paths[0].glob("**/cbt_config.yaml"))
 
         # This should only ever return a single path as each archive directory

--- a/post_processing/reports/simple_report_generator.py
+++ b/post_processing/reports/simple_report_generator.py
@@ -22,6 +22,7 @@ from post_processing.common import (
     TITLE_CONVERSION,
     get_blocksize_percentage_operation_from_file_name,
     get_latency_throughput_from_file,
+    get_resource_details_from_file,
     strip_confidential_data_from_yaml,
 )
 from post_processing.plotter.simple_plotter import SimplePlotter
@@ -59,8 +60,15 @@ class SimpleReportGenerator(ReportGenerator):
 
         log.info("Generating summary table")
 
-        self._report.new_line(text="|Workload Name|Maximum Throughput|Latency (ms)|")
-        self._report.new_line(text="| :--- | ---: | ---: |")
+        headers: str = "|Workload Name|Maximum Throughput|Latency (ms)|"
+        alignment: str = "| :--- | ---: | ---: |"
+
+        if self._plot_resources:
+            alignment += " ---: |"
+            headers += "System CPU (%)|"
+
+        self._report.new_line(text=headers)
+        self._report.new_line(text=alignment)
 
         data_tables: dict[str, list[str]] = {}
         for _, operation in TITLE_CONVERSION.items():
@@ -72,9 +80,11 @@ class SimpleReportGenerator(ReportGenerator):
                 #    for file_path in self._data_files[file_name]:
                 log.debug("Looking at file %s", file_path)
                 (max_throughput, latency_ms) = get_latency_throughput_from_file(file_path)
+                (cpu_usage, _) = get_resource_details_from_file(file_path)
+                # Eventually we will return the memory usage here, but for the first pass we'll just grab CPU
 
                 (_, _, operation) = get_blocksize_percentage_operation_from_file_name(file_path.stem)
-                data: str = f"|[{file_path.stem}](#{file_path.stem.replace('_', '-')})|{max_throughput}|{latency_ms}|"
+                data: str = f"|[{file_path.stem}](#{file_path.stem.replace('_', '-')})|{max_throughput}|{latency_ms}|{cpu_usage}|"
 
                 data_tables[operation].append(data)
 
@@ -139,7 +149,7 @@ class SimpleReportGenerator(ReportGenerator):
 
             # If there are no plotfiles in the directory then we should create them
             if len(plot_files) == 0 or self._force_refresh:
-                plotter = SimplePlotter(str(directory.parent), self._plot_error_bars)
+                plotter = SimplePlotter(str(directory.parent), self._plot_error_bars, self._plot_resources)
                 plotter.draw_and_save()
                 plot_files.extend(list(directory.glob(f"*{PLOT_FILE_EXTENSION_WITH_DOT}")))
 

--- a/post_processing/run_result/benchmark.py
+++ b/post_processing/run_result/benchmark.py
@@ -43,9 +43,9 @@ class BenchmarkRunResult(RunResult):
             iodepth_details: dict[str, IodepthDataType] = {iodepth: global_details}
 
             # This is intentionally commented out.
-            # sys_cpu: int = int(f"{data['jobs']['sys_cpu']}")
-            # user_cpu: int = int(f"{data['jobs']['usr_cpu']}")
-            # cpu_usage: str = f"{sys_cpu + user_cpu}"
+            sys_cpu: float = float(f"{data['jobs'][0]['sys_cpu']}")
+            user_cpu: float = float(f"{data['jobs'][0]['usr_cpu']}")
+            cpu_usage: str = f"{sys_cpu + user_cpu}"
 
             io_details: IodepthDataType = {}
 
@@ -67,7 +67,7 @@ class BenchmarkRunResult(RunResult):
 
             iodepth_details[iodepth].update(io_details)
             # TODO: add in resource stats here:
-            # iodepth_details[iodepth].update({"fio_cpu": cpu_usage})
+            iodepth_details[iodepth].update({"cpu": cpu_usage})
             blocksize_details[blocksize].update(iodepth_details)
 
             if self._processed_data.get(operation, None):

--- a/post_processing/run_result/benchmark.py
+++ b/post_processing/run_result/benchmark.py
@@ -245,6 +245,7 @@ class BenchmarkRunResult(RunResult):
             for value in logfile_name.split("/"):
                 if "total_iodepth" in value:
                     logfile_iodepth = int(value[len("total_iodepth") + 1 :])
+                    break
 
                 elif "iodepth" in value:
                     logfile_iodepth = int(value[len("iodepth") + 1 :])

--- a/post_processing/run_result/collectl.py
+++ b/post_processing/run_result/collectl.py
@@ -1,0 +1,90 @@
+"""
+A RunResult class that deals with reading copllectl results and parsing them
+into the common output format
+"""
+
+import re
+from logging import Logger, getLogger
+from pathlib import Path
+from typing import Any
+
+from post_processing.run_result.resource_result import ResourceResult
+
+log: Logger = getLogger("formatter")
+
+
+class Collectl(ResourceResult):
+    """
+    Collectl results processing
+    """
+
+    def _get_resource_output_file_from_file_path(self, file_path: Path) -> Path:
+        # The collectl results are stored in a collectl directory in the
+        # <bs_io_type><numjobs>/<total_iodepth>/<iodepth>/ directory so
+        # already saved in a helpful directory structure
+        resource_directory: Path = Path(f"{file_path.parent}/collectl")
+        resource_files: list[Path] = [path for path in resource_directory.glob("**/*.cpu")]
+        # There should only ever be one *.cpu file, but if there are more always use the first
+        # one anyway
+        if len(resource_files) > 1:
+            log.warning(
+                "More than one *.cpu file found in directory %s, using the first entry only: %s",
+                resource_directory,
+                resource_files[0],
+            )
+        return resource_files[0]
+
+    def _parse(self, data: dict[str, Any]) -> tuple[str, str]:
+        return super()._parse(data)
+        # The data format here is:
+        # {'#Date': '20250715','Time': '14:40:08',
+        #'[CPU:0]Guest%': '0','[CPU:0]GuestN%': '0','[CPU:0]Idle%': '47',
+        #'[CPU:0]Intrpt': '0','[CPU:0]Irq%': '2','[CPU:0]Nice%': '0',
+        #'[CPU:0]Soft%': '2','[CPU:0]Steal%': '0','[CPU:0]Sys%': '13',
+        #'[CPU:0]Totl%': '53','[CPU:0]User%': '37','[CPU:0]Wait%': '1',
+        #
+        #'[CPU:100]Guest%': '0','[CPU:100]GuestN%': '0','[CPU:100]Idle%': '50',
+        #'[CPU:100]Intrpt': '0','[CPU:100]Irq%': '1','[CPU:100]Nice%': '0',
+        #'[CPU:100]Soft%': '1','[CPU:100]Steal%': '0','[CPU:100]Sys%': '12',
+        #'[CPU:100]Totl%': '50','[CPU:100]User%': '35','[CPU:100]Wait%': '1',
+        #
+        # and so on for each CPU in the machine
+
+    def _read_file(self, line_separator: str = ",") -> dict[str, dict[str, str]]:
+        # we need to cope with the different collectl output file formats here
+        # The ones we know about are:
+        # - Summary
+        # - Detail file
+        # - Others??? Top style, per-process?
+        if self._contains_summary_data():
+            return self._read_summary_file(line_separator)
+        return {}
+
+    def _read_summary_file(self, line_separator: str = ",") -> dict[str, dict[str, str]]:
+        """
+        If the collectl file contains summary data then this is the method we
+        can use to parse the file
+        """
+        raw_data: dict[str, dict[str, str]] = {}
+
+        filtered_lines: list[str] = [
+            line
+            for line in self._resource_file_path.read_text(encoding="utf-8").splitlines()
+            if not line.startswith("# ") and not line.startswith("##")
+        ]
+
+        headings: list[str] = filtered_lines.pop(0).split(line_separator)
+        for line in filtered_lines:
+            raw_data.update({line[1]: dict(zip(headings, line))})
+
+        return raw_data
+
+    def _contains_summary_data(self) -> bool:
+        """
+        does the file contain collectl summary data
+        """
+        summary_data: bool = True
+        for line in self._resource_file_path.read_text(encoding="utf-8").splitlines():
+            if re.search(r"[CPU\d+]", line):
+                summary_data = False
+        return summary_data

--- a/post_processing/run_result/resource_result.py
+++ b/post_processing/run_result/resource_result.py
@@ -1,0 +1,86 @@
+"""
+A class that encapsulates the resource usage results from a benchmark run
+
+This could be CPU, Memory etc
+"""
+
+from abc import ABC, abstractmethod
+from logging import Logger, getLogger
+from pathlib import Path
+from typing import Any
+
+from post_processing.common import file_is_empty
+
+log: Logger = getLogger("formatter")
+
+
+class ResourceResult(ABC):
+    """
+    This is the top level class for a resource run result. As each
+    resource monitoring toop produces different output results we will need a
+    sub-class for each type
+    """
+
+    def __init__(self, file_path: Path) -> None:
+        self._resource_file_path: Path = self._get_resource_output_file_from_file_path(file_path)
+        self._cpu: str = ""
+        self._memory: str = ""
+        self._has_been_parsed: bool = False
+
+    @property
+    def cpu_statistics(self) -> str:
+        """
+        The CPU usage statistics for this particular workload
+        """
+        return self._cpu
+
+    @property
+    def memory_statistics(self) -> str:
+        """
+        The memory usage statistics
+        """
+        return self._memory
+
+    @abstractmethod
+    def _get_resource_output_file_from_file_path(self, file_path: Path) -> Path:
+        """
+        Given a particular resource file name find the corresponding
+        resource usage statistics file path
+        """
+
+    @abstractmethod
+    def _parse(self, data: dict[str, Any]) -> tuple[str, str]:
+        """
+        Read the resource usage data from the read data and return the
+        relevant resource usage statistics
+        """
+
+    @abstractmethod
+    def _read_results_from_file(self) -> dict[str, Any]:
+        """
+        Read the data from the results file and return the results in a dict
+        """
+
+    def _add_data_to_common_format_file(self) -> None:
+        """
+        Add the data from the resource monitoring into the common output
+        format file for this test run
+        """
+        if file_is_empty(self._resource_file_path):
+            log.warning("Unable to process file %s as it is empty", self._resource_file_path)
+            return
+
+        raw_data = self._read_results_from_file()
+        self._parse(raw_data)
+
+        # TODO: add the data to the results file
+
+        # The following should be in the fio sub module
+        # try:
+        #    with self._resource_file_path.open("r", encoding="utf-8") as file:
+        #        data: dict[str, Any] = json.load(file)
+        #        self._cpu, self._memory = self._parse(data)
+        #        self._has_been_parsed = True
+
+        # except json.JSONDecodeError:
+        #    log.warning("Unable to process file %s as it is not in json format", self._resource_file_path)

--- a/post_processing/run_result/run_result.py
+++ b/post_processing/run_result/run_result.py
@@ -1,0 +1,88 @@
+"""
+The base class that reads a results file and converts it into the
+common data format that can be plotted
+"""
+
+from abc import ABC, abstractmethod
+from logging import Logger, getLogger
+from pathlib import Path
+
+from post_processing.common import file_is_empty, file_is_precondition
+from post_processing.post_processing_types import InternalFormattedOutputType
+
+log: Logger = getLogger("formatter")
+
+
+class RunResult(ABC):
+    """
+    A result run file that needs processing
+    """
+
+    def __init__(self, directory: Path, file_name_root: str) -> None:
+        self._path: Path = directory
+        self._has_been_processed: bool = False
+
+        self._files: list[Path] = self._find_files_for_testrun(file_name_root=file_name_root)
+        self._processed_data: InternalFormattedOutputType = {}
+
+    @abstractmethod
+    def _find_files_for_testrun(self, file_name_root: str) -> list[Path]:
+        """
+        Find the relevant output files for this type of benchmark run
+
+        These will be specific to a benchmark type or data type
+        """
+
+    @abstractmethod
+    def _convert_file(self, file_path: Path) -> None:
+        """
+        convert the contents of a single output file from the run into the
+        JSON format we want for writing the graphs
+        """
+
+    def process(self) -> None:
+        """
+        Convert the results data from all the individual files that make up this
+        result into the standard intermediate format
+        """
+        number_of_volumes_for_test_run: int = len(self._files)
+
+        if number_of_volumes_for_test_run > 0:
+            self._process_test_run_files()
+        else:
+            log.warning("test run with directory %s has no files - not doing any conversion", self._path)
+
+        self._has_been_processed = True
+
+    def have_been_processed(self) -> bool:
+        """
+        True if we have already processed the files for this set of results,
+        otherwise False
+        """
+        return self._has_been_processed
+
+    def get(self) -> InternalFormattedOutputType:
+        """
+        Return the processed results
+        """
+
+        if not self._has_been_processed:
+            self.process()
+
+        return self._processed_data
+
+    def _process_test_run_files(self) -> None:
+        """
+        If there is only details for a single volume then we can convert the
+        data from the fio output directly into our output format
+        """
+        for file_path in self._files:
+            if not file_is_empty(file_path):
+                if not file_is_precondition(file_path):
+                    log.debug("Processing file %s", file_path)
+                    self._convert_file(file_path)
+                else:
+                    log.warning("Not processing file %s as it is from a precondition operation", file_path)
+                    self._files.remove(file_path)
+            else:
+                log.warning("Cannot process file %s as it is empty", file_path)

--- a/post_processing/run_result/run_result.py
+++ b/post_processing/run_result/run_result.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from post_processing.common import file_is_empty, file_is_precondition
 from post_processing.post_processing_types import InternalFormattedOutputType
 
+# from post_processing.run_result.resource_result import ResourceResult
+
 log: Logger = getLogger("formatter")
 
 
@@ -21,6 +23,7 @@ class RunResult(ABC):
     def __init__(self, directory: Path, file_name_root: str) -> None:
         self._path: Path = directory
         self._has_been_processed: bool = False
+        # self._resource_result: ResourceResult
 
         self._files: list[Path] = self._find_files_for_testrun(file_name_root=file_name_root)
         self._processed_data: InternalFormattedOutputType = {}
@@ -54,7 +57,7 @@ class RunResult(ABC):
 
         self._has_been_processed = True
 
-    def have_been_processed(self) -> bool:
+    def has_been_processed(self) -> bool:
         """
         True if we have already processed the files for this set of results,
         otherwise False

--- a/tests/test_common_output_formatter.py
+++ b/tests/test_common_output_formatter.py
@@ -4,10 +4,10 @@ Unit tests for the CommonOutputFormatter class
 
 import unittest
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import ClassVar, Union
 
-from post_processing.formatter.benchmark_run_result import BenchmarkRunResult
 from post_processing.formatter.common_output_formatter import CommonOutputFormatter
+from post_processing.run_result.benchmark import BenchmarkRunResult
 
 
 # pyright: ignore[reportPrivateUsage]
@@ -17,7 +17,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
      working as expected
     """
 
-    read_data: Dict[str, Union[int, float, Dict[str, Union[int, float]]]] = {
+    read_data: ClassVar[dict[str, Union[int, float, dict[str, Union[int, float]]]]] = {
         "io_bytes": 440397824,
         "bw_bytes": 34982748,
         "iops": 8539.518627,
@@ -27,7 +27,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
             "stddev": 9231257.966646,
         },
     }
-    write_data: Dict[str, Union[int, float, Dict[str, Union[int, float]]]] = {
+    write_data: ClassVar[dict[str, Union[int, float, dict[str, Union[int, float]]]]] = {
         "io_bytes": 480681984,
         "bw_bytes": 35640393,
         "iops": 8700.155705,
@@ -37,7 +37,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
             "stddev": 10820490.136089,
         },
     }
-    global_options_data: Dict[str, str] = {
+    global_options_data: ClassVar[dict[str, str]] = {
         "rw": "write",
         "runtime": "90",
         "numjobs": "1",
@@ -45,7 +45,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
         "iodepth": "16",
     }
 
-    job_data: List[Dict[str, Union[str, Dict[str, Union[int, float, Dict[str, Union[int, float]]]]]]] = [
+    job_data: ClassVar[list[dict[str, Union[str, dict[str, Union[int, float, dict[str, Union[int, float]]]]]]]] = [
         {},
         {"read": read_data, "write": write_data},
     ]
@@ -71,7 +71,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
 
         output = self.test_run_results._get_global_options(self.global_options_data)  # pyright: ignore[reportPrivateUsage]
 
-        expected_output: Dict[str, str] = {
+        expected_output: dict[str, str] = {
             "number_of_jobs": self.global_options_data["numjobs"],
             "runtime_seconds": self.global_options_data["runtime"],
             "blocksize": self.global_options_data["bs"][:-1],
@@ -83,11 +83,11 @@ class TestCommonOutputFormatter(unittest.TestCase):
         """
         Check the parsing of extended global_options
         """
-        extended_test_data: Dict[str, str] = self.global_options_data.copy()
+        extended_test_data: dict[str, str] = self.global_options_data.copy()
         extended_test_data.update({"rwmixread": "70", "rwmixwrite": "30"})
         output = self.test_run_results._get_global_options(extended_test_data)  # pyright: ignore[reportPrivateUsage]
 
-        expected_output: Dict[str, str] = {
+        expected_output: dict[str, str] = {
             "number_of_jobs": extended_test_data["numjobs"],
             "runtime_seconds": extended_test_data["runtime"],
             "blocksize": self.global_options_data["bs"][:-1],
@@ -101,7 +101,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
         """
         Make sure we pull the correct details from the read data
         """
-        read_job_details: List[Dict[str, Union[str, Dict[str, Union[int, float, Dict[str, Union[int, float]]]]]]] = [
+        read_job_details: list[dict[str, Union[str, dict[str, Union[int, float, dict[str, Union[int, float]]]]]]] = [
             {"read": self.read_data}
         ]
         output = self.test_run_results._get_io_details(read_job_details)  # pyright: ignore[reportPrivateUsage]
@@ -109,7 +109,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
         assert isinstance(self.read_data["io_bytes"], int)
         assert isinstance(self.read_data["bw_bytes"], int)
         assert isinstance(self.read_data["iops"], float)
-        expected_output: Dict[str, str] = {
+        expected_output: dict[str, str] = {
             "io_bytes": f"{self.read_data['io_bytes']}",
             "bandwidth_bytes": f"{self.read_data['bw_bytes']}",
             "iops": f"{self.read_data['iops']}",
@@ -122,7 +122,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
         """
         Make sure we pull the correct details from the read data
         """
-        write_job_details: List[Dict[str, Union[str, Dict[str, Union[int, float, Dict[str, Union[int, float]]]]]]] = [
+        write_job_details: list[dict[str, Union[str, dict[str, Union[int, float, dict[str, Union[int, float]]]]]]] = [
             {"write": self.write_data}
         ]
         output = self.test_run_results._get_io_details(write_job_details)  # pyright: ignore[reportPrivateUsage]
@@ -130,7 +130,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
         assert isinstance(self.write_data["io_bytes"], int)
         assert isinstance(self.write_data["bw_bytes"], int)
         assert isinstance(self.write_data["iops"], float)
-        expected_output: Dict[str, str] = {
+        expected_output: dict[str, str] = {
             "io_bytes": f"{self.write_data['io_bytes']}",
             "bandwidth_bytes": f"{self.write_data['bw_bytes']}",
             "iops": f"{self.write_data['iops']}",
@@ -158,7 +158,7 @@ class TestCommonOutputFormatter(unittest.TestCase):
         assert isinstance(self.read_data["iops"], float)
         iops: str = str(float(self.write_data["iops"]) + float(self.read_data["iops"]))
 
-        expected_output: Dict[str, str] = {
+        expected_output: dict[str, str] = {
             "io_bytes": io,
             "bandwidth_bytes": bw,
             "iops": iops,

--- a/tools/fio_common_output_wrapper.py
+++ b/tools/fio_common_output_wrapper.py
@@ -27,8 +27,8 @@ from post_processing.formatter.common_output_formatter import CommonOutputFormat
 from post_processing.log_configuration import setup_logging
 
 setup_logging()
-
 log: Logger = getLogger("formatter")
+log.info("=== Starting Post Processing of CBT results ===")
 
 
 def main() -> int:

--- a/tools/generate_comparison_performance_report.py
+++ b/tools/generate_comparison_performance_report.py
@@ -64,11 +64,12 @@ from argparse import ArgumentParser
 from logging import Logger, getLogger
 
 from post_processing.log_configuration import setup_logging
-from post_processing.report import Report, ReportOptions, parse_namespace_to_options
+from post_processing.post_processing_types import ReportOptions
+from post_processing.report import Report, parse_namespace_to_options
 
 setup_logging()
-
 log: Logger = getLogger("reports")
+log.info("=== Starting Post Processing of CBT results ===")
 
 
 def main() -> int:

--- a/tools/generate_performance_report.py
+++ b/tools/generate_performance_report.py
@@ -121,6 +121,13 @@ def main() -> int:
         help="Regenerate the intermediate files and plots, even if they exist",
     )
 
+    parser.add_argument(
+        "--plot_resources",
+        action="store_true",
+        required=False,
+        help="Add a line for resource usage to the plots, if details are avaialable",
+    )
+
     report_options: ReportOptions = parse_namespace_to_options(arguments=parser.parse_args())
 
     report: Report = Report(report_options)

--- a/tools/generate_performance_report.py
+++ b/tools/generate_performance_report.py
@@ -59,11 +59,12 @@ from argparse import ArgumentParser
 from logging import Logger, getLogger
 
 from post_processing.log_configuration import setup_logging
-from post_processing.report import Report, ReportOptions, parse_namespace_to_options
+from post_processing.post_processing_types import ReportOptions
+from post_processing.report import Report, parse_namespace_to_options
 
 setup_logging()
-
 log: Logger = getLogger("reports")
+log.info("=== Starting Post Processing of CBT results ===")
 
 
 def main() -> int:


### PR DESCRIPTION
In order to be able to include resource usage statistics in the reports produced as part of the post processing some re-factoring of the post_processing/run_result modules was necessary.

This is mainly the creating of a run_result directory and creation of some base classes that can be extended for particular run types.

This is the first step in adding resource monitor result file parsing and adding to the common format output file (which we use to generate the reports). Future PRs will deal with:
 - parsing the various resource monitoring options that CBT supports, top, collectl, perf etc. into the common format.
 - creating resource monitoring plots for the report e.g. CPU and Memory utilisation over time
 - Additional report options to control which resource statistics are addre to a report

#### Testing
Teuthology perf-basic: https://pulpito.ceph.com/harriscr-2025-12-01_13:29:31-perf-basic-main-distro-default-smithi/
rados/perf: https://pulpito.ceph.com/harriscr-2025-12-02_08:34:46-rados:perf-main-distro-default-smithi/

All tests passed