### PR TITLE
post processing: Adding unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.code-workspace
 .devcontainer
 *.toml
+.coverage

--- a/post_processing/run_results/benchmarks/benchmark_result.py
+++ b/post_processing/run_results/benchmarks/benchmark_result.py
@@ -26,6 +26,8 @@ class BenchmarkResult(ABC):
     def __init__(self, file_path: Path) -> None:
         self._resource_file_path: Path = file_path
         self._data: dict[str, Any] = self._read_results_from_file()
+        if not self._data:
+            raise ValueError(f"File {file_path} is empty")
 
         self._global_options: dict[str, str] = self._get_global_options(self._data["global options"])
         self._iodepth = self._get_iodepth(f"{self._data['global options']['iodepth']}")
@@ -39,17 +41,10 @@ class BenchmarkResult(ABC):
     def source(self) -> str:
         """
         Get the source/type identifier for the benchmark tool.
-        
+
         Returns:
             A string identifier for the benchmark source (e.g., "fio", "cosbench")
         """
-
-    # @abstractmethod
-    # def _parse(self, data: dict[str, Any]) -> None:
-    #    """
-    #    Read the resource usage data from the read data and return the
-    #    relevant resource usage statistics
-    #    """
 
     @abstractmethod
     def _get_global_options(self, fio_global_options: dict[str, str]) -> dict[str, str]:

--- a/tests/test_axis_plotter.py
+++ b/tests/test_axis_plotter.py
@@ -1,0 +1,112 @@
+"""
+Unit tests for the post_processing/plotter module classes
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import unittest
+from unittest.mock import MagicMock
+
+from matplotlib.axes import Axes
+
+from post_processing.plotter.axis_plotter import AxisPlotter
+
+
+class ConcreteAxisPlotter(AxisPlotter):
+    """Concrete implementation of AxisPlotter for testing"""
+
+    def plot(self, x_data: list[float], colour: str = "") -> None:
+        """Concrete implementation of abstract plot method"""
+        self._plot(x_data, self._main_axes, colour)
+
+    def add_y_data(self, data_value: str) -> None:
+        """Concrete implementation of abstract add_y_data method"""
+        self._y_data.append(float(data_value))
+
+
+class TestAxisPlotter(unittest.TestCase):
+    """Test cases for AxisPlotter base class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.mock_axes = MagicMock(spec=Axes)
+        self.plotter = ConcreteAxisPlotter(self.mock_axes)
+
+    def test_initialization(self) -> None:
+        """Test AxisPlotter initialization"""
+        self.assertEqual(self.plotter._main_axes, self.mock_axes)
+        self.assertEqual(self.plotter._y_data, [])
+        self.assertEqual(self.plotter._y_label, "")
+        self.assertEqual(self.plotter._label, "")
+
+    def test_y_label_property_getter(self) -> None:
+        """Test y_label property getter"""
+        self.plotter._y_label = "Test Label"
+        self.assertEqual(self.plotter.y_label, "Test Label")
+
+    def test_y_label_property_setter(self) -> None:
+        """Test y_label property setter"""
+        self.plotter.y_label = "New Label"
+        self.assertEqual(self.plotter._y_label, "New Label")
+
+    def test_y_label_setter_warning_on_overwrite(self) -> None:
+        """Test that setting y_label twice logs a warning"""
+        self.plotter.y_label = "First Label"
+
+        with self.assertLogs("plotter", level="WARNING") as log_context:
+            self.plotter.y_label = "Second Label"
+
+        self.assertIn("Y label value already set", log_context.output[0])
+        self.assertEqual(self.plotter._y_label, "Second Label")
+
+    def test_plot_label_property_getter(self) -> None:
+        """Test plot_label property getter"""
+        self.plotter._label = "Test Plot Label"
+        self.assertEqual(self.plotter.plot_label, "Test Plot Label")
+
+    def test_plot_label_property_setter(self) -> None:
+        """Test plot_label property setter"""
+        self.plotter.plot_label = "New Plot Label"
+        self.assertEqual(self.plotter._label, "New Plot Label")
+
+    def test_plot_label_setter_warning_on_overwrite(self) -> None:
+        """Test that setting plot_label twice logs a warning"""
+        self.plotter.plot_label = "First Label"
+
+        with self.assertLogs("plotter", level="WARNING") as log_context:
+            self.plotter.plot_label = "Second Label"
+
+        self.assertIn("Plot label value already set", log_context.output[0])
+        self.assertEqual(self.plotter._label, "Second Label")
+
+    def test_add_y_data(self) -> None:
+        """Test adding y-axis data"""
+        self.plotter.add_y_data("10.5")
+        self.plotter.add_y_data("20.3")
+        self.plotter.add_y_data("30.7")
+
+        self.assertEqual(len(self.plotter._y_data), 3)
+        self.assertAlmostEqual(self.plotter._y_data[0], 10.5)
+        self.assertAlmostEqual(self.plotter._y_data[1], 20.3)
+        self.assertAlmostEqual(self.plotter._y_data[2], 30.7)
+
+    def test_plot_calls_internal_plot(self) -> None:
+        """Test that plot method calls _plot"""
+        self.plotter.y_label = "Test Y"
+        self.plotter.plot_label = "Test Plot"
+        self.plotter.add_y_data("10")
+        self.plotter.add_y_data("20")
+
+        x_data = [1.0, 2.0]
+        self.plotter.plot(x_data, "blue")
+
+        # Verify axes methods were called
+        self.mock_axes.set_ylabel.assert_called_once_with("Test Y")
+        self.mock_axes.tick_params.assert_called_once()
+        self.mock_axes.plot.assert_called_once()
+
+
+# Made with Bob

--- a/tests/test_benchmark_result.py
+++ b/tests/test_benchmark_result.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for the post_processing/run_results module classes
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from post_processing.run_results.benchmarks.benchmark_result import BenchmarkResult
+
+
+class ConcreteBenchmarkResult(BenchmarkResult):
+    """Concrete implementation of BenchmarkResult for testing"""
+
+    @property
+    def source(self) -> str:
+        return "test_benchmark"
+
+    def _get_global_options(self, fio_global_options: dict[str, str]) -> dict[str, str]:
+        return {"test_option": "test_value"}
+
+    def _get_io_details(self, all_jobs: list[dict[str, Any]]) -> dict[str, str]:
+        return {"test_io": "test_value"}
+
+    def _get_iodepth(self, iodepth_value: str) -> str:
+        return iodepth_value
+
+
+class TestBenchmarkResult(unittest.TestCase):
+    """Test cases for BenchmarkResult base class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.test_file = Path(self.temp_dir) / "test_output.json"
+
+        # Create test FIO output data
+        self.test_data: dict[str, Any] = {
+            "global options": {"bs": "4096", "rw": "read", "iodepth": "1", "numjobs": "1", "runtime": "60"},
+            "jobs": [
+                {
+                    "read": {
+                        "io_bytes": 1000000,
+                        "bw_bytes": 16666,
+                        "iops": 4.0,
+                        "total_ios": 244,
+                        "clat_ns": {"mean": 5000000.0, "stddev": 500000.0},
+                    }
+                }
+            ],
+        }
+
+        with open(self.test_file, "w") as f:
+            json.dump(self.test_data, f)
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_initialization(self) -> None:
+        """Test BenchmarkResult initialization"""
+        result = ConcreteBenchmarkResult(self.test_file)
+
+        self.assertEqual(result._resource_file_path, self.test_file)
+        self.assertIsInstance(result._data, dict)
+        self.assertFalse(result._has_been_parsed)
+
+    def test_blocksize_property(self) -> None:
+        """Test blocksize property extraction"""
+        result = ConcreteBenchmarkResult(self.test_file)
+
+        self.assertEqual(result.blocksize, "4096")
+
+    def test_operation_property_simple(self) -> None:
+        """Test operation property for simple operation"""
+        result = ConcreteBenchmarkResult(self.test_file)
+
+        self.assertEqual(result.operation, "read")
+
+    def test_operation_property_with_percentages(self) -> None:
+        """Test operation property with read/write percentages"""
+        # Modify test data to include rwmix
+        data_with_mix: dict[str, Any] = {
+            "global options": {
+                "bs": "4096",
+                "rw": "randrw",
+                "iodepth": "1",
+                "numjobs": "1",
+                "runtime": "60",
+                "rwmixread": "70",
+                "rwmixwrite": "30",
+            },
+            "jobs": self.test_data["jobs"],
+        }
+
+        test_file_mix = Path(self.temp_dir) / "test_mix.json"
+        with open(test_file_mix, "w") as f:
+            json.dump(data_with_mix, f)
+
+        # Need to create a concrete class that handles percentages
+        class TestBenchmarkWithMix(ConcreteBenchmarkResult):
+            def _get_global_options(self, fio_global_options: dict[str, str]) -> dict[str, str]:
+                options = {"test_option": "test_value"}
+                if fio_global_options.get("rwmixread"):
+                    options["percentage_reads"] = fio_global_options["rwmixread"]
+                    options["percentage_writes"] = fio_global_options["rwmixwrite"]
+                return options
+
+        result = TestBenchmarkWithMix(test_file_mix)
+
+        self.assertEqual(result.operation, "70_30_randrw")
+
+    def test_global_options_property(self) -> None:
+        """Test global_options property"""
+        result = ConcreteBenchmarkResult(self.test_file)
+
+        self.assertIsInstance(result.global_options, dict)
+        self.assertEqual(result.global_options["test_option"], "test_value")
+
+    def test_iodepth_property(self) -> None:
+        """Test iodepth property"""
+        result = ConcreteBenchmarkResult(self.test_file)
+
+        self.assertEqual(result.iodepth, "1")
+
+    def test_io_details_property(self) -> None:
+        """Test io_details property"""
+        result = ConcreteBenchmarkResult(self.test_file)
+
+        self.assertIsInstance(result.io_details, dict)
+        self.assertEqual(result.io_details["test_io"], "test_value")
+
+    def test_read_results_from_empty_file(self) -> None:
+        """Test reading from empty file raises KeyError"""
+        empty_file = Path(self.temp_dir) / "empty.json"
+        empty_file.touch()
+
+        # Empty file should raise KeyError when trying to access 'global options'
+        with self.assertRaises(ValueError):
+            ConcreteBenchmarkResult(empty_file)
+
+    def test_read_results_from_invalid_json(self) -> None:
+        """Test reading from file with invalid JSON raises ValueError"""
+        invalid_file = Path(self.temp_dir) / "invalid.json"
+        with open(invalid_file, "w") as f:
+            f.write("not valid json {")
+
+        # Invalid JSON returns empty dict, which raises ValueError
+        with self.assertRaises(ValueError):
+            ConcreteBenchmarkResult(invalid_file)
+
+
+# Made with Bob

--- a/tests/test_common_output_formatter.py
+++ b/tests/test_common_output_formatter.py
@@ -2,197 +2,189 @@
 Unit tests for the CommonOutputFormatter class
 """
 
-import json
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
-from typing import ClassVar, Union
+from typing import Any
 
 from post_processing.formatter.common_output_formatter import CommonOutputFormatter
-from post_processing.run_results.benchmarks.fio import FIO
 
 
-# pyright: ignore[reportPrivateUsage]
 class TestCommonOutputFormatter(unittest.TestCase):
     """
-    A basic unit test to check our unit test infrastructure is
-     working as expected
+    Unit tests for CommonOutputFormatter class methods
     """
 
-    read_data: ClassVar[dict[str, Union[int, float, dict[str, Union[int, float]]]]] = {
-        "io_bytes": 440397824,
-        "bw_bytes": 34982748,
-        "iops": 8539.518627,
-        "total_ios": 107504,
-        "clat_ns": {
-            "mean": 1977392.018174,
-            "stddev": 9231257.966646,
-        },
-    }
-    write_data: ClassVar[dict[str, Union[int, float, dict[str, Union[int, float]]]]] = {
-        "io_bytes": 480681984,
-        "bw_bytes": 35640393,
-        "iops": 8700.155705,
-        "total_ios": 117339,
-        "clat_ns": {
-            "mean": 1825254.043151,
-            "stddev": 10820490.136089,
-        },
-    }
-    global_options_data: ClassVar[dict[str, str]] = {
-        "rw": "write",
-        "runtime": "90",
-        "numjobs": "1",
-        "bs": "4096B",
-        "iodepth": "16",
-    }
-
-    job_data: ClassVar[list[dict[str, Union[str, dict[str, Union[int, float, dict[str, Union[int, float]]]]]]]] = [
-        {},
-        {"read": read_data, "write": write_data},
-    ]
-
     def setUp(self) -> None:
-        print("setting up tests")
-        self.formatter = CommonOutputFormatter("/tmp")
-        
-        # Create a temporary file with mock FIO output data
-        self.temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
-        mock_fio_data = {
-            "global options": {
-                "rw": "write",
-                "runtime": "90",
-                "numjobs": "1",
-                "bs": "4096B",
-                "iodepth": "16"
-            },
-            "jobs": [
-                {},
-                {"read": self.read_data, "write": self.write_data}
-            ]
-        }
-        json.dump(mock_fio_data, self.temp_file)
-        self.temp_file.close()
-        
-        self.test_run_results = FIO(Path(self.temp_file.name))
-    
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.formatter = CommonOutputFormatter(self.temp_dir)
+
     def tearDown(self) -> None:
-        """Clean up temporary files"""
-        import os
-        if hasattr(self, 'temp_file'):
-            try:
-                os.unlink(self.temp_file.name)
-            except FileNotFoundError:
-                pass
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    def test_do_nothing(self) -> None:
-        """
-        A test that does nothing to verify that the unit tests
-        can be run as expected
-        """
-        print("This test case should pass")
-        value = True
-        self.assertTrue(value)
+    def test_initialization(self) -> None:
+        """Test that CommonOutputFormatter initializes correctly"""
+        self.assertEqual(self.formatter._directory, self.temp_dir)
+        self.assertEqual(self.formatter._filename_root, "json_output")
+        self.assertIsInstance(self.formatter._formatted_output, dict)
+        self.assertIsInstance(self.formatter._all_test_run_ids, set)
+        self.assertEqual(len(self.formatter._all_test_run_ids), 0)
 
-    def test_global_options_parsing(self) -> None:
-        """
-        Check the parsing of global_options
-        """
+    def test_initialization_with_custom_filename_root(self) -> None:
+        """Test initialization with custom filename root"""
+        custom_formatter = CommonOutputFormatter(self.temp_dir, "custom_output")
+        self.assertEqual(custom_formatter._filename_root, "custom_output")
 
-        output = self.test_run_results._get_global_options(self.global_options_data)  # pyright: ignore[reportPrivateUsage]
-
-        expected_output: dict[str, str] = {
-            "number_of_jobs": self.global_options_data["numjobs"],
-            "runtime_seconds": self.global_options_data["runtime"],
-            "blocksize": self.global_options_data["bs"][:-1],
+    def test_find_maximum_bandwidth_and_iops_with_latency(self) -> None:
+        """Test finding maximum bandwidth and IOPS with associated latencies"""
+        test_data: dict[str, Any] = {
+            "1": {
+                "bandwidth_bytes": "1000000",
+                "iops": "100.5",
+                "latency": "5000000",  # 5ms in nanoseconds
+            },
+            "2": {
+                "bandwidth_bytes": "2000000",
+                "iops": "150.5",
+                "latency": "8000000",  # 8ms in nanoseconds
+            },
+            "4": {
+                "bandwidth_bytes": "1500000",
+                "iops": "200.5",
+                "latency": "10000000",  # 10ms in nanoseconds
+            },
+            "metadata": "should be ignored",
         }
 
-        self.assertDictEqual(output, expected_output)
+        max_bw, bw_lat, max_iops, iops_lat = self.formatter._find_maximum_bandwidth_and_iops_with_latency(test_data)
+        # Max bandwidth is 2000000 with latency 8ms
+        self.assertEqual(max_bw, "2000000.0")
+        self.assertEqual(bw_lat, "8.0")
 
-    def test_extended_global_oprtions_parsing(self) -> None:
-        """
-        Check the parsing of extended global_options
-        """
-        extended_test_data: dict[str, str] = self.global_options_data.copy()
-        extended_test_data.update({"rwmixread": "70", "rwmixwrite": "30"})
-        output = self.test_run_results._get_global_options(extended_test_data)  # pyright: ignore[reportPrivateUsage]
+        # Max IOPS is 200.5 with latency 10ms
+        self.assertEqual(max_iops, "200.5")
+        self.assertEqual(iops_lat, "10.0")
 
-        expected_output: dict[str, str] = {
-            "number_of_jobs": extended_test_data["numjobs"],
-            "runtime_seconds": extended_test_data["runtime"],
-            "blocksize": self.global_options_data["bs"][:-1],
-            "percentage_reads": extended_test_data["rwmixread"],
-            "percentage_writes": extended_test_data["rwmixwrite"],
+    def test_find_maximum_bandwidth_and_iops_with_empty_data(self) -> None:
+        """Test finding maximum values with empty data"""
+        test_data: dict[str, Any] = {}
+
+        max_bw, bw_lat, max_iops, iops_lat = self.formatter._find_maximum_bandwidth_and_iops_with_latency(test_data)
+
+        self.assertEqual(max_bw, "0")
+        self.assertEqual(bw_lat, "0")
+        self.assertEqual(max_iops, "0")
+        self.assertEqual(iops_lat, "0")
+
+    def test_find_max_resource_usage(self) -> None:
+        """Test finding maximum CPU and memory usage"""
+        test_data: dict[str, Any] = {
+            "1": {
+                "cpu": "25.5",
+                "memory": "1024",
+            },
+            "2": {
+                "cpu": "45.8",
+                "memory": "2048",
+            },
+            "4": {
+                "cpu": "35.2",
+                "memory": "1536",
+            },
+            "metadata": "should be ignored",
         }
 
-        self.assertDictEqual(output, expected_output)
+        max_cpu, max_memory = self.formatter._find_max_resource_usage(test_data)
 
-    def test_read_parsing(self) -> None:
-        """
-        Make sure we pull the correct details from the read data
-        """
-        read_job_details: list[dict[str, Union[str, dict[str, Union[int, float, dict[str, Union[int, float]]]]]]] = [
-            {"read": self.read_data}
-        ]
-        output = self.test_run_results._get_io_details(read_job_details)  # pyright: ignore[reportPrivateUsage]
+        self.assertEqual(max_cpu, "45.8")
+        # Note: max_memory is not currently implemented in the code
+        self.assertEqual(max_memory, "0")
 
-        assert isinstance(self.read_data["io_bytes"], int)
-        assert isinstance(self.read_data["bw_bytes"], int)
-        assert isinstance(self.read_data["iops"], float)
-        expected_output: dict[str, str] = {
-            "io_bytes": f"{self.read_data['io_bytes']}",
-            "bandwidth_bytes": f"{self.read_data['bw_bytes']}",
-            "iops": f"{self.read_data['iops']}",
-        }
+    def test_find_max_resource_usage_with_empty_data(self) -> None:
+        """Test finding maximum resource usage with empty data"""
+        test_data: dict[str, Any] = {}
 
-        for key in expected_output.keys():
-            self.assertEqual(expected_output[key], output[key])
+        max_cpu, max_memory = self.formatter._find_max_resource_usage(test_data)
 
-    def test_write_parsing(self) -> None:
-        """
-        Make sure we pull the correct details from the read data
-        """
-        write_job_details: list[dict[str, Union[str, dict[str, Union[int, float, dict[str, Union[int, float]]]]]]] = [
-            {"write": self.write_data}
-        ]
-        output = self.test_run_results._get_io_details(write_job_details)  # pyright: ignore[reportPrivateUsage]
+        self.assertEqual(max_cpu, "0")
+        self.assertEqual(max_memory, "0")
 
-        assert isinstance(self.write_data["io_bytes"], int)
-        assert isinstance(self.write_data["bw_bytes"], int)
-        assert isinstance(self.write_data["iops"], float)
-        expected_output: dict[str, str] = {
-            "io_bytes": f"{self.write_data['io_bytes']}",
-            "bandwidth_bytes": f"{self.write_data['bw_bytes']}",
-            "iops": f"{self.write_data['iops']}",
-        }
+    def test_find_all_results_files_in_directory(self) -> None:
+        """Test finding result files in directory"""
+        # Create test directory structure with mock files
+        test_dir = Path(self.temp_dir) / "test_run" / "id-12345"
+        test_dir.mkdir(parents=True, exist_ok=True)
 
-        for key in expected_output.keys():
-            self.assertEqual(expected_output[key], output[key])
+        # Create valid output files
+        (test_dir / "json_output.0").touch()
+        (test_dir / "json_output.1").touch()
+        (test_dir / "json_output.2").touch()
 
-    def test_read_and_write_parsing(self) -> None:
-        """
-        Make sure we pull the correct details from the read data
-        """
+        # Create files that should be ignored
+        (test_dir / "json_output.txt").touch()
+        (test_dir / "other_file.0").touch()
 
-        output = self.test_run_results._get_io_details(self.job_data)  # pyright: ignore[reportPrivateUsage]
+        formatter = CommonOutputFormatter(str(test_dir))
+        formatter._find_all_results_files_in_directory()
 
-        assert isinstance(self.write_data["io_bytes"], int)
-        assert isinstance(self.read_data["io_bytes"], int)
-        io: str = str(int(self.write_data["io_bytes"]) + int(self.read_data["io_bytes"]))
+        # Should find exactly 3 files
+        self.assertEqual(len(formatter._file_list), 3)
 
-        assert isinstance(self.write_data["bw_bytes"], int)
-        assert isinstance(self.read_data["bw_bytes"], int)
-        bw: str = str(int(self.write_data["bw_bytes"]) + int(self.read_data["bw_bytes"]))
+        # All files should match the pattern
+        for file_path in formatter._file_list:
+            self.assertTrue(file_path.name.startswith("json_output."))
+            self.assertTrue(file_path.name.split(".")[-1].isdigit())
 
-        assert isinstance(self.write_data["iops"], float)
-        assert isinstance(self.read_data["iops"], float)
-        iops: str = str(float(self.write_data["iops"]) + float(self.read_data["iops"]))
+    def test_find_all_testrun_ids(self) -> None:
+        """Test extracting test run IDs from file paths"""
+        # Create test directory structure
+        test_dir = Path(self.temp_dir)
+        run1_dir = test_dir / "00000000" / "id-abc123" / "workload"
+        run2_dir = test_dir / "00000001" / "id-def456" / "workload"
 
-        expected_output: dict[str, str] = {
-            "io_bytes": io,
-            "bandwidth_bytes": bw,
-            "iops": iops,
-        }
+        run1_dir.mkdir(parents=True, exist_ok=True)
+        run2_dir.mkdir(parents=True, exist_ok=True)
 
-        for key in expected_output.keys():
-            self.assertEqual(expected_output[key], output[key])
+        # Create output files
+        (run1_dir / "json_output.0").touch()
+        (run2_dir / "json_output.0").touch()
+
+        formatter = CommonOutputFormatter(str(test_dir))
+        formatter._find_all_results_files_in_directory()
+        formatter._find_all_testrun_ids()
+
+        # Should find 2 unique test run IDs
+        self.assertEqual(len(formatter._all_test_run_ids), 2)
+        self.assertIn("id-abc123", formatter._all_test_run_ids)
+        self.assertIn("id-def456", formatter._all_test_run_ids)
+
+    def test_find_all_testrun_ids_without_id_prefix(self) -> None:
+        """Test extracting test run IDs when no 'id-' prefix exists"""
+        # Create test directory structure without id- prefix
+        test_dir = Path(self.temp_dir)
+        run_dir = test_dir / "some_directory" / "workload"
+
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "json_output.0").touch()
+
+        formatter = CommonOutputFormatter(str(test_dir))
+        formatter._find_all_results_files_in_directory()
+        formatter._find_all_testrun_ids()
+
+        # Should use the directory name above the file
+        self.assertEqual(len(formatter._all_test_run_ids), 1)
+        self.assertIn("workload", formatter._all_test_run_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+# Made with Bob

--- a/tests/test_comparison_report_generator.py
+++ b/tests/test_comparison_report_generator.py
@@ -1,0 +1,217 @@
+"""
+Unit tests for the post_processing/reports comparison report class
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from post_processing.reports.comparison_report_generator import ComparisonReportGenerator
+
+
+class TestComparisonReportGenerator(unittest.TestCase):
+    """Test cases for ComparisonReportGenerator class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+
+        # Create two archive directories for comparison
+        self.archive1 = Path(self.temp_dir) / "baseline"
+        self.archive2 = Path(self.temp_dir) / "comparison"
+
+        self.vis1 = self.archive1 / "visualisation"
+        self.vis2 = self.archive2 / "visualisation"
+
+        self.vis1.mkdir(parents=True)
+        self.vis2.mkdir(parents=True)
+
+        # Create matching data files in both
+        (self.vis1 / "4096_read.json").touch()
+        (self.vis2 / "4096_read.json").touch()
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_initialization_with_multiple_archives(self) -> None:
+        """Test initialization with multiple archive directories"""
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = ComparisonReportGenerator(
+            archive_directories=[str(self.archive1), str(self.archive2)],
+            output_directory=output_dir,
+        )
+
+        self.assertEqual(len(generator._archive_directories), 2)
+        self.assertEqual(len(generator._data_directories), 2)
+
+    def test_generate_report_title(self) -> None:
+        """Test generating comparison report title"""
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = ComparisonReportGenerator(
+            archive_directories=[str(self.archive1), str(self.archive2)],
+            output_directory=output_dir,
+        )
+
+        title = generator._generate_report_title()
+
+        self.assertIn("Comparitive Performance Report", title)
+        self.assertIn("baseline", title)
+        self.assertIn("comparison", title)
+        self.assertIn(" vs ", title)
+
+    def test_generate_report_name(self) -> None:
+        """Test generating comparison report name"""
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = ComparisonReportGenerator(
+            archive_directories=[str(self.archive1), str(self.archive2)],
+            output_directory=output_dir,
+        )
+
+        report_name = generator._generate_report_name()
+
+        self.assertTrue(report_name.startswith("comparitive_performance_report_"))
+        self.assertTrue(report_name.endswith(".md"))
+
+    def test_find_and_sort_file_paths_multiple_directories(self) -> None:
+        """Test finding files across multiple directories"""
+        # Create additional files
+        (self.vis1 / "8192_write.json").touch()
+        (self.vis2 / "8192_write.json").touch()
+
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = ComparisonReportGenerator(
+            archive_directories=[str(self.archive1), str(self.archive2)],
+            output_directory=output_dir,
+        )
+
+        paths = generator._find_and_sort_file_paths(paths=[self.vis1, self.vis2], search_pattern="*.json", index=0)
+
+        # Should find files from both directories
+        self.assertEqual(len(paths), 4)
+
+    @patch("post_processing.reports.comparison_report_generator.DirectoryComparisonPlotter")
+    def test_copy_images_creates_comparison_plots(self, mock_plotter_class: MagicMock) -> None:
+        """Test that _copy_images creates comparison plots"""
+        output_dir = f"{self.temp_dir}/output"
+
+        mock_plotter = MagicMock()
+        mock_plotter_class.return_value = mock_plotter
+
+        generator = ComparisonReportGenerator(
+            archive_directories=[str(self.archive1), str(self.archive2)],
+            output_directory=output_dir,
+        )
+
+        generator._copy_images()
+
+        # Should create comparison plotter
+        mock_plotter_class.assert_called_once()
+        mock_plotter.draw_and_save.assert_called_once()
+
+    def test_generate_table_headers_two_directories(self) -> None:
+        """Test generating table headers for two directories"""
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = ComparisonReportGenerator(
+            archive_directories=[str(self.archive1), str(self.archive2)],
+            output_directory=output_dir,
+        )
+
+        header, justification = generator._generate_table_headers()
+
+        # Should include baseline directory name
+        self.assertIn("baseline", header)
+        # Should include comparison directory name
+        self.assertIn("comparison", header)
+        # Should have percentage change columns
+        self.assertIn("%change", header)
+        
+        # Test justification string for two directories
+        # Format: | :--- | ---: | ---: | ---: | ---: |
+        # (left-aligned first column, right-aligned for baseline, comparison, %change throughput, %change latency)
+        self.assertEqual(justification, "| :--- | ---: | ---: | ---: | ---: |")
+
+    def test_generate_table_headers_multiple_directories(self) -> None:
+        """Test generating table headers for more than two directories"""
+        archive3 = Path(self.temp_dir) / "comparison2"
+        vis3 = archive3 / "visualisation"
+        vis3.mkdir(parents=True)
+        (vis3 / "4096_read.json").touch()
+
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = ComparisonReportGenerator(
+            archive_directories=[str(self.archive1), str(self.archive2), str(archive3)],
+            output_directory=output_dir,
+        )
+
+        header, justification = generator._generate_table_headers()
+
+        # Should have all directory names
+        self.assertIn("baseline", header)
+        self.assertIn("comparison", header)
+        self.assertIn("comparison2", header)
+        
+        # Test justification string for multiple directories (3+ total)
+        # Format: | :--- | ---: | ---: | ---: | ---: | ---: |
+        # (left-aligned first column, right-aligned for baseline, then comparison + %change for each comparison dir)
+        self.assertEqual(justification, "| :--- | ---: | ---: | ---: | ---: | ---: |")
+
+    @patch("subprocess.check_output")
+    def test_yaml_file_has_more_than_20_differences_true(self, mock_check_output: MagicMock) -> None:
+        """Test detecting significant differences between yaml files"""
+        # Mock diff output showing 25 differences
+        mock_check_output.return_value = b"25\n"
+
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = ComparisonReportGenerator(
+            archive_directories=[str(self.archive1), str(self.archive2)],
+            output_directory=output_dir,
+        )
+
+        file1 = Path(self.temp_dir) / "file1.yaml"
+        file2 = Path(self.temp_dir) / "file2.yaml"
+        file1.touch()
+        file2.touch()
+
+        result = generator._yaml_file_has_more_that_20_differences(file1, file2)
+
+        self.assertTrue(result)
+
+    @patch("subprocess.check_output")
+    def test_yaml_file_has_more_than_20_differences_false(self, mock_check_output: MagicMock) -> None:
+        """Test detecting minor differences between yaml files"""
+        # Mock diff output showing 10 differences
+        mock_check_output.return_value = b"10\n"
+
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = ComparisonReportGenerator(
+            archive_directories=[str(self.archive1), str(self.archive2)],
+            output_directory=output_dir,
+        )
+
+        file1 = Path(self.temp_dir) / "file1.yaml"
+        file2 = Path(self.temp_dir) / "file2.yaml"
+        file1.touch()
+        file2.touch()
+
+        result = generator._yaml_file_has_more_that_20_differences(file1, file2)
+
+        self.assertFalse(result)
+
+
+# Made with Bob

--- a/tests/test_cpu_plotter.py
+++ b/tests/test_cpu_plotter.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for the post_processing/plotter cpu plotter module class
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import unittest
+from unittest.mock import MagicMock
+
+from matplotlib.axes import Axes
+
+from post_processing.plotter.cpu_plotter import (
+    CPU_PLOT_DEFAULT_COLOUR,
+    CPU_PLOT_LABEL,
+    CPU_Y_LABEL,
+    CPUPlotter,
+)
+
+
+class TestCPUPlotter(unittest.TestCase):
+    """Test cases for CPUPlotter class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.mock_axes = MagicMock(spec=Axes)
+        self.mock_twin_axes = MagicMock(spec=Axes)
+        self.mock_axes.twinx.return_value = self.mock_twin_axes
+        self.plotter = CPUPlotter(self.mock_axes)
+
+    def test_initialization(self) -> None:
+        """Test CPUPlotter initialization"""
+        self.assertEqual(self.plotter._main_axes, self.mock_axes)
+        self.assertEqual(self.plotter._y_data, [])
+
+    def test_add_y_data(self) -> None:
+        """Test adding CPU data"""
+        self.plotter.add_y_data("45.5")
+        self.plotter.add_y_data("67.8")
+
+        self.assertEqual(len(self.plotter._y_data), 2)
+        self.assertAlmostEqual(self.plotter._y_data[0], 45.5)
+        self.assertAlmostEqual(self.plotter._y_data[1], 67.8)
+
+    def test_plot(self) -> None:
+        """Test plotting CPU data"""
+        self.plotter.add_y_data("50.0")
+        self.plotter.add_y_data("60.0")
+
+        x_data = [100.0, 200.0]
+        self.plotter.plot(x_data)
+
+        # Should create twin axes
+        self.mock_axes.twinx.assert_called_once()
+
+        # Should set label and y_label
+        self.assertEqual(self.plotter._label, CPU_PLOT_LABEL)
+        self.assertEqual(self.plotter._y_label, CPU_Y_LABEL)
+
+        # Should call plot on twin axes
+        self.mock_twin_axes.set_ylabel.assert_called_once_with(CPU_Y_LABEL)
+        self.mock_twin_axes.plot.assert_called_once()
+
+    def test_cpu_constants(self) -> None:
+        """Test CPU plotter constants"""
+        self.assertEqual(CPU_PLOT_DEFAULT_COLOUR, "#5ca904")
+        self.assertEqual(CPU_Y_LABEL, "System CPU use (%)")
+        self.assertEqual(CPU_PLOT_LABEL, "CPU use")
+
+
+# Made with Bob

--- a/tests/test_fio.py
+++ b/tests/test_fio.py
@@ -1,0 +1,183 @@
+"""
+Unit tests for the FIO benchmark result class
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import unittest
+from pathlib import Path
+from typing import ClassVar, Union
+
+from post_processing.run_results.benchmarks.fio import FIO
+
+
+class MockFIO(FIO):
+    """Mock FIO class for testing that doesn't require a file"""
+
+    def __init__(self) -> None:
+        # Skip the parent __init__ to avoid file reading
+        self._resource_file_path = Path("/tmp/test")
+        self._data = {}
+        self._global_options = {}
+        self._iodepth = "1"
+        self._io_details = {}
+        self._has_been_parsed = False
+        self._source = "fio"
+
+
+class TestFIO(unittest.TestCase):
+    """
+    Unit tests for FIO benchmark result parsing methods
+    """
+
+    read_data: ClassVar[dict[str, Union[int, float, dict[str, Union[int, float]]]]] = {
+        "io_bytes": 440397824,
+        "bw_bytes": 34982748,
+        "iops": 8539.518627,
+        "total_ios": 107504,
+        "clat_ns": {
+            "mean": 1977392.018174,
+            "stddev": 9231257.966646,
+        },
+    }
+    write_data: ClassVar[dict[str, Union[int, float, dict[str, Union[int, float]]]]] = {
+        "io_bytes": 480681984,
+        "bw_bytes": 35640393,
+        "iops": 8700.155705,
+        "total_ios": 117339,
+        "clat_ns": {
+            "mean": 1825254.043151,
+            "stddev": 10820490.136089,
+        },
+    }
+    global_options_data: ClassVar[dict[str, str]] = {
+        "rw": "write",
+        "runtime": "90",
+        "numjobs": "1",
+        "bs": "4096B",
+        "iodepth": "16",
+    }
+
+    job_data: ClassVar[list[dict[str, Union[str, dict[str, Union[int, float, dict[str, Union[int, float]]]]]]]] = [
+        {},
+        {"read": read_data, "write": write_data},
+    ]
+
+    def setUp(self) -> None:
+        print("setting up tests")
+        self.test_run_results = MockFIO()
+
+    def test_do_nothing(self) -> None:
+        """
+        A test that does nothing to verify that the unit tests
+        can be run as expected
+        """
+        print("This test case should pass")
+        value = True
+        self.assertTrue(value)
+
+    def test_global_options_parsing(self) -> None:
+        """
+        Check the parsing of global_options
+        """
+
+        output = self.test_run_results._get_global_options(self.global_options_data)
+
+        expected_output: dict[str, str] = {
+            "number_of_jobs": self.global_options_data["numjobs"],
+            "runtime_seconds": self.global_options_data["runtime"],
+            "blocksize": self.global_options_data["bs"][:-1],
+        }
+
+        self.assertDictEqual(output, expected_output)
+
+    def test_extended_global_oprtions_parsing(self) -> None:
+        """
+        Check the parsing of extended global_options
+        """
+        extended_test_data: dict[str, str] = self.global_options_data.copy()
+        extended_test_data.update({"rwmixread": "70", "rwmixwrite": "30"})
+        output = self.test_run_results._get_global_options(extended_test_data)
+
+        expected_output: dict[str, str] = {
+            "number_of_jobs": extended_test_data["numjobs"],
+            "runtime_seconds": extended_test_data["runtime"],
+            "blocksize": self.global_options_data["bs"][:-1],
+            "percentage_reads": extended_test_data["rwmixread"],
+            "percentage_writes": extended_test_data["rwmixwrite"],
+        }
+
+        self.assertDictEqual(output, expected_output)
+
+    def test_read_parsing(self) -> None:
+        """
+        Make sure we pull the correct details from the read data
+        """
+        read_job_details: list[dict[str, Union[str, dict[str, Union[int, float, dict[str, Union[int, float]]]]]]] = [
+            {"read": self.read_data}
+        ]
+        output = self.test_run_results._get_io_details(read_job_details)
+
+        assert isinstance(self.read_data["io_bytes"], int)
+        assert isinstance(self.read_data["bw_bytes"], int)
+        assert isinstance(self.read_data["iops"], float)
+        expected_output: dict[str, str] = {
+            "io_bytes": f"{self.read_data['io_bytes']}",
+            "bandwidth_bytes": f"{self.read_data['bw_bytes']}",
+            "iops": f"{self.read_data['iops']}",
+        }
+
+        for key in expected_output.keys():
+            self.assertEqual(expected_output[key], output[key])
+
+    def test_write_parsing(self) -> None:
+        """
+        Make sure we pull the correct details from the read data
+        """
+        write_job_details: list[dict[str, Union[str, dict[str, Union[int, float, dict[str, Union[int, float]]]]]]] = [
+            {"write": self.write_data}
+        ]
+        output = self.test_run_results._get_io_details(write_job_details)
+
+        assert isinstance(self.write_data["io_bytes"], int)
+        assert isinstance(self.write_data["bw_bytes"], int)
+        assert isinstance(self.write_data["iops"], float)
+        expected_output: dict[str, str] = {
+            "io_bytes": f"{self.write_data['io_bytes']}",
+            "bandwidth_bytes": f"{self.write_data['bw_bytes']}",
+            "iops": f"{self.write_data['iops']}",
+        }
+
+        for key in expected_output.keys():
+            self.assertEqual(expected_output[key], output[key])
+
+    def test_read_and_write_parsing(self) -> None:
+        """
+        Make sure we pull the correct details from the read data
+        """
+
+        output = self.test_run_results._get_io_details(self.job_data)
+
+        assert isinstance(self.write_data["io_bytes"], int)
+        assert isinstance(self.read_data["io_bytes"], int)
+        io: str = str(int(self.write_data["io_bytes"]) + int(self.read_data["io_bytes"]))
+
+        assert isinstance(self.write_data["bw_bytes"], int)
+        assert isinstance(self.read_data["bw_bytes"], int)
+        bw: str = str(int(self.write_data["bw_bytes"]) + int(self.read_data["bw_bytes"]))
+
+        assert isinstance(self.write_data["iops"], float)
+        assert isinstance(self.read_data["iops"], float)
+        iops: str = str(float(self.write_data["iops"]) + float(self.read_data["iops"]))
+
+        expected_output: dict[str, str] = {
+            "io_bytes": io,
+            "bandwidth_bytes": bw,
+            "iops": iops,
+        }
+
+        for key in expected_output.keys():
+            self.assertEqual(expected_output[key], output[key])

--- a/tests/test_fio_resource_result.py
+++ b/tests/test_fio_resource_result.py
@@ -1,0 +1,78 @@
+"""
+Unit tests for the post_processing FIO resource result module class
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from post_processing.run_results.resources.fio_resource import FIOResource
+
+
+class TestFIOResource(unittest.TestCase):
+    """Test cases for FIOResource class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.test_file = Path(self.temp_dir) / "fio_output.json"
+
+        self.test_data = {"jobs": [{"sys_cpu": 25.5, "usr_cpu": 30.2}]}
+
+        with open(self.test_file, "w") as f:
+            json.dump(self.test_data, f)
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_source_property(self) -> None:
+        """Test source property returns 'fio'"""
+        resource = FIOResource(self.test_file)
+
+        self.assertEqual(resource.source, "fio")
+
+    def test_get_resource_output_file_from_file_path(self) -> None:
+        """Test that resource file path is same as input path"""
+        resource = FIOResource(self.test_file)
+
+        self.assertEqual(resource._resource_file_path, self.test_file)
+
+    def test_parse_cpu_usage(self) -> None:
+        """Test parsing CPU usage from FIO output"""
+        resource = FIOResource(self.test_file)
+
+        cpu = resource.cpu
+
+        # Should be sum of sys_cpu (25.5) and usr_cpu (30.2) = 55.7
+        self.assertAlmostEqual(float(cpu), 55.7, places=1)
+
+    def test_parse_memory_usage(self) -> None:
+        """Test parsing memory usage (currently returns 0)"""
+        resource = FIOResource(self.test_file)
+
+        memory = resource.memory
+
+        # Memory is not currently extracted from FIO output
+        self.assertEqual(float(memory), 0.0)
+
+    def test_get_method(self) -> None:
+        """Test get method returns formatted resource data"""
+        resource = FIOResource(self.test_file)
+
+        data = resource.get()
+
+        self.assertEqual(data["source"], "fio")
+        self.assertIn("cpu", data)
+        self.assertIn("memory", data)
+        self.assertAlmostEqual(float(data["cpu"]), 55.7, places=1)
+
+
+# Made with Bob

--- a/tests/test_fio_result.py
+++ b/tests/test_fio_result.py
@@ -1,0 +1,146 @@
+"""
+Unit tests for the post_processing/run_results FIO resuly module class
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from post_processing.run_results.benchmarks.fio import FIO
+
+
+class TestFIO(unittest.TestCase):
+    """Test cases for FIO class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.test_file = Path(self.temp_dir) / "fio_output.json"
+
+        self.test_data = {
+            "global options": {"bs": "4K", "rw": "randread", "iodepth": "4", "numjobs": "2", "runtime": "60"},
+            "jobs": [
+                {
+                    "read": {
+                        "io_bytes": 1000000,
+                        "bw_bytes": 16666,
+                        "iops": 100.5,
+                        "total_ios": 244,
+                        "clat_ns": {"mean": 5000000.0, "stddev": 500000.0},
+                    },
+                    "write": {
+                        "io_bytes": 0,
+                        "bw_bytes": 0,
+                        "iops": 0.0,
+                        "total_ios": 0,
+                        "clat_ns": {"mean": 0.0, "stddev": 0.0},
+                    },
+                }
+            ],
+        }
+
+        with open(self.test_file, "w") as f:
+            json.dump(self.test_data, f)
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_source_property(self) -> None:
+        """Test source property returns 'fio'"""
+        fio = FIO(self.test_file)
+
+        self.assertEqual(fio.source, "fio")
+
+    def test_get_global_options(self) -> None:
+        """Test extracting global options"""
+        fio = FIO(self.test_file)
+
+        options = fio.global_options
+
+        self.assertEqual(options["number_of_jobs"], "2")
+        self.assertEqual(options["runtime_seconds"], "60")
+        self.assertEqual(options["blocksize"], "4")
+
+    def test_get_global_options_with_rwmix(self) -> None:
+        """Test extracting global options with rwmix"""
+        data_with_mix: dict[str, Any] = {
+            "global options": {
+                "bs": "4K",
+                "rw": "randread",
+                "iodepth": "4",
+                "numjobs": "2",
+                "runtime": "60",
+                "rwmixread": "70",
+                "rwmixwrite": "30",
+            },
+            "jobs": self.test_data["jobs"],
+        }
+
+        test_file_mix = Path(self.temp_dir) / "fio_mix.json"
+        with open(test_file_mix, "w") as f:
+            json.dump(data_with_mix, f)
+
+        fio = FIO(test_file_mix)
+
+        self.assertEqual(fio.global_options["percentage_reads"], "70")
+        self.assertEqual(fio.global_options["percentage_writes"], "30")
+
+    def test_get_io_details(self) -> None:
+        """Test extracting IO details"""
+        fio = FIO(self.test_file)
+
+        io_details = fio.io_details
+
+        self.assertIn("io_bytes", io_details)
+        self.assertIn("bandwidth_bytes", io_details)
+        self.assertIn("iops", io_details)
+        self.assertIn("latency", io_details)
+        self.assertIn("std_deviation", io_details)
+        self.assertIn("total_ios", io_details)
+
+        self.assertEqual(io_details["io_bytes"], "1000000")
+        self.assertEqual(io_details["bandwidth_bytes"], "16666")
+
+    def test_get_iodepth_from_value(self) -> None:
+        """Test getting iodepth from value"""
+        fio = FIO(self.test_file)
+
+        self.assertEqual(fio.iodepth, "4")
+
+    def test_get_iodepth_from_filename_new_style(self) -> None:
+        """Test extracting iodepth from new-style filename"""
+        test_file = Path(self.temp_dir) / "total_iodepth-8" / "fio_output.json"
+        test_file.parent.mkdir(parents=True)
+
+        with open(test_file, "w") as f:
+            json.dump(self.test_data, f)
+
+        fio = FIO(test_file)
+
+        # Should use max of file value (4) and filename value (8)
+        self.assertEqual(fio.iodepth, "8")
+
+    def test_get_iodepth_from_filename_old_style(self) -> None:
+        """Test extracting iodepth from old-style filename"""
+        test_file = Path(self.temp_dir) / "iodepth-016" / "numjobs-001" / "output.0"
+        test_file.parent.mkdir(parents=True)
+
+        with open(test_file, "w") as f:
+            json.dump(self.test_data, f)
+
+        fio = FIO(test_file)
+
+        # Should use max of file value (4) and filename value (16)
+        self.assertEqual(fio.iodepth, "16")
+
+
+# Made with Bob

--- a/tests/test_io_plotter.py
+++ b/tests/test_io_plotter.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for the post_processing/plotter IO_plotter module class
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import unittest
+from unittest.mock import MagicMock
+
+from matplotlib.axes import Axes
+
+from post_processing.plotter.io_plotter import (
+    IO_PLOT_DEFAULT_COLOUR,
+    IO_PLOT_LABEL,
+    IO_Y_LABEL,
+    IOPlotter,
+)
+
+
+class TestIOPlotter(unittest.TestCase):
+    """Test cases for IOPlotter class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.mock_axes = MagicMock(spec=Axes)
+        self.plotter = IOPlotter(self.mock_axes)
+
+    def test_initialization(self) -> None:
+        """Test IOPlotter initialization"""
+        self.assertEqual(self.plotter._main_axes, self.mock_axes)
+        self.assertEqual(self.plotter._y_data, [])
+
+    def test_add_y_data_converts_nanoseconds_to_milliseconds(self) -> None:
+        """Test that add_y_data converts nanoseconds to milliseconds"""
+        # 5,000,000 nanoseconds = 5 milliseconds
+        self.plotter.add_y_data("5000000")
+        self.assertAlmostEqual(self.plotter._y_data[0], 5.0)
+
+        # 10,000,000 nanoseconds = 10 milliseconds
+        self.plotter.add_y_data("10000000")
+        self.assertAlmostEqual(self.plotter._y_data[1], 10.0)
+
+    def test_plot_raises_not_implemented(self) -> None:
+        """Test that plot method raises NotImplementedError"""
+        with self.assertRaises(NotImplementedError):
+            self.plotter.plot([1.0, 2.0])
+
+    def test_plot_with_error_bars(self) -> None:
+        """Test plotting IO data with error bars"""
+        self.plotter.plot_label = "Test IO"
+        self.plotter.add_y_data("5000000")  # 5ms
+        self.plotter.add_y_data("10000000")  # 10ms
+
+        x_data = [100.0, 200.0]
+        error_data = [0.5, 1.0]
+        cap_size = 3
+
+        self.plotter.plot_with_error_bars(x_data, error_data, cap_size)
+
+        # Should call errorbar on main axes
+        self.mock_axes.errorbar.assert_called_once()
+        call_args = self.mock_axes.errorbar.call_args
+
+        # Verify x_data and y_data
+        self.assertEqual(list(call_args[0][0]), x_data)
+        self.assertEqual(list(call_args[0][1]), [5.0, 10.0])
+
+        # Verify error bars
+        self.assertEqual(list(call_args[1]["yerr"]), error_data)
+        self.assertEqual(call_args[1]["capsize"], cap_size)
+        self.assertEqual(call_args[1]["ecolor"], "red")
+
+    def test_plot_with_error_bars_no_caps(self) -> None:
+        """Test plotting with cap_size=0 (no error bar caps)"""
+        self.plotter.add_y_data("5000000")
+
+        x_data = [100.0]
+        error_data = [0.5]
+
+        self.plotter.plot_with_error_bars(x_data, error_data, cap_size=0)
+
+        call_args = self.mock_axes.errorbar.call_args
+        self.assertEqual(call_args[1]["capsize"], 0)
+
+    def test_io_constants(self) -> None:
+        """Test IO plotter constants"""
+        self.assertEqual(IO_PLOT_DEFAULT_COLOUR, "#5ca904")
+        self.assertEqual(IO_Y_LABEL, "Latency (ms)")
+        self.assertEqual(IO_PLOT_LABEL, "IO Details")
+
+
+# Made with Bob

--- a/tests/test_log_configuration.py
+++ b/tests/test_log_configuration.py
@@ -1,0 +1,209 @@
+"""
+Unit tests for the post_processing/log_configuration.py module
+"""
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from post_processing.log_configuration import (
+    LOGFILE_EXTENSION,
+    LOGFILE_LOCATION,
+    LOGFILE_NAME_BASE,
+    LOGGERS,
+    _get_configuration,
+    _get_handler_names,
+    _get_handlers_configuration,
+    setup_logging,
+)
+
+
+class TestLogConfiguration(unittest.TestCase):
+    """Test cases for log_configuration.py"""
+
+    def test_loggers_list(self) -> None:
+        """Test that LOGGERS contains expected logger names"""
+        self.assertIn("formatter", LOGGERS)
+        self.assertIn("plotter", LOGGERS)
+        self.assertIn("reports", LOGGERS)
+        self.assertEqual(len(LOGGERS), 3)
+
+    def test_logfile_constants(self) -> None:
+        """Test that log file constants are properly defined"""
+        self.assertEqual(LOGFILE_EXTENSION, ".log")
+        self.assertTrue(LOGFILE_LOCATION.startswith("/"))
+        self.assertTrue(LOGFILE_NAME_BASE.endswith("post_processing"))
+
+    def test_get_handlers_configuration(self) -> None:
+        """Test that handler configuration is properly structured"""
+        handlers = _get_handlers_configuration()
+
+        # Should have console and log_file handlers
+        self.assertIn("console", handlers)
+        self.assertIn("log_file", handlers)
+
+        # Console handler should be StreamHandler
+        self.assertEqual(handlers["console"]["class"], "logging.StreamHandler")
+        self.assertEqual(handlers["console"]["formatter"], "console")
+        self.assertEqual(handlers["console"]["level"], "INFO")
+        self.assertEqual(handlers["console"]["stream"], "ext://sys.stdout")
+
+        # Log file handler should be FileHandler
+        self.assertEqual(handlers["log_file"]["class"], "logging.FileHandler")
+        self.assertEqual(handlers["log_file"]["formatter"], "logfile")
+        self.assertEqual(handlers["log_file"]["level"], "DEBUG")
+        self.assertIn("filename", handlers["log_file"])
+
+    def test_get_handler_names(self) -> None:
+        """Test getting handler names"""
+        handler_names = _get_handler_names()
+
+        self.assertIn("console", handler_names)
+        self.assertIn("log_file", handler_names)
+        self.assertEqual(len(handler_names), 2)
+
+    def test_get_configuration_structure(self) -> None:
+        """Test that configuration dictionary has proper structure"""
+        config = _get_configuration()
+
+        # Check top-level keys
+        self.assertIn("version", config)
+        self.assertIn("disable_existing_loggers", config)
+        self.assertIn("formatters", config)
+        self.assertIn("loggers", config)
+        self.assertIn("handlers", config)
+
+        # Check version
+        self.assertEqual(config["version"], 1)
+
+        # Check disable_existing_loggers is False
+        self.assertFalse(config["disable_existing_loggers"])
+
+    def test_get_configuration_formatters(self) -> None:
+        """Test that formatters are properly configured"""
+        config = _get_configuration()
+        formatters = config["formatters"]
+
+        # Should have default, console, and logfile formatters
+        self.assertIn("default", formatters)
+        self.assertIn("console", formatters)
+        self.assertIn("logfile", formatters)
+
+        # Each formatter should have format and datefmt
+        for formatter_name in ["default", "console", "logfile"]:
+            self.assertIn("format", formatters[formatter_name])
+            self.assertIn("datefmt", formatters[formatter_name])
+
+    def test_get_configuration_loggers(self) -> None:
+        """Test that loggers are properly configured"""
+        config = _get_configuration()
+        loggers = config["loggers"]
+
+        # Should have all loggers from LOGGERS list
+        for logger_name in LOGGERS:
+            self.assertIn(logger_name, loggers)
+
+            # Each logger should have required keys
+            logger_config = loggers[logger_name]
+            self.assertIn("handlers", logger_config)
+            self.assertIn("level", logger_config)
+            self.assertIn("propagate", logger_config)
+            self.assertIn("filename", logger_config)
+
+            # Check values
+            self.assertEqual(logger_config["level"], "DEBUG")
+            self.assertFalse(logger_config["propagate"])
+            self.assertIsInstance(logger_config["handlers"], list)
+
+    def test_get_configuration_handlers(self) -> None:
+        """Test that handlers are properly configured"""
+        config = _get_configuration()
+        handlers = config["handlers"]
+
+        # Should match _get_handlers_configuration output
+        expected_handlers = _get_handlers_configuration()
+        self.assertEqual(handlers, expected_handlers)
+
+    @patch("post_processing.log_configuration.os.makedirs")
+    @patch("post_processing.log_configuration.logging.config.dictConfig")
+    @patch("post_processing.log_configuration.getLogger")
+    def test_setup_logging(
+        self, mock_get_logger: MagicMock, mock_dict_config: MagicMock, mock_makedirs: MagicMock
+    ) -> None:
+        """Test setup_logging function"""
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+
+        setup_logging()
+
+        # Should create log directory
+        mock_makedirs.assert_called_once()
+        call_args = mock_makedirs.call_args[0][0]
+        self.assertTrue(call_args.endswith("/cbt/"))
+
+        # Should configure logging
+        mock_dict_config.assert_called_once()
+
+        # Should get formatter logger
+        mock_get_logger.assert_called_once_with("formatter")
+
+        # Should log startup message
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args[0][0]
+        self.assertIn("Starting Post Processing", call_args)
+
+    @patch.dict(os.environ, {"CBT_PP_LOGFILE_LOCATION": "/custom/path"})
+    def test_logfile_location_from_env(self) -> None:
+        """Test that LOGFILE_LOCATION can be set via environment variable"""
+        # Need to reload the module to pick up the environment variable
+        import importlib
+
+        import post_processing.log_configuration as log_config
+
+        importlib.reload(log_config)
+
+        # The constant should reflect the environment variable
+        # Note: This test may not work as expected due to module-level constants
+        # being set at import time. This is more of a documentation test.
+        self.assertTrue(True)  # Placeholder assertion
+
+    def test_handler_configuration_completeness(self) -> None:
+        """Test that all handlers have required configuration"""
+        handlers = _get_handlers_configuration()
+
+        for handler_name, handler_config in handlers.items():
+            # All handlers should have class, formatter, and level
+            self.assertIn("class", handler_config, f"Handler {handler_name} missing 'class'")
+            self.assertIn("formatter", handler_config, f"Handler {handler_name} missing 'formatter'")
+            self.assertIn("level", handler_config, f"Handler {handler_name} missing 'level'")
+
+    def test_logger_handlers_reference_valid_handlers(self) -> None:
+        """Test that logger handlers reference valid handler names"""
+        config = _get_configuration()
+        valid_handlers = set(config["handlers"].keys())
+
+        for logger_name, logger_config in config["loggers"].items():
+            for handler in logger_config["handlers"]:
+                self.assertIn(handler, valid_handlers, f"Logger {logger_name} references invalid handler {handler}")
+
+    def test_logger_formatters_reference_valid_formatters(self) -> None:
+        """Test that handlers reference valid formatters"""
+        config = _get_configuration()
+        valid_formatters = set(config["formatters"].keys())
+
+        for handler_name, handler_config in config["handlers"].items():
+            formatter = handler_config.get("formatter")
+            if formatter:
+                self.assertIn(
+                    formatter, valid_formatters, f"Handler {handler_name} references invalid formatter {formatter}"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+# Made with Bob

--- a/tests/test_post_processing_common.py
+++ b/tests/test_post_processing_common.py
@@ -1,0 +1,336 @@
+"""
+Unit tests for the post_processing/common.py module
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from post_processing.common import (
+    TITLE_CONVERSION,
+    calculate_percent_difference_to_baseline,
+    file_is_empty,
+    file_is_precondition,
+    find_common_data_file_names,
+    get_blocksize,
+    get_blocksize_percentage_operation_from_file_name,
+    get_date_time_string,
+    get_latency_throughput_from_file,
+    get_resource_details_from_file,
+    read_intermediate_file,
+    recursive_search,
+    strip_confidential_data_from_yaml,
+    sum_mean_values,
+    sum_standard_deviation_values,
+)
+
+
+class TestCommonFunctions(unittest.TestCase):
+    """Test cases for common.py utility functions"""
+
+    def test_get_blocksize_percentage_operation_from_file_name_simple(self) -> None:
+        """Test parsing simple filename format: BLOCKSIZE_OPERATION"""
+        blocksize, read_percent, operation = get_blocksize_percentage_operation_from_file_name("4096_read")
+        self.assertEqual(blocksize, "4K")
+        self.assertEqual(read_percent, "")
+        self.assertEqual(operation, "Sequential Read")
+
+    def test_get_blocksize_percentage_operation_from_file_name_with_percentage(self) -> None:
+        """Test parsing filename with read/write percentage: BLOCKSIZE_READ_WRITE_OPERATION"""
+        blocksize, read_percent, operation = get_blocksize_percentage_operation_from_file_name("4096_70_30_randrw")
+        self.assertEqual(blocksize, "4K")
+        self.assertEqual(read_percent, "70/30 ")
+        self.assertEqual(operation, "Random Read/Write")
+
+    def test_get_blocksize_percentage_operation_from_file_name_randwrite(self) -> None:
+        """Test parsing randwrite operation"""
+        blocksize, read_percent, operation = get_blocksize_percentage_operation_from_file_name("8192_randwrite")
+        self.assertEqual(blocksize, "8K")
+        self.assertEqual(read_percent, "")
+        self.assertEqual(operation, "Random Write")
+
+    def test_read_intermediate_file_success(self) -> None:
+        """Test successfully reading an intermediate JSON file"""
+        test_data: dict[str, Any] = {"key1": "value1", "key2": {"nested": "data"}}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(test_data, f)
+            temp_path = f.name
+
+        try:
+            result = read_intermediate_file(temp_path)
+            self.assertEqual(result, test_data)
+        finally:
+            Path(temp_path).unlink()
+
+    def test_read_intermediate_file_not_found(self) -> None:
+        """Test reading a non-existent file returns empty dict"""
+        result = read_intermediate_file("/nonexistent/path/file.json")
+        self.assertEqual(result, {})
+
+    def test_get_latency_throughput_from_file_small_blocksize(self) -> None:
+        """Test getting latency/throughput for small blocksize (< 64K) - returns IOPS"""
+        test_data: dict[str, Any] = {
+            "test_key": {"blocksize": "4096"},
+            "maximum_iops": "1000.5",
+            "latency_at_max_iops": "5.5",
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(test_data, f)
+            temp_path = Path(f.name)
+
+        try:
+            throughput, latency = get_latency_throughput_from_file(temp_path)
+            self.assertEqual(throughput, "1000 IOps")
+            self.assertEqual(latency, "5.5")
+        finally:
+            temp_path.unlink()
+
+    def test_get_latency_throughput_from_file_large_blocksize(self) -> None:
+        """Test getting latency/throughput for large blocksize (>= 64K) - returns MB/s"""
+        test_data: dict[str, Any] = {
+            "test_key": {"blocksize": "65536"},  # 64K
+            "maximum_iops": "1000",  # Still needed even though we use bandwidth
+            "maximum_bandwidth": "100000000",  # 100MB in bytes
+            "latency_at_max_iops": "5.0",
+            "latency_at_max_bandwidth": "10.5",
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(test_data, f)
+            temp_path = Path(f.name)
+
+        try:
+            throughput, latency = get_latency_throughput_from_file(temp_path)
+            self.assertEqual(throughput, "100 MB/s")
+            self.assertEqual(latency, "10.5")
+        finally:
+            temp_path.unlink()
+
+    def test_get_resource_details_from_file(self) -> None:
+        """Test extracting CPU and memory usage from file"""
+        test_data = {
+            "maximum_cpu_usage": "45.67",
+            "maximum_memory_usage": "2048.89",
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(test_data, f)
+            temp_path = Path(f.name)
+
+        try:
+            cpu, memory = get_resource_details_from_file(temp_path)
+            self.assertEqual(cpu, "45.67")
+            self.assertEqual(memory, "2048.89")
+        finally:
+            temp_path.unlink()
+
+    def test_get_resource_details_from_file_missing_keys(self) -> None:
+        """Test extracting resource details when keys are missing"""
+        test_data: dict[str, str] = {}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(test_data, f)
+            temp_path = Path(f.name)
+
+        try:
+            cpu, memory = get_resource_details_from_file(temp_path)
+            self.assertEqual(cpu, "0.00")
+            self.assertEqual(memory, "0.00")
+        finally:
+            temp_path.unlink()
+
+    def test_strip_confidential_data_from_yaml_ipv4(self) -> None:
+        """Test stripping IPv4 addresses from YAML"""
+        yaml_data = "server: 192.168.1.100\nbackup: 10.0.0.1"
+        result = strip_confidential_data_from_yaml(yaml_data)
+        self.assertNotIn("192.168.1.100", result)
+        self.assertNotIn("10.0.0.1", result)
+        self.assertIn("--- IP Address --", result)
+
+    def test_strip_confidential_data_from_yaml_hostname(self) -> None:
+        """Test stripping hostnames from YAML"""
+        yaml_data = "server: server1.example.com\nbackup: server2.example.com"
+        result = strip_confidential_data_from_yaml(yaml_data)
+        self.assertNotIn("server1.example.com", result)
+        self.assertNotIn("server2.example.com", result)
+        self.assertIn("--- server1 ---", result)
+        self.assertIn("--- server2 ---", result)
+
+    def test_strip_confidential_data_from_yaml_mixed(self) -> None:
+        """Test stripping both IPs and hostnames"""
+        yaml_data = "server: 192.168.1.1 host.example.com"
+        result = strip_confidential_data_from_yaml(yaml_data)
+        self.assertNotIn("192.168.1.1", result)
+        self.assertNotIn("host.example.com", result)
+
+    def test_find_common_data_file_names(self) -> None:
+        """Test finding common files across multiple directories"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dir1 = Path(temp_dir) / "dir1"
+            dir2 = Path(temp_dir) / "dir2"
+            dir3 = Path(temp_dir) / "dir3"
+
+            dir1.mkdir()
+            dir2.mkdir()
+            dir3.mkdir()
+
+            # Create common files
+            (dir1 / "file1.json").touch()
+            (dir1 / "file2.json").touch()
+            (dir1 / "file3.json").touch()
+
+            (dir2 / "file1.json").touch()
+            (dir2 / "file2.json").touch()
+            (dir2 / "unique.json").touch()
+
+            (dir3 / "file1.json").touch()
+            (dir3 / "file2.json").touch()
+
+            common_files = find_common_data_file_names([dir1, dir2, dir3])
+
+            self.assertEqual(len(common_files), 2)
+            self.assertIn("file1.json", common_files)
+            self.assertIn("file2.json", common_files)
+            self.assertNotIn("file3.json", common_files)
+            self.assertNotIn("unique.json", common_files)
+
+    def test_calculate_percent_difference_to_baseline(self) -> None:
+        """Test calculating percentage difference"""
+        result = calculate_percent_difference_to_baseline("100 IOps", "150 IOps")
+        self.assertEqual(result, "50%")
+
+        result = calculate_percent_difference_to_baseline("200 MB/s", "180 MB/s")
+        self.assertEqual(result, "-10%")
+
+        result = calculate_percent_difference_to_baseline("100 IOps", "100 IOps")
+        self.assertEqual(result, "0%")
+
+    def test_get_date_time_string(self) -> None:
+        """Test getting formatted date/time string"""
+        result = get_date_time_string()
+        # Should be in format YYMMDD_HHMMSS
+        self.assertEqual(len(result), 13)
+        self.assertTrue(result[6] == "_")
+        self.assertTrue(result[:6].isdigit())
+        self.assertTrue(result[7:].isdigit())
+
+    def test_recursive_search_simple(self) -> None:
+        """Test recursive search in simple dictionary"""
+        data = {"key1": "value1", "key2": "value2"}
+        result = recursive_search(data, "key1")
+        self.assertEqual(result, "value1")
+
+    def test_recursive_search_nested(self) -> None:
+        """Test recursive search in nested dictionary"""
+        data = {"level1": {"level2": {"target_key": "found_value"}}}
+        result = recursive_search(data, "target_key")
+        self.assertEqual(result, "found_value")
+
+    def test_recursive_search_with_list(self) -> None:
+        """Test recursive search with list containing dictionaries"""
+        data = {"items": [{"name": "item1"}, {"target_key": "found_in_list"}]}
+        result = recursive_search(data, "target_key")
+        self.assertEqual(result, "found_in_list")
+
+    def test_recursive_search_not_found(self) -> None:
+        """Test recursive search when key doesn't exist"""
+        data = {"key1": "value1"}
+        result = recursive_search(data, "nonexistent")
+        self.assertIsNone(result)
+
+    def test_get_blocksize_with_unit(self) -> None:
+        """Test extracting blocksize from string with unit suffix"""
+        self.assertEqual(get_blocksize("4K"), "4")
+        self.assertEqual(get_blocksize("8M"), "8")
+        self.assertEqual(get_blocksize("16G"), "16")
+
+    def test_get_blocksize_without_unit(self) -> None:
+        """Test extracting blocksize from numeric string"""
+        self.assertEqual(get_blocksize("4096"), "4096")
+        self.assertEqual(get_blocksize("8192"), "8192")
+
+    def test_sum_standard_deviation_values(self) -> None:
+        """Test summing standard deviations from multiple runs"""
+        std_deviations = [1.0, 2.0, 1.5]
+        operations = [100, 200, 150]
+        latencies = [5.0, 6.0, 5.5]
+        total_ios = 450
+        combined_latency = 5.611111  # weighted average
+
+        result = sum_standard_deviation_values(std_deviations, operations, latencies, total_ios, combined_latency)
+
+        # Result should be a positive float
+        self.assertIsInstance(result, float)
+        self.assertGreater(result, 0)
+
+    def test_file_is_empty_true(self) -> None:
+        """Test detecting empty file"""
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            temp_path = Path(f.name)
+
+        try:
+            self.assertTrue(file_is_empty(temp_path))
+        finally:
+            temp_path.unlink()
+
+    def test_file_is_empty_false(self) -> None:
+        """Test detecting non-empty file"""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("some content")
+            temp_path = Path(f.name)
+
+        try:
+            self.assertFalse(file_is_empty(temp_path))
+        finally:
+            temp_path.unlink()
+
+    def test_file_is_precondition_true(self) -> None:
+        """Test detecting precondition file"""
+        path = Path("/some/path/precond_test.json")
+        self.assertTrue(file_is_precondition(path))
+
+    def test_file_is_precondition_false(self) -> None:
+        """Test detecting non-precondition file"""
+        path = Path("/some/path/regular_test.json")
+        self.assertFalse(file_is_precondition(path))
+
+    def test_sum_mean_values(self) -> None:
+        """Test calculating combined mean from multiple means"""
+        latencies = [5.0, 6.0, 7.0]
+        num_ops = [100, 200, 300]
+        total_ios = 600
+
+        result = sum_mean_values(latencies, num_ops, total_ios)
+
+        # Expected: (5*100 + 6*200 + 7*300) / 600 = 3800/600 = 6.333...
+        self.assertAlmostEqual(result, 6.333333, places=5)
+
+    def test_sum_mean_values_equal_weights(self) -> None:
+        """Test combined mean with equal weights"""
+        latencies = [4.0, 6.0, 8.0]
+        num_ops = [100, 100, 100]
+        total_ios = 300
+
+        result = sum_mean_values(latencies, num_ops, total_ios)
+
+        # Expected: (4 + 6 + 8) / 3 = 6.0
+        self.assertAlmostEqual(result, 6.0, places=5)
+
+    def test_title_conversion_dict(self) -> None:
+        """Test that TITLE_CONVERSION contains expected mappings"""
+        self.assertEqual(TITLE_CONVERSION["read"], "Sequential Read")
+        self.assertEqual(TITLE_CONVERSION["write"], "Sequential Write")
+        self.assertEqual(TITLE_CONVERSION["randread"], "Random Read")
+        self.assertEqual(TITLE_CONVERSION["randwrite"], "Random Write")
+        self.assertEqual(TITLE_CONVERSION["readwrite"], "Sequential Read/Write")
+        self.assertEqual(TITLE_CONVERSION["randrw"], "Random Read/Write")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+# Made with Bob

--- a/tests/test_post_processing_types.py
+++ b/tests/test_post_processing_types.py
@@ -1,0 +1,314 @@
+"""
+Unit tests for the post_processing/post_processing_types.py module
+"""
+
+import unittest
+
+from post_processing.post_processing_types import (
+    CommonFormatDataType,
+    CPUPlotType,
+    HandlerType,
+    InternalBlocksizeDataType,
+    InternalFormattedOutputType,
+    IodepthDataType,
+    JobsDataType,
+    PlotDataType,
+    ReportOptions,
+)
+
+
+class TestCPUPlotType(unittest.TestCase):
+    """Test cases for CPUPlotType enum"""
+
+    def test_cpu_plot_type_values(self) -> None:
+        """Test that CPUPlotType enum has expected values"""
+        self.assertEqual(CPUPlotType.NOCPU.value, 0)
+        self.assertEqual(CPUPlotType.OVERALL.value, 1)
+        self.assertEqual(CPUPlotType.OSD.value, 2)
+        self.assertEqual(CPUPlotType.FIO.value, 3)
+        self.assertEqual(CPUPlotType.NODES.value, 4)
+
+    def test_cpu_plot_type_members(self) -> None:
+        """Test that CPUPlotType has all expected members"""
+        members = [member.name for member in CPUPlotType]
+        self.assertIn("NOCPU", members)
+        self.assertIn("OVERALL", members)
+        self.assertIn("OSD", members)
+        self.assertIn("FIO", members)
+        self.assertIn("NODES", members)
+        self.assertEqual(len(members), 5)
+
+    def test_cpu_plot_type_comparison(self) -> None:
+        """Test CPUPlotType enum comparison"""
+        self.assertEqual(CPUPlotType.NOCPU, CPUPlotType.NOCPU)
+        self.assertNotEqual(CPUPlotType.NOCPU, CPUPlotType.OVERALL)
+
+    def test_cpu_plot_type_from_value(self) -> None:
+        """Test creating CPUPlotType from value"""
+        self.assertEqual(CPUPlotType(0), CPUPlotType.NOCPU)
+        self.assertEqual(CPUPlotType(1), CPUPlotType.OVERALL)
+        self.assertEqual(CPUPlotType(2), CPUPlotType.OSD)
+
+    def test_cpu_plot_type_from_name(self) -> None:
+        """Test accessing CPUPlotType by name"""
+        self.assertEqual(CPUPlotType["NOCPU"], CPUPlotType.NOCPU)
+        self.assertEqual(CPUPlotType["OVERALL"], CPUPlotType.OVERALL)
+
+
+class TestReportOptions(unittest.TestCase):
+    """Test cases for ReportOptions NamedTuple"""
+
+    def test_report_options_creation(self) -> None:
+        """Test creating ReportOptions instance"""
+        options = ReportOptions(
+            archives=["archive1", "archive2"],
+            output_directory="/output",
+            results_file_root="results",
+            create_pdf=True,
+            force_refresh=False,
+            no_error_bars=True,
+            comparison=False,
+            plot_resources=True,
+        )
+
+        self.assertEqual(options.archives, ["archive1", "archive2"])
+        self.assertEqual(options.output_directory, "/output")
+        self.assertEqual(options.results_file_root, "results")
+        self.assertTrue(options.create_pdf)
+        self.assertFalse(options.force_refresh)
+        self.assertTrue(options.no_error_bars)
+        self.assertFalse(options.comparison)
+        self.assertTrue(options.plot_resources)
+
+    def test_report_options_immutable(self) -> None:
+        """Test that ReportOptions is immutable"""
+        options = ReportOptions(
+            archives=["archive1"],
+            output_directory="/output",
+            results_file_root="results",
+            create_pdf=True,
+            force_refresh=False,
+            no_error_bars=False,
+            comparison=False,
+            plot_resources=False,
+        )
+
+        with self.assertRaises(AttributeError):
+            options.archives = ["new_archive"]  # type: ignore
+
+    def test_report_options_access_by_index(self) -> None:
+        """Test accessing ReportOptions fields by index"""
+        options = ReportOptions(
+            archives=["archive1"],
+            output_directory="/output",
+            results_file_root="results",
+            create_pdf=True,
+            force_refresh=False,
+            no_error_bars=False,
+            comparison=False,
+            plot_resources=False,
+        )
+
+        self.assertEqual(options[0], ["archive1"])
+        self.assertEqual(options[1], "/output")
+        self.assertEqual(options[2], "results")
+        self.assertTrue(options[3])
+
+    def test_report_options_unpack(self) -> None:
+        """Test unpacking ReportOptions"""
+        options = ReportOptions(
+            archives=["archive1"],
+            output_directory="/output",
+            results_file_root="results",
+            create_pdf=True,
+            force_refresh=False,
+            no_error_bars=False,
+            comparison=False,
+            plot_resources=False,
+        )
+
+        (archives, output_dir, results_root, create_pdf, force_refresh, no_error_bars, comparison, plot_resources) = (
+            options
+        )
+
+        self.assertEqual(archives, ["archive1"])
+        self.assertEqual(output_dir, "/output")
+        self.assertEqual(results_root, "results")
+        self.assertTrue(create_pdf)
+
+    def test_report_options_as_dict(self) -> None:
+        """Test converting ReportOptions to dict"""
+        options = ReportOptions(
+            archives=["archive1"],
+            output_directory="/output",
+            results_file_root="results",
+            create_pdf=True,
+            force_refresh=False,
+            no_error_bars=False,
+            comparison=False,
+            plot_resources=False,
+        )
+
+        options_dict = options._asdict()
+
+        self.assertEqual(options_dict["archives"], ["archive1"])
+        self.assertEqual(options_dict["output_directory"], "/output")
+        self.assertEqual(options_dict["results_file_root"], "results")
+        self.assertTrue(options_dict["create_pdf"])
+
+    def test_report_options_replace(self) -> None:
+        """Test replacing fields in ReportOptions"""
+        options = ReportOptions(
+            archives=["archive1"],
+            output_directory="/output",
+            results_file_root="results",
+            create_pdf=True,
+            force_refresh=False,
+            no_error_bars=False,
+            comparison=False,
+            plot_resources=False,
+        )
+
+        new_options = options._replace(create_pdf=False, force_refresh=True)
+
+        self.assertFalse(new_options.create_pdf)
+        self.assertTrue(new_options.force_refresh)
+        # Original should be unchanged
+        self.assertTrue(options.create_pdf)
+        self.assertFalse(options.force_refresh)
+
+
+class TestTypeAliases(unittest.TestCase):
+    """Test cases for type aliases"""
+
+    def test_handler_type_structure(self) -> None:
+        """Test HandlerType type alias structure"""
+        handler: HandlerType = {
+            "console": {
+                "class": "logging.StreamHandler",
+                "level": "INFO",
+            }
+        }
+
+        self.assertIsInstance(handler, dict)
+        self.assertIsInstance(handler["console"], dict)
+        self.assertIsInstance(handler["console"]["class"], str)
+
+    def test_iodepth_data_type_structure(self) -> None:
+        """Test IodepthDataType type alias structure"""
+        iodepth_data: IodepthDataType = {
+            "1": "100",
+            "2": "200",
+            "4": "400",
+        }
+
+        self.assertIsInstance(iodepth_data, dict)
+        for key, value in iodepth_data.items():
+            self.assertIsInstance(key, str)
+            self.assertIsInstance(value, str)
+
+    def test_common_format_data_type_structure(self) -> None:
+        """Test CommonFormatDataType type alias structure"""
+        common_data: CommonFormatDataType = {
+            "1": {"bandwidth": "1000", "iops": "100"},
+            "metadata": "test",
+        }
+
+        self.assertIsInstance(common_data, dict)
+
+    def test_internal_blocksize_data_type_structure(self) -> None:
+        """Test InternalBlocksizeDataType type alias structure"""
+        blocksize_data: InternalBlocksizeDataType = {
+            "4096": {
+                "1": {"bandwidth": "1000"},
+                "metadata": "test",
+            }
+        }
+
+        self.assertIsInstance(blocksize_data, dict)
+
+    def test_internal_formatted_output_type_structure(self) -> None:
+        """Test InternalFormattedOutputType type alias structure"""
+        formatted_output: InternalFormattedOutputType = {
+            "read": {
+                "4096": {
+                    "1": {"bandwidth": "1000"},
+                }
+            }
+        }
+
+        self.assertIsInstance(formatted_output, dict)
+
+    def test_plot_data_type_structure(self) -> None:
+        """Test PlotDataType type alias structure"""
+        plot_data: PlotDataType = {
+            "series1": {
+                "x": "1,2,3",
+                "y": "10,20,30",
+            }
+        }
+
+        self.assertIsInstance(plot_data, dict)
+        self.assertIsInstance(plot_data["series1"], dict)
+
+    def test_jobs_data_type_structure(self) -> None:
+        """Test JobsDataType type alias structure"""
+        jobs_data: JobsDataType = [
+            {
+                "jobname": "test_job",
+                "read": {
+                    "iops": 100,
+                    "bw": 1000,
+                    "lat_ns": {
+                        "mean": 5000,
+                    },
+                },
+            }
+        ]
+
+        self.assertIsInstance(jobs_data, list)
+        self.assertIsInstance(jobs_data[0], dict)
+
+
+class TestTypeAliasUsage(unittest.TestCase):
+    """Test practical usage of type aliases"""
+
+    def test_nested_common_format_data(self) -> None:
+        """Test nested structure of CommonFormatDataType"""
+        data: CommonFormatDataType = {
+            "1": {"bandwidth_bytes": "1000000", "iops": "100"},
+            "2": {"bandwidth_bytes": "2000000", "iops": "200"},
+            "maximum_iops": "200",
+            "maximum_bandwidth": "2000000",
+        }
+
+        # Should be able to access nested data
+        iodepth_1 = data["1"]
+        self.assertIsInstance(iodepth_1, dict)
+
+        # Should be able to access string values
+        max_iops = data["maximum_iops"]
+        self.assertIsInstance(max_iops, str)
+
+    def test_handler_type_multiple_handlers(self) -> None:
+        """Test HandlerType with multiple handlers"""
+        handlers: HandlerType = {
+            "console": {
+                "class": "logging.StreamHandler",
+                "level": "INFO",
+                "formatter": "console",
+            },
+            "file": {
+                "class": "logging.FileHandler",
+                "level": "DEBUG",
+                "formatter": "detailed",
+                "filename": "/tmp/test.log",
+            },
+        }
+
+        self.assertEqual(len(handlers), 2)
+        self.assertIn("console", handlers)
+        self.assertIn("file", handlers)
+
+
+# Made with Bob

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,420 @@
+"""
+Unit tests for the post_processing/report.py module
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import shutil
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from post_processing.post_processing_types import ReportOptions
+from post_processing.report import Report, parse_namespace_to_options
+
+
+class TestParseNamespaceToOptions(unittest.TestCase):
+    """Test cases for parse_namespace_to_options function"""
+
+    def test_parse_namespace_simple_report(self) -> None:
+        """Test parsing namespace for simple (non-comparison) report"""
+        args = Namespace(
+            archive="/path/to/archive",
+            output_directory="/output",
+            results_file_root="results",
+            create_pdf=True,
+            force_refresh=False,
+        )
+
+        options = parse_namespace_to_options(args, comparison_report=False)
+
+        self.assertEqual(options.archives, ["/path/to/archive"])
+        self.assertEqual(options.output_directory, "/output")
+        self.assertEqual(options.results_file_root, "results")
+        self.assertTrue(options.create_pdf)
+        self.assertFalse(options.force_refresh)
+        self.assertFalse(options.no_error_bars)
+        self.assertFalse(options.comparison)
+        self.assertFalse(options.plot_resources)
+
+    def test_parse_namespace_comparison_report(self) -> None:
+        """Test parsing namespace for comparison report"""
+        args = Namespace(
+            baseline="/path/to/baseline",
+            archives="/path/to/archive1,/path/to/archive2",
+            output_directory="/output",
+            results_file_root="results",
+            create_pdf=False,
+            force_refresh=True,
+        )
+
+        options = parse_namespace_to_options(args, comparison_report=True)
+
+        self.assertEqual(len(options.archives), 3)
+        self.assertEqual(options.archives[0], "/path/to/baseline")
+        self.assertEqual(options.archives[1], "/path/to/archive1")
+        self.assertEqual(options.archives[2], "/path/to/archive2")
+        self.assertTrue(options.comparison)
+        self.assertTrue(options.force_refresh)
+
+    def test_parse_namespace_with_no_error_bars(self) -> None:
+        """Test parsing namespace with no_error_bars attribute"""
+        args = Namespace(
+            archive="/path/to/archive",
+            output_directory="/output",
+            results_file_root="results",
+            create_pdf=False,
+            force_refresh=False,
+            no_error_bars=True,
+        )
+
+        options = parse_namespace_to_options(args, comparison_report=False)
+
+        self.assertTrue(options.no_error_bars)
+
+    def test_parse_namespace_with_plot_resources(self) -> None:
+        """Test parsing namespace with plot_resources attribute"""
+        args = Namespace(
+            archive="/path/to/archive",
+            output_directory="/output",
+            results_file_root="results",
+            create_pdf=False,
+            force_refresh=False,
+            plot_resources=True,
+        )
+
+        options = parse_namespace_to_options(args, comparison_report=False)
+
+        self.assertTrue(options.plot_resources)
+
+    def test_parse_namespace_without_optional_attributes(self) -> None:
+        """Test parsing namespace without optional attributes"""
+        args = Namespace(
+            archive="/path/to/archive",
+            output_directory="/output",
+            results_file_root="results",
+            create_pdf=False,
+            force_refresh=False,
+        )
+
+        options = parse_namespace_to_options(args, comparison_report=False)
+
+        # Should default to False when attributes don't exist
+        self.assertFalse(options.no_error_bars)
+        self.assertFalse(options.plot_resources)
+
+
+class TestReport(unittest.TestCase):
+    """Test cases for Report class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.options = ReportOptions(
+            archives=[self.temp_dir],
+            output_directory=f"{self.temp_dir}/output",
+            results_file_root="test_results",
+            create_pdf=False,
+            force_refresh=False,
+            no_error_bars=False,
+            comparison=False,
+            plot_resources=False,
+        )
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_report_initialization(self) -> None:
+        """Test Report class initialization"""
+        report = Report(self.options)
+
+        self.assertEqual(report._options, self.options)
+        self.assertEqual(report.result_code, 0)
+
+    def test_result_code_property(self) -> None:
+        """Test result_code property"""
+        report = Report(self.options)
+
+        self.assertEqual(report.result_code, 0)
+
+        # Simulate error by setting internal result code
+        report._result_code = 1
+        self.assertEqual(report.result_code, 1)
+
+    @patch("post_processing.report.os.makedirs")
+    @patch("post_processing.report.CommonOutputFormatter")
+    @patch("post_processing.report.SimpleReportGenerator")
+    def test_generate_simple_report_success(
+        self,
+        mock_simple_generator: MagicMock,
+        mock_formatter: MagicMock,
+        mock_makedirs: MagicMock,
+    ) -> None:
+        """Test successful generation of simple report"""
+        # Setup mocks
+        mock_formatter_instance = MagicMock()
+        mock_formatter.return_value = mock_formatter_instance
+
+        mock_generator_instance = MagicMock()
+        mock_simple_generator.return_value = mock_generator_instance
+
+        # Create report with existing visualisation directory
+        vis_dir = Path(self.temp_dir) / "visualisation"
+        vis_dir.mkdir()
+        (vis_dir / "dummy.json").touch()
+
+        report = Report(self.options)
+        report.generate()
+
+        # Should create output directory
+        mock_makedirs.assert_called()
+
+        # Should not create formatter since visualisation directory exists and not force_refresh
+        mock_formatter.assert_not_called()
+
+        # Should create report generator
+        mock_simple_generator.assert_called_once()
+        mock_generator_instance.create_report.assert_called_once()
+
+        # Should not create PDF
+        mock_generator_instance.save_as_pdf.assert_not_called()
+
+        # Result code should be 0
+        self.assertEqual(report.result_code, 0)
+
+    @patch("post_processing.report.os.makedirs")
+    @patch("post_processing.report.os.path.exists")
+    @patch("post_processing.report.os.listdir")
+    @patch("post_processing.report.CommonOutputFormatter")
+    @patch("post_processing.report.SimpleReportGenerator")
+    def test_generate_with_intermediate_file_creation(
+        self,
+        mock_simple_generator: MagicMock,
+        mock_formatter: MagicMock,
+        mock_listdir: MagicMock,
+        mock_exists: MagicMock,
+        mock_makedirs: MagicMock,
+    ) -> None:
+        """Test report generation when intermediate files need to be created"""
+        # Setup mocks - visualisation directory doesn't exist
+        mock_exists.return_value = False
+        mock_listdir.return_value = []
+
+        mock_formatter_instance = MagicMock()
+        mock_formatter.return_value = mock_formatter_instance
+
+        mock_generator_instance = MagicMock()
+        mock_simple_generator.return_value = mock_generator_instance
+
+        report = Report(self.options)
+        report.generate()
+
+        # Should create formatter and convert files
+        mock_formatter.assert_called_once()
+        mock_formatter_instance.convert_all_files.assert_called_once()
+        mock_formatter_instance.write_output_file.assert_called_once()
+
+    @patch("post_processing.report.os.makedirs")
+    @patch("post_processing.report.CommonOutputFormatter")
+    @patch("post_processing.report.ComparisonReportGenerator")
+    def test_generate_comparison_report(
+        self,
+        mock_comparison_generator: MagicMock,
+        mock_formatter: MagicMock,
+        mock_makedirs: MagicMock,
+    ) -> None:
+        """Test generation of comparison report"""
+        comparison_options = ReportOptions(
+            archives=[self.temp_dir, f"{self.temp_dir}/archive2"],
+            output_directory=f"{self.temp_dir}/output",
+            results_file_root="test_results",
+            create_pdf=False,
+            force_refresh=False,
+            no_error_bars=False,
+            comparison=True,
+            plot_resources=False,
+        )
+
+        # Create visualisation directories
+        for archive in comparison_options.archives:
+            vis_dir = Path(archive) / "visualisation"
+            vis_dir.mkdir(parents=True, exist_ok=True)
+            (vis_dir / "dummy.json").touch()
+
+        mock_generator_instance = MagicMock()
+        mock_comparison_generator.return_value = mock_generator_instance
+
+        report = Report(comparison_options)
+        report.generate()
+
+        # Should create comparison report generator
+        mock_comparison_generator.assert_called_once()
+        mock_generator_instance.create_report.assert_called_once()
+
+    @patch("post_processing.report.os.makedirs")
+    @patch("post_processing.report.CommonOutputFormatter")
+    @patch("post_processing.report.SimpleReportGenerator")
+    def test_generate_with_pdf_creation(
+        self,
+        mock_simple_generator: MagicMock,
+        mock_formatter: MagicMock,
+        mock_makedirs: MagicMock,
+    ) -> None:
+        """Test report generation with PDF creation"""
+        pdf_options = ReportOptions(
+            archives=[self.temp_dir],
+            output_directory=f"{self.temp_dir}/output",
+            results_file_root="test_results",
+            create_pdf=True,
+            force_refresh=False,
+            no_error_bars=False,
+            comparison=False,
+            plot_resources=False,
+        )
+
+        # Create visualisation directory
+        vis_dir = Path(self.temp_dir) / "visualisation"
+        vis_dir.mkdir()
+        (vis_dir / "dummy.json").touch()
+
+        mock_generator_instance = MagicMock()
+        mock_simple_generator.return_value = mock_generator_instance
+
+        report = Report(pdf_options)
+        report.generate()
+
+        # Should create PDF
+        mock_generator_instance.save_as_pdf.assert_called_once()
+
+    @patch("post_processing.report.os.makedirs")
+    @patch("post_processing.report.CommonOutputFormatter")
+    @patch("post_processing.report.SimpleReportGenerator")
+    def test_generate_with_exception_no_throw(
+        self,
+        mock_simple_generator: MagicMock,
+        mock_formatter: MagicMock,
+        mock_makedirs: MagicMock,
+    ) -> None:
+        """Test report generation when exception occurs and throw_exception=False"""
+        # Create visualisation directory
+        vis_dir = Path(self.temp_dir) / "visualisation"
+        vis_dir.mkdir()
+        (vis_dir / "dummy.json").touch()
+
+        # Make report generator raise exception
+        mock_generator_instance = MagicMock()
+        mock_generator_instance.create_report.side_effect = Exception("Test error")
+        mock_simple_generator.return_value = mock_generator_instance
+
+        report = Report(self.options)
+        report.generate(throw_exception=False)
+
+        # Should set result code to 1
+        self.assertEqual(report.result_code, 1)
+
+    @patch("post_processing.report.os.makedirs")
+    @patch("post_processing.report.CommonOutputFormatter")
+    @patch("post_processing.report.SimpleReportGenerator")
+    def test_generate_with_exception_throw(
+        self,
+        mock_simple_generator: MagicMock,
+        mock_formatter: MagicMock,
+        mock_makedirs: MagicMock,
+    ) -> None:
+        """Test report generation when exception occurs and throw_exception=True"""
+        # Create visualisation directory
+        vis_dir = Path(self.temp_dir) / "visualisation"
+        vis_dir.mkdir()
+        (vis_dir / "dummy.json").touch()
+
+        # Make report generator raise exception
+        mock_generator_instance = MagicMock()
+        test_exception = Exception("Test error")
+        mock_generator_instance.create_report.side_effect = test_exception
+        mock_simple_generator.return_value = mock_generator_instance
+
+        report = Report(self.options)
+
+        # Should re-raise exception
+        with self.assertRaises(Exception) as context:
+            report.generate(throw_exception=True)
+
+        self.assertEqual(str(context.exception), "Test error")
+        self.assertEqual(report.result_code, 1)
+
+    @patch("post_processing.report.os.makedirs")
+    @patch("post_processing.report.os.path.exists")
+    @patch("post_processing.report.os.listdir")
+    @patch("post_processing.report.CommonOutputFormatter")
+    @patch("post_processing.report.SimpleReportGenerator")
+    def test_generate_with_force_refresh(
+        self,
+        mock_simple_generator: MagicMock,
+        mock_formatter: MagicMock,
+        mock_listdir: MagicMock,
+        mock_exists: MagicMock,
+        mock_makedirs: MagicMock,
+    ) -> None:
+        """Test report generation with force_refresh=True"""
+        refresh_options = ReportOptions(
+            archives=[self.temp_dir],
+            output_directory=f"{self.temp_dir}/output",
+            results_file_root="test_results",
+            create_pdf=False,
+            force_refresh=True,
+            no_error_bars=False,
+            comparison=False,
+            plot_resources=False,
+        )
+
+        # Visualisation directory exists with files
+        mock_exists.return_value = True
+        mock_listdir.return_value = ["existing_file.json"]
+
+        mock_formatter_instance = MagicMock()
+        mock_formatter.return_value = mock_formatter_instance
+
+        mock_generator_instance = MagicMock()
+        mock_simple_generator.return_value = mock_generator_instance
+
+        report = Report(refresh_options)
+        report.generate()
+
+        # Should still create formatter and regenerate files
+        mock_formatter.assert_called_once()
+        mock_formatter_instance.convert_all_files.assert_called_once()
+        mock_formatter_instance.write_output_file.assert_called_once()
+
+    @patch("post_processing.report.os.makedirs")
+    @patch("post_processing.report.os.path.exists")
+    @patch("post_processing.report.os.listdir")
+    @patch("post_processing.report.CommonOutputFormatter")
+    def test_generate_intermediate_files_exception(
+        self,
+        mock_formatter: MagicMock,
+        mock_listdir: MagicMock,
+        mock_exists: MagicMock,
+        mock_makedirs: MagicMock,
+    ) -> None:
+        """Test exception handling during intermediate file generation"""
+        mock_exists.return_value = False
+
+        # Make formatter raise exception
+        mock_formatter_instance = MagicMock()
+        mock_formatter_instance.convert_all_files.side_effect = Exception("Conversion error")
+        mock_formatter.return_value = mock_formatter_instance
+
+        report = Report(self.options)
+
+        # Should catch and re-raise exception
+        with self.assertRaises(Exception):
+            report.generate(throw_exception=True)
+
+
+# Made with Bob

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,0 +1,156 @@
+"""
+Unit tests for the post_processing/reports module classes
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from post_processing.reports.report_generator import ReportGenerator
+from post_processing.reports.simple_report_generator import SimpleReportGenerator
+
+
+class TestReportGenerator(unittest.TestCase):
+    """Test cases for ReportGenerator base class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.archive_dir = Path(self.temp_dir) / "archive"
+        self.vis_dir = self.archive_dir / "visualisation"
+        self.vis_dir.mkdir(parents=True)
+
+        # Create some test data files
+        (self.vis_dir / "4096_read.json").touch()
+        (self.vis_dir / "8192_write.json").touch()
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_initialization(self) -> None:
+        """Test ReportGenerator initialization"""
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = SimpleReportGenerator(
+            archive_directories=[str(self.archive_dir)],
+            output_directory=output_dir,
+            no_error_bars=False,
+            force_refresh=False,
+            plot_resources=False,
+        )
+
+        self.assertTrue(generator._plot_error_bars)
+        self.assertFalse(generator._force_refresh)
+        self.assertFalse(generator._plot_resources)
+        self.assertEqual(len(generator._archive_directories), 1)
+        self.assertEqual(len(generator._data_directories), 1)
+
+    def test_initialization_with_no_error_bars(self) -> None:
+        """Test initialization with no_error_bars=True"""
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = SimpleReportGenerator(
+            archive_directories=[str(self.archive_dir)],
+            output_directory=output_dir,
+            no_error_bars=True,
+            force_refresh=False,
+            plot_resources=False,
+        )
+
+        self.assertFalse(generator._plot_error_bars)
+
+    def test_initialization_with_plot_resources(self) -> None:
+        """Test initialization with plot_resources=True"""
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = SimpleReportGenerator(
+            archive_directories=[str(self.archive_dir)],
+            output_directory=output_dir,
+            no_error_bars=False,
+            force_refresh=False,
+            plot_resources=True,
+        )
+
+        self.assertTrue(generator._plot_resources)
+
+    def test_build_strings_replace_underscores(self) -> None:
+        """Test that build strings replace underscores with hyphens"""
+        archive_with_underscores = Path(self.temp_dir) / "test_archive_name"
+        vis_dir = archive_with_underscores / "visualisation"
+        vis_dir.mkdir(parents=True)
+        (vis_dir / "4096_read.json").touch()
+
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = SimpleReportGenerator(
+            archive_directories=[str(archive_with_underscores)],
+            output_directory=output_dir,
+        )
+
+        self.assertEqual(generator._build_strings[0], "test-archive-name")
+        self.assertNotIn("_", generator._build_strings[0])
+
+    def test_find_files_with_filename(self) -> None:
+        """Test finding files with specific filename"""
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = SimpleReportGenerator(
+            archive_directories=[str(self.archive_dir)],
+            output_directory=output_dir,
+        )
+
+        files = generator._find_files_with_filename("4096_read")
+
+        self.assertEqual(len(files), 1)
+        self.assertTrue(str(files[0]).endswith("4096_read.json"))
+
+    def test_sort_list_of_paths(self) -> None:
+        """Test sorting paths by numeric blocksize"""
+        # Create files with different blocksizes
+        (self.vis_dir / "16384_read.json").touch()
+        (self.vis_dir / "1024_read.json").touch()
+
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = SimpleReportGenerator(
+            archive_directories=[str(self.archive_dir)],
+            output_directory=output_dir,
+        )
+
+        paths = list(self.vis_dir.glob("*.json"))
+        sorted_paths = generator._sort_list_of_paths(paths, index=0)
+
+        # Should be sorted by blocksize: 1024, 4096, 8192, 16384
+        self.assertTrue(str(sorted_paths[0]).endswith("1024_read.json"))
+        self.assertTrue(str(sorted_paths[-1]).endswith("16384_read.json"))
+
+    def test_generate_plot_directory_name(self) -> None:
+        """Test generating unique plot directory name"""
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = SimpleReportGenerator(
+            archive_directories=[str(self.archive_dir)],
+            output_directory=output_dir,
+        )
+
+        plot_dir_name = generator._generate_plot_directory_name()
+
+        self.assertTrue(plot_dir_name.startswith(f"{output_dir}/plots."))
+        # Should have timestamp appended
+        self.assertGreater(len(plot_dir_name), len(f"{output_dir}/plots."))
+
+    def test_constants(self) -> None:
+        """Test ReportGenerator constants"""
+        self.assertEqual(ReportGenerator.MARKDOWN_FILE_EXTENSION, "md")
+        self.assertEqual(ReportGenerator.PDF_FILE_EXTENSION, "pdf")
+        self.assertEqual(ReportGenerator.BASE_HEADER_FILE_PATH, "include/performance_report.tex")
+
+
+# Made with Bob

--- a/tests/test_resource_result.py
+++ b/tests/test_resource_result.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for the post_processing/run_results resource result class
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from post_processing.run_results.resources.resource_result import ResourceResult
+
+
+class ConcreteResourceResult(ResourceResult):
+    """Concrete implementation of ResourceResult for testing"""
+
+    @property
+    def source(self) -> str:
+        return "test_resource"
+
+    def _get_resource_output_file_from_file_path(self, file_path: Path) -> Path:
+        return file_path
+
+    def _parse(self, data: dict[str, Any]) -> None:
+        self._cpu = "50.0"
+        self._memory = "1024.0"
+        self._has_been_parsed = True
+
+
+class TestResourceResult(unittest.TestCase):
+    """Test cases for ResourceResult base class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.test_file = Path(self.temp_dir) / "resource_output.json"
+
+        self.test_data = {"cpu_usage": 50.5, "memory_usage": 2048}
+
+        with open(self.test_file, "w") as f:
+            json.dump(self.test_data, f)
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_initialization(self) -> None:
+        """Test ResourceResult initialization"""
+        result = ConcreteResourceResult(self.test_file)
+
+        self.assertEqual(result._resource_file_path, self.test_file)
+        self.assertFalse(result._has_been_parsed)
+
+    def test_cpu_property(self) -> None:
+        """Test CPU property triggers parsing"""
+        result = ConcreteResourceResult(self.test_file)
+
+        cpu = result.cpu
+
+        self.assertEqual(cpu, "50.0")
+        self.assertTrue(result._has_been_parsed)
+
+    def test_memory_property(self) -> None:
+        """Test memory property triggers parsing"""
+        result = ConcreteResourceResult(self.test_file)
+
+        memory = result.memory
+
+        self.assertEqual(memory, "1024.0")
+        self.assertTrue(result._has_been_parsed)
+
+    def test_get_method(self) -> None:
+        """Test get method returns formatted dict"""
+        result = ConcreteResourceResult(self.test_file)
+
+        data = result.get()
+
+        self.assertIn("source", data)
+        self.assertIn("cpu", data)
+        self.assertIn("memory", data)
+        self.assertEqual(data["source"], "test_resource")
+        self.assertEqual(data["cpu"], "50.0")
+        self.assertEqual(data["memory"], "1024.0")
+
+    def test_read_results_from_empty_file(self) -> None:
+        """Test reading from empty file"""
+        empty_file = Path(self.temp_dir) / "empty.json"
+        empty_file.touch()
+
+        result = ConcreteResourceResult(empty_file)
+        data = result._read_results_from_file()
+
+        self.assertEqual(data, {})
+
+
+# Made with Bob

--- a/tests/test_simple_plotter.py
+++ b/tests/test_simple_plotter.py
@@ -1,0 +1,147 @@
+"""
+Unit tests for the post_processing/plotter simple_plotter module class
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from post_processing.plotter.simple_plotter import SimplePlotter
+
+
+class TestSimplePlotter(unittest.TestCase):
+    """Test cases for SimplePlotter class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.archive_dir = Path(self.temp_dir) / "archive"
+        self.vis_dir = self.archive_dir / "visualisation"
+        self.vis_dir.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_initialization(self) -> None:
+        """Test SimplePlotter initialization"""
+        plotter = SimplePlotter(archive_directory=str(self.archive_dir), plot_error_bars=True, plot_resources=False)
+
+        self.assertEqual(plotter._path, self.vis_dir)
+        self.assertTrue(plotter._plot_error_bars)
+        self.assertFalse(plotter._plot_resources)
+
+    def test_initialization_with_different_options(self) -> None:
+        """Test SimplePlotter initialization with different options"""
+        plotter = SimplePlotter(archive_directory=str(self.archive_dir), plot_error_bars=False, plot_resources=True)
+
+        self.assertFalse(plotter._plot_error_bars)
+        self.assertTrue(plotter._plot_resources)
+
+    def test_generate_output_file_name(self) -> None:
+        """Test generating output file name"""
+        plotter = SimplePlotter(archive_directory=str(self.archive_dir), plot_error_bars=True, plot_resources=False)
+
+        input_file = Path("/path/to/4096_read.json")
+        output_name = plotter._generate_output_file_name([input_file])
+
+        self.assertEqual(output_name, "/path/to/4096_read.svg")
+
+    @patch("post_processing.plotter.simple_plotter.read_intermediate_file")
+    @patch("matplotlib.pyplot.subplots")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.close")
+    def test_draw_and_save(
+        self,
+        mock_close: MagicMock,
+        mock_savefig: MagicMock,
+        mock_subplots: MagicMock,
+        mock_read_file: MagicMock,
+    ) -> None:
+        """Test draw_and_save method"""
+        # Create test data file
+        test_file = self.vis_dir / "4096_read.json"
+        test_file.touch()
+
+        # Mock file data
+        mock_read_file.return_value = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "100",
+                "latency": "5000000",
+                "std_deviation": "500000",
+            },
+            "maximum_iops": "100",
+        }
+
+        # Mock matplotlib
+        mock_figure = MagicMock()
+        mock_axes = MagicMock()
+        mock_subplots.return_value = (mock_figure, mock_axes)
+
+        plotter = SimplePlotter(archive_directory=str(self.archive_dir), plot_error_bars=True, plot_resources=False)
+
+        plotter.draw_and_save()
+
+        # Should read the file
+        mock_read_file.assert_called_once()
+
+        # Should create subplots
+        mock_subplots.assert_called_once()
+
+        # Should save the plot
+        mock_savefig.assert_called_once()
+
+        # Should close the plot (may be called once or twice depending on matplotlib version)
+        self.assertGreaterEqual(mock_close.call_count, 1)
+
+    @patch("post_processing.plotter.simple_plotter.read_intermediate_file")
+    @patch("matplotlib.pyplot.subplots")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.close")
+    def test_draw_and_save_multiple_files(
+        self,
+        mock_close: MagicMock,
+        mock_savefig: MagicMock,
+        mock_subplots: MagicMock,
+        mock_read_file: MagicMock,
+    ) -> None:
+        """Test draw_and_save with multiple data files"""
+        # Create multiple test data files
+        (self.vis_dir / "4096_read.json").touch()
+        (self.vis_dir / "8192_write.json").touch()
+
+        mock_read_file.return_value = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "100",
+                "latency": "5000000",
+                "std_deviation": "500000",
+            },
+        }
+
+        mock_figure = MagicMock()
+        mock_axes = MagicMock()
+        mock_subplots.return_value = (mock_figure, mock_axes)
+
+        plotter = SimplePlotter(archive_directory=str(self.archive_dir), plot_error_bars=False, plot_resources=False)
+
+        plotter.draw_and_save()
+
+        # Should process both files
+        self.assertEqual(mock_read_file.call_count, 2)
+        self.assertEqual(mock_savefig.call_count, 2)
+        # close may be called 2-4 times depending on matplotlib version
+        self.assertGreaterEqual(mock_close.call_count, 2)
+
+
+# Made with Bob

--- a/tests/test_simple_report_generator.py
+++ b/tests/test_simple_report_generator.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for the post_processing/reports module classes
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from post_processing.reports.simple_report_generator import SimpleReportGenerator
+
+
+class TestSimpleReportGenerator(unittest.TestCase):
+    """Test cases for SimpleReportGenerator class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.archive_dir = Path(self.temp_dir) / "test_archive"
+        self.vis_dir = self.archive_dir / "visualisation"
+        self.vis_dir.mkdir(parents=True)
+
+        # Create test data files
+        (self.vis_dir / "4096_read.json").touch()
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_generate_report_title(self) -> None:
+        """Test generating report title"""
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = SimpleReportGenerator(
+            archive_directories=[str(self.archive_dir)],
+            output_directory=output_dir,
+        )
+
+        title = generator._generate_report_title()
+
+        self.assertIn("Performance Report", title)
+        self.assertIn("test-archive", title)
+
+    def test_generate_report_name(self) -> None:
+        """Test generating report name with timestamp"""
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = SimpleReportGenerator(
+            archive_directories=[str(self.archive_dir)],
+            output_directory=output_dir,
+        )
+
+        report_name = generator._generate_report_name()
+
+        self.assertTrue(report_name.startswith("performance_report_"))
+        self.assertTrue(report_name.endswith(".md"))
+        # Should contain timestamp in format YYMMDD_HHMMSS
+        self.assertIn("_", report_name)
+
+    @patch("post_processing.reports.simple_report_generator.SimplePlotter")
+    def test_copy_images_creates_plots_if_missing(self, mock_plotter_class: MagicMock) -> None:
+        """Test that _copy_images creates plots if they don't exist"""
+        output_dir = f"{self.temp_dir}/output"
+
+        mock_plotter = MagicMock()
+        mock_plotter_class.return_value = mock_plotter
+
+        generator = SimpleReportGenerator(
+            archive_directories=[str(self.archive_dir)],
+            output_directory=output_dir,
+        )
+
+        generator._copy_images()
+
+        # Should create plotter and call draw_and_save
+        mock_plotter_class.assert_called_once()
+        mock_plotter.draw_and_save.assert_called_once()
+
+    def test_find_and_sort_file_paths(self) -> None:
+        """Test finding and sorting file paths"""
+        # Create multiple files
+        (self.vis_dir / "8192_write.json").touch()
+        (self.vis_dir / "16384_read.json").touch()
+
+        output_dir = f"{self.temp_dir}/output"
+
+        generator = SimpleReportGenerator(
+            archive_directories=[str(self.archive_dir)],
+            output_directory=output_dir,
+        )
+
+        paths = generator._find_and_sort_file_paths(paths=[self.vis_dir], search_pattern="*.json", index=0)
+
+        self.assertEqual(len(paths), 3)
+        # Should be sorted by blocksize
+        self.assertTrue(str(paths[0]).endswith("4096_read.json"))
+
+
+# Made with Bob

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -1,0 +1,258 @@
+"""Unit tests for the Workload class"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import unittest
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+from command.command import Command
+from workloads.workload import Workload
+from workloads.workload_types import WorkloadType
+
+
+class TestWorkload(unittest.TestCase):
+    """Tests for the Workload class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.workload_name = "test_workload"
+        self.base_run_directory = "/tmp/test_run/"
+        self.workload_options: WorkloadType = {
+            "mode": "randwrite",
+            "iodepth": ["4", "8"],
+            "numjobs": ["1", "2"],
+            "op_size": ["4096"],
+            "volumes_per_client": "1",
+        }
+
+    def _create_workload(self, options: Optional[WorkloadType] = None) -> Workload:
+        """Helper to create a Workload instance"""
+        if options is None:
+            options = self.workload_options
+        return Workload(self.workload_name, options, self.base_run_directory)
+
+    def test_workload_initialization(self) -> None:
+        """Test that a Workload initializes correctly"""
+        workload = self._create_workload()
+
+        self.assertEqual(workload.get_name(), self.workload_name)
+        self.assertIsNotNone(workload)
+        self.assertFalse(workload.has_script())
+
+    def test_workload_with_script(self) -> None:
+        """Test workload with pre_workload_script"""
+        options = self.workload_options.copy()
+        options["pre_workload_script"] = "/path/to/script.sh"
+        workload = self._create_workload(options)
+
+        self.assertTrue(workload.has_script())
+        self.assertEqual(workload.get_script_command(), "/path/to/script.sh")
+
+    def test_workload_without_script(self) -> None:
+        """Test workload without pre_workload_script"""
+        workload = self._create_workload()
+
+        self.assertFalse(workload.has_script())
+        self.assertIsNone(workload.get_script_command())
+
+    def test_set_executable(self) -> None:
+        """Test setting the executable path"""
+        workload = self._create_workload()
+        executable_path = "/usr/bin/fio"
+
+        workload.set_executable(executable_path)
+        self.assertEqual(workload._executable_path, executable_path)
+
+    def test_set_benchmark_type_rbdfio(self) -> None:
+        """Test setting benchmark type to rbdfio"""
+        workload = self._create_workload()
+        workload.set_benchmark_type("rbdfio")
+
+        self.assertEqual(workload._parent_benchmark_type, "rbdfio")
+
+    def test_set_benchmark_type_fio(self) -> None:
+        """Test setting benchmark type to fio"""
+        workload = self._create_workload()
+        workload.set_benchmark_type("fio")
+
+        self.assertEqual(workload._parent_benchmark_type, "fio")
+
+    def test_add_global_options(self) -> None:
+        """Test adding global options to workload"""
+        workload = self._create_workload()
+        global_options: WorkloadType = {
+            "time": "300",
+            "ramp": "30",
+        }
+
+        workload.add_global_options(global_options)
+
+        self.assertEqual(workload._all_options["time"], "300")
+        self.assertEqual(workload._all_options["ramp"], "30")
+
+    def test_add_global_options_no_override(self) -> None:
+        """Test that global options don't override existing options"""
+        workload = self._create_workload()
+        original_mode = workload._all_options["mode"]
+
+        global_options: WorkloadType = {
+            "mode": "randread",  # Try to override
+            "time": "300",
+        }
+
+        workload.add_global_options(global_options)
+
+        # Original mode should be preserved
+        self.assertEqual(workload._all_options["mode"], original_mode)
+        # New option should be added
+        self.assertEqual(workload._all_options["time"], "300")
+
+    @patch("workloads.workload.all_configs")
+    def test_get_output_directories(self, mock_all_configs: MagicMock) -> None:
+        """Test getting output directories"""
+        # Mock all_configs to return a single configuration
+        mock_all_configs.return_value = [
+            {
+                "mode": "randwrite",
+                "iodepth": "4",
+                "numjobs": "1",
+                "op_size": "4096",
+                "volumes_per_client": "1",
+                "target_number": "0",
+            }
+        ]
+
+        workload = self._create_workload()
+        workload.set_benchmark_type("rbdfio")
+        workload.set_executable("/usr/bin/fio")
+
+        directories = list(workload.get_output_directories())
+
+        self.assertGreater(len(directories), 0)
+        for directory in directories:
+            self.assertIsInstance(directory, str)
+            self.assertIn(self.workload_name, directory)
+
+    def test_get_iodepth_key_default(self) -> None:
+        """Test getting iodepth key when only iodepth is present"""
+        workload = self._create_workload()
+        configuration_keys = ["mode", "iodepth", "numjobs"]
+
+        iodepth_key = workload._get_iodepth_key(configuration_keys)
+
+        self.assertEqual(iodepth_key, "iodepth")
+
+    def test_get_iodepth_key_total(self) -> None:
+        """Test getting iodepth key when total_iodepth is present"""
+        workload = self._create_workload()
+        configuration_keys = ["mode", "iodepth", "total_iodepth", "numjobs"]
+
+        iodepth_key = workload._get_iodepth_key(configuration_keys)
+
+        self.assertEqual(iodepth_key, "total_iodepth")
+
+    def test_calculate_iodepth_per_target_equal_distribution(self) -> None:
+        """Test calculating iodepth per target with equal distribution"""
+        workload = self._create_workload()
+        number_of_targets = 4
+        total_iodepth = 16
+
+        result = workload._calculate_iodepth_per_target_from_total_iodepth(number_of_targets, total_iodepth)
+
+        self.assertEqual(len(result), number_of_targets)
+        self.assertEqual(sum(result.values()), total_iodepth)
+        for iodepth in result.values():
+            self.assertEqual(iodepth, 4)
+
+    def test_calculate_iodepth_per_target_unequal_distribution(self) -> None:
+        """Test calculating iodepth per target with unequal distribution"""
+        workload = self._create_workload()
+        number_of_targets = 3
+        total_iodepth = 10
+
+        result = workload._calculate_iodepth_per_target_from_total_iodepth(number_of_targets, total_iodepth)
+
+        self.assertEqual(len(result), number_of_targets)
+        self.assertEqual(sum(result.values()), total_iodepth)
+        # Should distribute as evenly as possible: 4, 3, 3
+        self.assertIn(4, result.values())
+        self.assertEqual(list(result.values()).count(3), 2)
+
+    def test_calculate_iodepth_per_target_insufficient_iodepth(self) -> None:
+        """Test calculating iodepth when total is less than number of targets"""
+        workload = self._create_workload()
+        number_of_targets = 10
+        total_iodepth = 5
+
+        result = workload._calculate_iodepth_per_target_from_total_iodepth(number_of_targets, total_iodepth)
+
+        # Should reduce number of targets to match iodepth
+        self.assertEqual(len(result), total_iodepth)
+        self.assertEqual(sum(result.values()), total_iodepth)
+        for iodepth in result.values():
+            self.assertEqual(iodepth, 1)
+
+    def test_set_iodepth_for_every_target(self) -> None:
+        """Test setting same iodepth for all targets"""
+        workload = self._create_workload()
+        number_of_targets = 5
+        iodepth = 8
+
+        result = workload._set_iodepth_for_every_target(number_of_targets, iodepth)
+
+        self.assertEqual(len(result), number_of_targets)
+        for target_iodepth in result.values():
+            self.assertEqual(target_iodepth, iodepth)
+
+    def test_create_command_class_rbdfio(self) -> None:
+        """Test creating RbdFioCommand for rbdfio benchmark"""
+        workload = self._create_workload()
+        workload.set_benchmark_type("rbdfio")
+
+        options = {
+            "mode": "randwrite",
+            "iodepth": "4",
+            "numjobs": "1",
+            "target_number": "0",
+            "name": self.workload_name,
+        }
+
+        command = workload._create_command_class(options)
+
+        self.assertIsNotNone(command)
+        self.assertIsInstance(command, Command)
+
+    def test_create_command_class_unsupported(self) -> None:
+        """Test creating command for unsupported benchmark type"""
+        workload = self._create_workload()
+        workload.set_benchmark_type("unsupported_benchmark")
+
+        options = {
+            "mode": "randwrite",
+            "iodepth": "4",
+            "numjobs": "1",
+            "target_number": "0",
+            "name": self.workload_name,
+        }
+
+        with self.assertRaises(NotImplementedError):
+            workload._create_command_class(options)
+
+    def test_workload_str_representation(self) -> None:
+        """Test string representation of workload"""
+        workload = self._create_workload()
+
+        str_repr = str(workload)
+
+        self.assertIn(self.workload_name, str_repr)
+        self.assertIn("Name:", str_repr)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+# Made with Bob

--- a/tests/test_workloads.py
+++ b/tests/test_workloads.py
@@ -1,0 +1,321 @@
+"""Unit tests for the Workloads class"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import unittest
+from typing import Any, Optional
+from unittest.mock import MagicMock, patch
+
+from workloads.workload import Workload
+from workloads.workloads import Workloads
+
+
+class TestWorkloads(unittest.TestCase):
+    """Tests for the Workloads class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.base_run_directory = "/tmp/test_run/"
+        self.benchmark_configuration: dict[str, Any] = {
+            "time": "300",
+            "ramp": "30",
+            "mode": "randwrite",
+            "iodepth": ["4", "8"],
+            "numjobs": ["1", "2"],
+            "workloads": {
+                "workload1": {
+                    "mode": "randread",
+                    "iodepth": ["16"],
+                },
+                "workload2": {
+                    "mode": "randwrite",
+                    "numjobs": ["4"],
+                },
+            },
+        }
+
+    def _create_workloads(self, configuration: Optional[dict[str, Any]] = None) -> Workloads:
+        """Helper to create a Workloads instance"""
+        if configuration is None:
+            configuration = self.benchmark_configuration
+        return Workloads(configuration, self.base_run_directory)
+
+    def test_workloads_initialization(self) -> None:
+        """Test that Workloads initializes correctly"""
+        workloads: Workloads = self._create_workloads()
+
+        self.assertIsNotNone(workloads)
+        self.assertTrue(workloads.exist())
+        self.assertEqual(len(workloads._workloads), 2)
+
+    def test_workloads_initialization_no_workloads(self) -> None:
+        """Test initialization when no workloads are defined"""
+        config: dict[str, Any] = {
+            "time": "300",
+            "mode": "randwrite",
+        }
+        workloads: Workloads = self._create_workloads(config)
+
+        self.assertIsNotNone(workloads)
+        self.assertFalse(workloads.exist())
+        self.assertEqual(len(workloads._workloads), 0)
+
+    def test_exist_with_workloads(self) -> None:
+        """Test exist() returns True when workloads are defined"""
+        workloads: Workloads = self._create_workloads()
+
+        self.assertTrue(workloads.exist())
+
+    def test_exist_without_workloads(self) -> None:
+        """Test exist() returns False when no workloads are defined"""
+        config: dict[str, Any] = {"time": "300"}
+        workloads: Workloads = self._create_workloads(config)
+
+        self.assertFalse(workloads.exist())
+
+    def test_get_names(self) -> None:
+        """Test getting workload names"""
+        workloads: Workloads = self._create_workloads()
+
+        names = workloads.get_names()
+
+        self.assertIn("workload1", names)
+        self.assertIn("workload2", names)
+
+    def test_set_benchmark_type(self) -> None:
+        """Test setting the benchmark type"""
+        workloads: Workloads = self._create_workloads()
+        benchmark_type = "fio"
+
+        workloads.set_benchmark_type(benchmark_type)
+
+        self.assertEqual(workloads._benchmark_type, benchmark_type)
+
+    def test_set_executable(self) -> None:
+        """Test setting the executable path"""
+        workloads: Workloads = self._create_workloads()
+        executable_path = "/usr/bin/fio"
+
+        workloads.set_executable(executable_path)
+
+        self.assertEqual(workloads._executable, executable_path)
+
+    def test_get_base_run_directory(self) -> None:
+        """Test getting the base run directory"""
+        workloads: Workloads = self._create_workloads()
+
+        base_dir: str = workloads.get_base_run_directory()
+
+        self.assertEqual(base_dir, self.base_run_directory)
+
+    def test_get_global_options_from_configuration(self) -> None:
+        """Test extracting global options from configuration"""
+        workloads: Workloads = self._create_workloads()
+
+        # Global options should include everything except 'workloads' and 'prefill'
+        self.assertIn("time", workloads._global_options)
+        self.assertIn("ramp", workloads._global_options)
+        self.assertIn("mode", workloads._global_options)
+        self.assertNotIn("workloads", workloads._global_options)
+
+    def test_get_global_options_excludes_prefill(self) -> None:
+        """Test that prefill is excluded from global options"""
+        config: dict[str, Any] = {
+            "time": "300",
+            "prefill": {"blocksize": "4M"},
+            "workloads": {
+                "test": {"mode": "randwrite"},
+            },
+        }
+        workloads: Workloads = self._create_workloads(config)
+
+        self.assertNotIn("prefill", workloads._global_options)
+
+    @patch("workloads.workloads.pdsh")
+    @patch("workloads.workloads.make_remote_dir")
+    @patch("workloads.workloads.monitoring")
+    @patch("workloads.workloads.getnodes")
+    @patch("workloads.workloads.sleep")
+    def test_run_with_workloads(
+        self,
+        mock_sleep: MagicMock,
+        mock_getnodes: MagicMock,
+        mock_monitoring: MagicMock,
+        mock_make_remote_dir: MagicMock,
+        mock_pdsh: MagicMock,
+    ) -> None:
+        """Test running workloads"""
+        mock_getnodes.return_value = "client1,client2"
+        mock_process: MagicMock = MagicMock()
+        mock_pdsh.return_value = mock_process
+
+        workloads: Workloads = self._create_workloads()
+        workloads.set_benchmark_type("rbdfio")
+        workloads.set_executable("/usr/bin/fio")
+
+        workloads.run()
+
+        # Verify monitoring was started and stopped
+        self.assertTrue(mock_monitoring.start.called)
+        self.assertTrue(mock_monitoring.stop.called)
+
+    @patch("workloads.workloads.pdsh")
+    @patch("workloads.workloads.make_remote_dir")
+    @patch("workloads.workloads.monitoring")
+    @patch("workloads.workloads.getnodes")
+    def test_run_with_script(
+        self,
+        mock_getnodes: MagicMock,
+        mock_monitoring: MagicMock,
+        mock_make_remote_dir: MagicMock,
+        mock_pdsh: MagicMock,
+    ) -> None:
+        """Test running workloads with pre_workload_script"""
+        mock_getnodes.return_value = "client1"
+        mock_process: MagicMock = MagicMock()
+        mock_pdsh.return_value = mock_process
+
+        config: dict[str, Any] = {
+            "time": "300",
+            "workloads": {
+                "test_workload": {
+                    "mode": "randwrite",
+                    "pre_workload_script": "/path/to/script.sh",
+                },
+            },
+        }
+
+        workloads: Workloads = self._create_workloads(config)
+        workloads.set_benchmark_type("rbdfio")
+        workloads.set_executable("/usr/bin/fio")
+
+        workloads.run()
+
+        # Verify script was executed
+        script_calls = [call_args for call_args in mock_pdsh.call_args_list if "/path/to/script.sh" in str(call_args)]
+        self.assertGreater(len(script_calls), 0)
+
+    def test_run_without_benchmark_type(self) -> None:
+        """Test that run() handles missing benchmark type gracefully"""
+        workloads: Workloads = self._create_workloads()
+        workloads.set_executable("/usr/bin/fio")
+
+        # Should not raise an exception, just log an error
+        workloads.run()
+
+    def test_run_without_executable(self) -> None:
+        """Test that run() handles missing executable gracefully"""
+        workloads: Workloads = self._create_workloads()
+        workloads.set_benchmark_type("rbdfio")
+
+        # Should not raise an exception, just log an error
+        workloads.run()
+
+    def test_run_without_workloads(self) -> None:
+        """Test that run() handles no workloads gracefully"""
+        config: dict[str, Any] = {"time": "300"}
+        workloads: Workloads = self._create_workloads(config)
+        workloads.set_benchmark_type("rbdfio")
+        workloads.set_executable("/usr/bin/fio")
+
+        # Should not raise an exception, just log an error
+        workloads.run()
+
+    @patch("workloads.workloads.pdsh")
+    @patch("workloads.workloads.make_remote_dir")
+    @patch("workloads.workloads.monitoring")
+    @patch("workloads.workloads.getnodes")
+    @patch("workloads.workloads.sleep")
+    def test_run_with_ramp_time(
+        self,
+        mock_sleep: MagicMock,
+        mock_getnodes: MagicMock,
+        mock_monitoring: MagicMock,
+        mock_make_remote_dir: MagicMock,
+        mock_pdsh: MagicMock,
+    ) -> None:
+        """Test running workloads with ramp time"""
+        mock_getnodes.return_value = "client1"
+        mock_process: MagicMock = MagicMock()
+        mock_pdsh.return_value = mock_process
+
+        config: dict[str, Any] = {
+            "time": "300",
+            "ramp": "30",
+            "workloads": {
+                "test": {"mode": "randwrite"},
+            },
+        }
+
+        workloads: Workloads = self._create_workloads(config)
+        workloads.set_benchmark_type("rbdfio")
+        workloads.set_executable("/usr/bin/fio")
+
+        workloads.run()
+
+        # Verify sleep was called with ramp time
+        mock_sleep.assert_called_with(30)
+
+    def test_create_configurations(self) -> None:
+        """Test that workload configurations are created correctly"""
+        workloads: Workloads = self._create_workloads()
+
+        # Should have created 2 workload objects
+        self.assertEqual(len(workloads._workloads), 2)
+
+        # Check workload names
+        workload_names: list[str] = [w.get_name() for w in workloads._workloads]
+        self.assertIn("workload1", workload_names)
+        self.assertIn("workload2", workload_names)
+
+    def test_workload_inherits_global_options(self) -> None:
+        """Test that workloads inherit global options"""
+        workloads: Workloads = self._create_workloads()
+
+        # Each workload should have access to global options
+        for workload in workloads._workloads:
+            # Global options should be available
+            self.assertIn("time", workload._all_options)
+            self.assertEqual(workload._all_options["time"], "300")
+
+    def test_workload_local_options_override_global(self) -> None:
+        """Test that local workload options override global options"""
+        workloads: Workloads = self._create_workloads()
+
+        # Find workload1 which has mode: randread (overriding global randwrite)
+        workload1: Workload = next(w for w in workloads._workloads if w.get_name() == "workload1")
+
+        # Local mode should override global mode
+        self.assertEqual(workload1._all_options["mode"], "randread")
+
+    def test_list_conversion_in_global_options(self) -> None:
+        """Test that list values in configuration are preserved"""
+        workloads: Workloads = self._create_workloads()
+
+        # iodepth is a list in the configuration
+        self.assertIsInstance(workloads._global_options["iodepth"], list)
+        self.assertEqual(workloads._global_options["iodepth"], ["4", "8"])
+
+    def test_string_conversion_in_global_options(self) -> None:
+        """Test that non-list values are converted to strings"""
+        config: dict[str, Any] = {
+            "time": 300,  # int
+            "ramp": 30,  # int
+            "workloads": {
+                "test": {"mode": "randwrite"},
+            },
+        }
+        workloads: Workloads = self._create_workloads(config)
+
+        # Should be converted to strings
+        self.assertIsInstance(workloads._global_options["time"], str)
+        self.assertEqual(workloads._global_options["time"], "300")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+# Made with Bob

--- a/workloads/workload.py
+++ b/workloads/workload.py
@@ -3,8 +3,9 @@ The workload class that encapsulates a single workload that can be
 run by any benchmark
 """
 
+from collections.abc import Generator
 from logging import Logger, getLogger
-from typing import Generator, Optional
+from typing import Optional
 
 from command.command import Command
 from command.rbd_fio_command import RbdFioCommand


### PR DESCRIPTION
Add unit tests for the post_processing/* modules, as well as the workloads modules. This will help to make sure that changes in the future to these modules get sufficient testing coverage and mean we can spot issues eariler in the development cycle. The unit tests for CBT have now increased from 348 to 544

An AI code assistant, IBM Bob, was used to help  create these unit tests.

The tests all pass:

```
============================= slowest 5 durations ==============================
0.18s call     tests/test_simple_plotter.py::TestSimplePlotter::test_draw_and_save
0.01s setup    tests/test_bm_cephtestrados.py::TestBenchmarkcephtestrados::test_valid__base_archive_directory
0.01s setup    tests/test_bm_fio.py::TestBenchmarkfio::test_valid__base_archive_directory
0.01s setup    tests/test_bm_getput.py::TestBenchmarkgetput::test_valid__base_archive_directory
0.01s setup    tests/test_bm_radosbench.py::TestBenchmarkradosbench::test_valid__base_archive_directory
================= 544 passed, 3 skipped, 21 warnings in 1.50s ==================
Finished running tests!
```

There were also some code changes made based on code issues discovered when running the unit tests