### PR TITLE
Add multiple numjobs values support to the post processing reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .devcontainer
 *.toml
 .coverage
+.bob

--- a/cbt_types.py
+++ b/cbt_types.py
@@ -1,0 +1,19 @@
+"""
+A file to contain common type definitions for use in the post-processing
+"""
+
+from enum import Enum, auto
+
+
+class BenchmarkType(Enum):
+    """
+    The different benchamrk types for a run
+    """
+
+    UNKNOWN = 0
+    RBDFIO = auto()
+    KVMRBDFIO = auto()
+    RAWFIO = auto()
+    RADOSBENCH = auto()
+    COSBENCH = auto()
+    HSBENCH = auto()

--- a/command/command.py
+++ b/command/command.py
@@ -56,6 +56,13 @@ class Command(ABC):
         The format is dependent on the specific Command implementation
         """
 
+    @property
+    @abstractmethod
+    def benchmark(self) -> str:
+        """
+        Return the benchmark type for this command type
+        """
+
     def get(self) -> str:
         """
         get the full cli string that can be sent to a system.

--- a/command/fio_command.py
+++ b/command/fio_command.py
@@ -143,7 +143,11 @@ class FioCommand(Command, ABC):
         if total_iodepth was used in the options, otherwise:
         numjobs-<numjobs>/iodepth-<iodepth>
         """
-        output_path: str = f"{self._workload_output_directory}/numjobs-{int(str(self._options['numjobs'])):03d}/"
+        # TODO Need to output the benchmark type in this directory structure,
+        # before the numjobs bit
+        output_path: str = (
+            f"{self._workload_output_directory}/{self.benchmark}/numjobs-{int(str(self._options['numjobs'])):03d}/"
+        )
 
         if self._total_iodepth is not None:
             output_path += f"total_iodepth-{self._total_iodepth}/"

--- a/command/rbd_fio_command.py
+++ b/command/rbd_fio_command.py
@@ -29,6 +29,10 @@ class RbdFioCommand(FioCommand):
     def __init__(self, options: dict[str, str], workload_output_directory: str) -> None:
         super().__init__(options, workload_output_directory)
 
+    @property
+    def benchmark(self) -> str:
+        return "rbdfio"
+
     def _parse_ioengine_specific_parameters(self, options: dict[str, str]) -> dict[str, str]:
         rbd_options: dict[str, str] = self._RBD_DEFAULT_OPTIONS
 

--- a/post_processing/common.py
+++ b/post_processing/common.py
@@ -52,28 +52,33 @@ _HOSTNAME_PATTERN: Pattern[str] = re.compile(
 )
 
 
-def get_blocksize_percentage_operation_from_file_name(file_name: str) -> tuple[str, str, str]:
+def get_blocksize_percentage_operation_numjobs_from_file_name(file_name: str) -> tuple[str, str, str, str]:
     """
         Return the blocksize , operation and read/write percentage from the
     filename
 
     The filename is in one of 2 formats:
-        BLOCKSIZE_OPERATION.json
-        BLOCKSIZE_READ_WRITE_OPERATION.json
+        BLOCKSIZE_NUMJOBS_OPERATION.json
+        BLOCKSIZE_NUMJOBS_READ_WRITE_OPERATION.json
     """
     file_parts: list[str] = file_name.split("_")
 
     # The split on _ will mean that the last element [-1] will always be
-    # the operation, and the first part [0] will be the blocksize
+    # the operation, the first part [0] will be the blocksize, and the
+    # second part [1] will be the number of jobs
     operation: str = f"{TITLE_CONVERSION[file_parts[-1]]}"
     blocksize: str = get_blocksize(f"{file_parts[0]}")
     blocksize = f"{int(int(blocksize) / 1024)}K"
+    number_of_jobs: str = file_parts[1]
     read_percent: str = ""
 
-    if len(file_parts) > 2:
-        read_percent = f"{file_parts[1]}/{file_parts[2]} "
+    # If there are more than 3 parts, we have read/write percentages
+    # Format: BLOCKSIZE_NUMJOBS_READ_WRITE_OPERATION
+    # Parts:  [0]       [1]     [2]  [3]    [4]
+    if len(file_parts) > 3:
+        read_percent = f"{file_parts[2]}/{file_parts[3]} "
 
-    return (blocksize, read_percent, operation)
+    return (blocksize, read_percent, operation, number_of_jobs)
 
 
 def read_intermediate_file(file_path: str) -> CommonFormatDataType:

--- a/post_processing/formatter/common_output_formatter.py
+++ b/post_processing/formatter/common_output_formatter.py
@@ -46,10 +46,9 @@ import json
 import re
 from logging import Logger, getLogger
 from pathlib import Path
-from pprint import pprint
 from typing import Optional
 
-from common import pdsh  # pyright: ignore[reportUnknownVariableType]
+from common import pdsh  # pylint: disable=[no-name-in-module]
 from post_processing.post_processing_types import CommonFormatDataType, InternalFormattedOutputType
 from post_processing.run_results.run_result_factory import get_run_result_from_directory_name
 
@@ -94,7 +93,9 @@ class CommonOutputFormatter:
         Args:
             processed_results: Dictionary of processed results to merge
         """
-        for run_type, run_data in processed_results.items():
+        # We need to do a deep merge of the data here, so we need the nested blocks for the moment
+        # Maybe we can get rid of them in a future re-factor
+        for run_type, run_data in processed_results.items():  # pylint: disable=[too-many-nested-blocks]
             if run_type not in self._formatted_output:
                 self._formatted_output[run_type] = run_data
             else:
@@ -249,7 +250,7 @@ class CommonOutputFormatter:
                 benchmark_type = self._process_single_testrun(testrun_directories[0])
 
             # Track benchmark type for all operations processed in this test run
-            for operation_type in self._formatted_output.keys():
+            for operation_type, _ in self._formatted_output.items():
                 self._benchmark_types[operation_type] = benchmark_type
 
         # Add common metadata fields (benchmark type, number_of_jobs) to the test run data

--- a/post_processing/formatter/common_output_formatter.py
+++ b/post_processing/formatter/common_output_formatter.py
@@ -19,7 +19,6 @@ The output is a JSON file of the format:
                     runtime_seconds:
                     std_deviation:
                     total_ios:
-                    resource_type:
                     cpu:
                     memory:
 
@@ -34,6 +33,8 @@ The output is a JSON file of the format:
     latency_at_max_iops:
     maximum_cpu_usage:
     maximum_memory_usage:
+    number_of_jobs:
+    resource_type:
     benchmark:
 }
 
@@ -45,11 +46,12 @@ import json
 import re
 from logging import Logger, getLogger
 from pathlib import Path
+from pprint import pprint
 from typing import Optional
 
 from common import pdsh  # pyright: ignore[reportUnknownVariableType]
 from post_processing.post_processing_types import CommonFormatDataType, InternalFormattedOutputType
-from post_processing.run_results.rbdfio import RBDFIO
+from post_processing.run_results.run_result_factory import get_run_result_from_directory_name
 
 log: Logger = getLogger(name="formatter")
 
@@ -79,6 +81,150 @@ class CommonOutputFormatter:
 
         self._path: Path = Path(self._directory)
         self._file_list: list[Path] = []
+        self._benchmark_types: dict[str, str] = {}  # Track benchmark type per operation
+
+    def _merge_results(self, processed_results: InternalFormattedOutputType) -> None:
+        """
+        Merge processed results into the formatted output dictionary.
+
+        This method handles merging new results into existing data, updating
+        existing entries or creating new ones as needed. Performs a deep merge
+        to preserve nested numjobs and blocksize data.
+
+        Args:
+            processed_results: Dictionary of processed results to merge
+        """
+        for run_type, run_data in processed_results.items():
+            if run_type not in self._formatted_output:
+                self._formatted_output[run_type] = run_data
+            else:
+                # Deep merge: operation -> numjobs -> blocksize
+                for numjobs, numjobs_data in run_data.items():
+                    if numjobs not in self._formatted_output[run_type]:
+                        self._formatted_output[run_type][numjobs] = numjobs_data
+                    else:
+                        # Merge blocksize level
+                        for blocksize, blocksize_data in numjobs_data.items():
+                            if blocksize not in self._formatted_output[run_type][numjobs]:
+                                self._formatted_output[run_type][numjobs][blocksize] = blocksize_data
+                            else:
+                                # Update existing blocksize data
+                                self._formatted_output[run_type][numjobs][blocksize].update(blocksize_data)
+
+    def _get_testrun_directories(self, testrun_id: str) -> list[Path]:
+        """
+        Get the directories for a specific test run ID.
+
+        When calling from CBT itself, the archive dir already includes the testrun
+        directory, so we handle this case by checking if 'id-' is in the path.
+
+        Args:
+            testrun_id: The test run identifier to find directories for
+
+        Returns:
+            List of Path objects for directories matching the test run ID
+        """
+        if "id-" in f"{self._path}":
+            return [self._path]
+        return list(self._path.glob(f"**/{testrun_id}"))
+
+    def _process_compatibility_mode(self) -> str:
+        """
+        Process test run using compatibility method for legacy directory structures.
+
+        This handles cases where there are multiple directories for a single test run,
+        which requires using the directory-level processing approach.
+
+        Returns:
+            The benchmark type identifier (e.g., "rbdfio", "fio")
+
+        Note: This is only here for compatibility with runs that were done before the new workloads code was uploaded
+        """
+
+        results = get_run_result_from_directory_name(Path(self._directory), self._filename_root)
+        results.process()
+        self._merge_results(results.get())
+        return results.type
+
+    def _process_single_testrun(self, testrun_directory: Path) -> str:
+        """
+        Process a single test run directory and all its IO pattern subdirectories.
+
+        This method iterates through all subdirectories in the test run directory,
+        processes each one, and merges the results into the formatted output.
+
+        Args:
+            testrun_directory: Path to the test run directory
+
+        Returns:
+            The benchmark type identifier from the last processed result
+
+        """
+        benchmark_type: str = "unknown"
+
+        for io_pattern_directory in [
+            directory
+            for directory in testrun_directory.iterdir()
+            if directory.is_dir()
+            and not f"{directory.name}".startswith(".")
+            and "visualisation" not in f"{directory.name}"
+        ]:
+            log.debug("Looking at results for directory %s", io_pattern_directory)
+            # Use factory method to get the correct results type based on directory name
+            results = get_run_result_from_directory_name(
+                directory=io_pattern_directory, file_name_root=self._filename_root
+            )
+
+            results.process()
+            processed_results = results.get()
+            self._merge_results(processed_results)
+            benchmark_type = results.type
+
+        return benchmark_type
+
+    def _add_common_metadata(self) -> None:
+        """
+        Add common metadata fields to the top level of each blocksize dataset.
+
+        This method extracts metadata like number_of_jobs and benchmark type
+        from the nested iodepth entries and adds them at the blocksize level
+        for easier access.
+        """
+        for operation_type, operation_data in self._formatted_output.items():
+            for _, numjobs_data in operation_data.items():
+                for _, blocksize_data in numjobs_data.items():
+                    # Add benchmark type
+                    blocksize_data["benchmark"] = self._benchmark_types.get(operation_type, "unknown")
+
+                    # Extract number_of_jobs from the first iodepth entry
+                    # All iodepth entries should have the same number_of_jobs value
+                    for _, value in blocksize_data.items():
+                        if isinstance(value, dict) and "number_of_jobs" in value:
+                            blocksize_data["number_of_jobs"] = value["number_of_jobs"]
+                            break
+
+    def _add_peak_metrics(self) -> None:
+        """
+        Add aggregate metrics (max bandwidth, IOPS, resource usage) to all test runs.
+
+        This method calculates and adds maximum values and associated latencies
+        for bandwidth and IOPS, as well as maximum resource usage, to each
+        blocksize dataset in the formatted output.
+        """
+        for operation_type, operation_data in self._formatted_output.items():
+            for _, numjobs_data in operation_data.items():
+                for _, blocksize_data in numjobs_data.items():
+                    max_bandwidth, max_bandwidth_latency, max_iops, max_iops_latency = (
+                        self._find_maximum_bandwidth_and_iops_with_latency(blocksize_data)
+                    )
+                    max_cpu, max_memory = self._find_max_resource_usage(blocksize_data)
+                    blocksize_data["maximum_bandwidth"] = max_bandwidth
+                    blocksize_data["latency_at_max_bandwidth"] = max_bandwidth_latency
+                    blocksize_data["maximum_iops"] = max_iops
+                    blocksize_data["latency_at_max_iops"] = max_iops_latency
+                    blocksize_data["maximum_cpu_usage"] = max_cpu
+                    blocksize_data["maximum_memory_usage"] = max_memory
+                    blocksize_data["benchmark"] = self._benchmark_types.get(operation_type, "unknown")
 
     def convert_all_files(self) -> None:
         """
@@ -87,60 +233,29 @@ class CommonOutputFormatter:
         """
         log.info("Converting all files with name %s in directory %s", self._filename_root, self._directory)
         self._find_all_results_files_in_directory()
-
         self._find_all_testrun_ids()
-        results: RBDFIO
+
         for testrun_id in self._all_test_run_ids:
             log.debug("Looking at test run with id %s", testrun_id)
 
-            # Actually find the test run ID directory
-            # When calling from CBT itself this archive dir already includes the testrun directory
-            # so we should handle this case here
-            testrun_directories: list[Path] = [self._path]
+            testrun_directories = self._get_testrun_directories(testrun_id)
 
-            if "id-" not in f"{self._path}":
-                testrun_directories = list(self._path.glob(f"**/{testrun_id}"))
             if len(testrun_directories) > 1:
                 log.debug(
                     "We have more than one directory for test run %s so using the compatibility method", testrun_id
                 )
-                results = RBDFIO(Path(self._directory), self._filename_root)
-
-                results.process()
-                self._formatted_output.update(results.get())
-
+                benchmark_type = self._process_compatibility_mode()
             else:
-                testrun_directory_path: Path = testrun_directories[0]
+                benchmark_type = self._process_single_testrun(testrun_directories[0])
 
-                for io_pattern_directory in [
-                    directory for directory in testrun_directory_path.iterdir() if directory.is_dir()
-                ]:
-                    log.debug("Looking at results for directory %s", io_pattern_directory)
-                    results = RBDFIO(directory=io_pattern_directory, file_name_root=self._filename_root)
+            # Track benchmark type for all operations processed in this test run
+            for operation_type in self._formatted_output.keys():
+                self._benchmark_types[operation_type] = benchmark_type
 
-                    results.process()
-                    processed_results: InternalFormattedOutputType = results.get()
-                    for run_type, run_data in processed_results.items():
-                        if self._formatted_output.get(run_type, None):
-                            # if run_type in self._formatted_output.keys():
-                            self._formatted_output[run_type].update(run_data)
-                        else:
-                            self._formatted_output.update(results.get())
-
-        # get the max bandwidth and associated latency for each test run
-        for _, operation_data in self._formatted_output.items():
-            for _, blocksize_data in operation_data.items():
-                max_bandwidth, max_bandwidth_latency, max_iops, max_iops_latency = (
-                    self._find_maximum_bandwidth_and_iops_with_latency(blocksize_data)
-                )
-                max_cpu, max_memory = self._find_max_resource_usage(blocksize_data)
-                blocksize_data["maximum_bandwidth"] = max_bandwidth
-                blocksize_data["latency_at_max_bandwidth"] = max_bandwidth_latency
-                blocksize_data["maximum_iops"] = max_iops
-                blocksize_data["latency_at_max_iops"] = max_iops_latency
-                blocksize_data["maximum_cpu_usage"] = max_cpu
-                blocksize_data["maximum_memory_usage"] = max_memory
-                blocksize_data["benchmark"] = results.type  # pyright: ignore[reportPossiblyUnboundVariable]
+        # Add common metadata fields (benchmark type, number_of_jobs) to the test run data
+        self._add_common_metadata()
+        # Add the maximum values (max bandwidth, IOPS, resource usage) to the test run data
+        self._add_peak_metrics()
 
     def write_output_file(self) -> None:
         """
@@ -154,11 +269,14 @@ class CommonOutputFormatter:
             pdsh("localhost", f"mkdir -p {destination_directory}").communicate()  # type: ignore[no-untyped-call]
 
         for operation_type, operation_data in self._formatted_output.items():
-            for blocksize, blocksize_data in operation_data.items():
-                destination_filename: str = f"{self._directory}/visualisation/{blocksize}_{operation_type}.json"
-                log.info("Writing formatted results to destination file %s", destination_filename)
-                with open(destination_filename, "w", encoding="utf8") as output:
-                    json.dump(blocksize_data, output, indent=4, sort_keys=True)
+            for number_of_jobs, numbjob_data in operation_data.items():
+                for blocksize, blocksize_data in numbjob_data.items():
+                    destination_filename: str = (
+                        f"{self._directory}/visualisation/{blocksize}_{number_of_jobs}_{operation_type}.json"
+                    )
+                    log.info("Writing formatted results to destination file %s", destination_filename)
+                    with open(destination_filename, "w", encoding="utf8") as output:
+                        json.dump(blocksize_data, output, indent=4, sort_keys=True)
 
     def _find_all_results_files_in_directory(self) -> None:
         """
@@ -213,10 +331,10 @@ class CommonOutputFormatter:
         """
         Find the maximum bandwidth and associated latency and the maximum iops
         and associated latency for a given test.
-        
+
         Args:
             test_run_data: Dictionary containing test run data with bandwidth, iops, and latency info
-        
+
         Returns:
             A tuple of (max_bandwidth, bandwidth_latency_ms, max_iops, iops_latency_ms).
             All values are returned as strings.
@@ -241,10 +359,10 @@ class CommonOutputFormatter:
     def _find_max_resource_usage(self, test_run_data: CommonFormatDataType) -> tuple[str, str]:
         """
         Record the maximum CPU usage and maximum memory usage for this workload.
-        
+
         Args:
             test_run_data: Dictionary containing test run data with CPU and memory usage info
-        
+
         Returns:
             A tuple of (max_cpu, max_memory) as strings
         """

--- a/post_processing/plotter/axis_plotter.py
+++ b/post_processing/plotter/axis_plotter.py
@@ -19,7 +19,7 @@ class AxisPlotter(ABC):
     def __init__(self, main_axis: Axes) -> None:
         """
         Initialize the AxisPlotter with a matplotlib Axes object.
-        
+
         Args:
             main_axis: The main matplotlib Axes object for this plot
         """

--- a/post_processing/plotter/common_format_plotter.py
+++ b/post_processing/plotter/common_format_plotter.py
@@ -17,13 +17,22 @@ from matplotlib.axes import Axes
 from post_processing.common import (
     DATA_FILE_EXTENSION_WITH_DOT,
     PLOT_FILE_EXTENSION,
-    get_blocksize_percentage_operation_from_file_name,
+    get_blocksize_percentage_operation_numjobs_from_file_name,
 )
 from post_processing.plotter.cpu_plotter import CPUPlotter
 from post_processing.plotter.io_plotter import IOPlotter
+from post_processing.plotter.plot_data_collector import PlotDataCollector
+from post_processing.plotter.plot_data_results import DataPointResult, PlotDataResult
 from post_processing.post_processing_types import CommonFormatDataType, PlotDataType
 
 log: Logger = getLogger("plotter")
+
+# Module-level constants for data conversion and plotting
+BLOCKSIZE_THRESHOLD_KB = 64
+BYTES_TO_MB_DIVISOR = 1024 * 1024  # Using 1024 for MiB
+NANOSECONDS_TO_MS_DIVISOR = 1_000_000
+ERROR_BAR_CAP_SIZE = 3
+KB_CONVERSION_FACTOR = 1024
 
 
 # pylint: disable=too-few-public-methods, too-many-locals
@@ -78,7 +87,9 @@ class CommonFormatPlotter(ABC):
         operations: list[str] = []
 
         for file in file_paths:
-            (blocksize, read_percent, operation) = get_blocksize_percentage_operation_from_file_name(file.stem)
+            (blocksize, read_percent, operation, _) = get_blocksize_percentage_operation_numjobs_from_file_name(
+                file.stem
+            )
             titles.append((blocksize, read_percent, operation))
 
             if blocksize not in blocksizes:
@@ -109,7 +120,7 @@ class CommonFormatPlotter(ABC):
         given a single file name construct a plot title from the blocksize,
         read percent and operation contained in the title
         """
-        (blocksize, read_percent, operation) = get_blocksize_percentage_operation_from_file_name(
+        (blocksize, read_percent, operation, _) = get_blocksize_percentage_operation_numjobs_from_file_name(
             file_name[: -len(DATA_FILE_EXTENSION_WITH_DOT)]
         )
 
@@ -118,7 +129,7 @@ class CommonFormatPlotter(ABC):
     def _set_axis(self, maximum_values: Optional[tuple[int, int]] = None) -> None:
         """
         Set the range for the plot axes starting from 0.
-        
+
         Args:
             maximum_values: Optional tuple of (maximum_x, maximum_y) values.
                            If None, matplotlib will auto-scale the axes.
@@ -151,8 +162,277 @@ class CommonFormatPlotter(ABC):
 
         return sorted_plot_data
 
-    
-    def _add_single_file_data_with_optional_errorbars(
+    def _calculate_blocksize_kb(self, blocksize_bytes: str) -> int:
+        """Convert blocksize from bytes to kilobytes."""
+        return int(int(blocksize_bytes) / KB_CONVERSION_FACTOR)
+
+    def _should_use_bandwidth(self, blocksize_kb: int) -> bool:
+        """Determine if bandwidth should be used instead of IOPS based on blocksize."""
+        return blocksize_kb >= BLOCKSIZE_THRESHOLD_KB
+
+    def _convert_bandwidth_to_mb(self, bandwidth_bytes: str) -> float:
+        """Convert bandwidth from bytes to megabytes."""
+        return float(bandwidth_bytes) / BYTES_TO_MB_DIVISOR
+
+    def _convert_std_dev_to_ms(self, std_dev_ns: str) -> float:
+        """Convert standard deviation from nanoseconds to milliseconds."""
+        return float(std_dev_ns) / NANOSECONDS_TO_MS_DIVISOR
+
+    def _extract_x_axis_data(self, data: dict[str, str]) -> tuple[float, str]:
+        """
+        Extract x-axis data point and label based on blocksize.
+
+        Returns:
+            Tuple of (x_value, x_label) where x_value is either bandwidth or IOPS
+        """
+        blocksize_kb = self._calculate_blocksize_kb(data["blocksize"])
+
+        if self._should_use_bandwidth(blocksize_kb):
+            x_value = self._convert_bandwidth_to_mb(data["bandwidth_bytes"])
+            x_label = "Bandwidth (MB/s)"
+        else:
+            x_value = float(data["iops"])
+            x_label = "IOps"
+
+        return x_value, x_label
+
+    def _validate_cpu_data_availability(self, data: dict[str, str], plot_resource_usage: bool) -> bool:
+        """
+        Check if CPU data is available when resource plotting is requested.
+
+        Returns:
+            True if resource usage should be plotted, False otherwise
+        """
+        if data.get("cpu") is None and plot_resource_usage:
+            log.warning(
+                "Unable to plot CPU usage: CPU data not found in intermediate files. Disabling resource usage plotting."
+            )
+            return False
+        return plot_resource_usage
+
+    def _calculate_error_bar(
+        self, data: dict[str, str], plot_error_bars: bool, resource_plotting_enabled: bool
+    ) -> float:
+        """
+        Calculate error bar value for a data point.
+
+        Args:
+            data: Data dictionary containing std_deviation
+            plot_error_bars: Whether error bars are enabled
+            resource_plotting_enabled: Whether resource plotting is active
+
+        Returns:
+            Error bar value in milliseconds, or 0.0 if not applicable
+        """
+        if plot_error_bars and not resource_plotting_enabled:
+            if "std_deviation" not in data:
+                log.warning("Missing 'std_deviation' field, using 0 for error bar")
+                return 0.0
+            return self._convert_std_dev_to_ms(data["std_deviation"])
+        return 0.0
+
+    def _initialize_plotters(self, main_axes: Axes, label: Optional[str]) -> tuple[IOPlotter, CPUPlotter]:
+        """Initialize and configure IO and CPU plotters."""
+        io_plot_label = label if label else "IO Details"
+
+        cpu_plotter = CPUPlotter(main_axis=main_axes)
+        io_plotter = IOPlotter(main_axis=main_axes)
+        io_plotter.y_label = "Latency (ms)"
+        io_plotter.plot_label = io_plot_label
+
+        return io_plotter, cpu_plotter
+
+    def _validate_input_data(self, sorted_plot_data: PlotDataType) -> None:
+        """
+        Validate input data is not empty.
+
+        Args:
+            sorted_plot_data: The data to validate
+
+        Raises:
+            ValueError: If data is empty
+        """
+        if not sorted_plot_data:
+            raise ValueError("Cannot extract plot data from empty dataset")
+
+    def _process_data_point(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        data: dict[str, str],
+        queue_depth: str,
+        io_plotter: IOPlotter,
+        cpu_plotter: CPUPlotter,
+        plot_error_bars: bool,
+        resource_plotting_enabled: bool,
+    ) -> DataPointResult:
+        """
+        Process a single data point for plotting.
+
+        Args:
+            data: Data dictionary for this point
+            queue_depth: Queue depth identifier for error messages
+            io_plotter: IO plotter to receive latency data
+            cpu_plotter: CPU plotter to receive CPU data
+            plot_error_bars: Whether error bars are enabled
+            resource_plotting_enabled: Whether resource plotting is active
+
+        Returns:
+            DataPointResult with processed values
+
+        Raises:
+            ValueError: If required fields are missing or invalid
+            TypeError: If data types are incorrect
+        """
+        # Validate required fields exist
+        required_fields = ["latency", "blocksize"]
+        missing_fields = [field for field in required_fields if field not in data]
+        if missing_fields:
+            raise ValueError(f"Missing required fields for queue depth {queue_depth}: {', '.join(missing_fields)}")
+
+        # Validate latency is numeric
+        latency_value = data["latency"]
+        try:
+            float(latency_value)  # Validate it's convertible to float
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"Invalid latency value for queue depth {queue_depth}: {latency_value}") from e
+
+        # Extract x-axis data (may raise ValueError)
+        x_value, x_label = self._extract_x_axis_data(data)
+
+        # Add latency data
+        io_plotter.add_y_data(latency_value)
+
+        # Handle CPU data with proper validation
+        resource_available = resource_plotting_enabled
+        if resource_plotting_enabled:
+            cpu_value = data.get("cpu")
+            if cpu_value is None:
+                resource_available = False
+            else:
+                # Validate CPU value is numeric
+                try:
+                    float(cpu_value)
+                    cpu_plotter.add_y_data(cpu_value)
+                except (ValueError, TypeError):
+                    log.warning(
+                        "Invalid CPU value for queue depth %s: %s. Skipping CPU data.",
+                        queue_depth,
+                        cpu_value,
+                    )
+                    resource_available = False
+
+        # Calculate error bars
+        error_bar = self._calculate_error_bar(data, plot_error_bars, resource_available)
+
+        return DataPointResult(
+            x_value=x_value,
+            x_label=x_label,
+            error_bar=error_bar,
+            resource_available=resource_available,
+        )
+
+    def _extract_plot_data(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        sorted_plot_data: PlotDataType,
+        main_axes: Axes,
+        io_plotter: IOPlotter,
+        cpu_plotter: CPUPlotter,
+        plot_error_bars: bool,
+        plot_resource_usage: bool,
+    ) -> PlotDataResult:
+        """
+        Extract and process data points for plotting.
+
+        Args:
+            sorted_plot_data: Pre-sorted performance data by queue depth
+            main_axes: Matplotlib axes object for plotting
+            io_plotter: IO plotter instance to receive latency data
+            cpu_plotter: CPU plotter instance to receive CPU data
+            plot_error_bars: Whether to include standard deviation error bars
+            plot_resource_usage: Whether to include CPU usage on secondary axis
+
+        Returns:
+            PlotDataResult containing extracted x_data, error_bars, cap_size,
+            updated plot_resource_usage flag, and x_label
+
+        Raises:
+            ValueError: If sorted_plot_data is empty or contains invalid entries
+        """
+        self._validate_input_data(sorted_plot_data)
+
+        # Initialize data collectors
+        data_collector = PlotDataCollector()
+        resource_plotting_enabled = plot_resource_usage
+        x_label: Optional[str] = None
+        cpu_warning_logged = False  # Track if we've already warned about missing CPU data
+
+        for queue_depth, data in sorted_plot_data.items():
+            try:
+                # Process single data point
+                point_result = self._process_data_point(
+                    data=data,
+                    queue_depth=queue_depth,
+                    io_plotter=io_plotter,
+                    cpu_plotter=cpu_plotter,
+                    plot_error_bars=plot_error_bars,
+                    resource_plotting_enabled=resource_plotting_enabled,
+                )
+
+                # Set x-axis label once (from first valid data point)
+                if x_label is None:
+                    x_label = point_result.x_label
+                    main_axes.set_xlabel(x_label)  # pyright: ignore[reportUnknownMemberType]
+
+                # Disable resource plotting if CPU data unavailable (only check once)
+                if resource_plotting_enabled and not point_result.resource_available:
+                    if not cpu_warning_logged:
+                        log.warning(
+                            "Unable to plot CPU usage: CPU data not found in intermediate files. "
+                            "Disabling resource usage plotting."
+                        )
+                        cpu_warning_logged = True
+                    resource_plotting_enabled = False
+
+                # Collect the processed data
+                data_collector.add_point(point_result.x_value, point_result.error_bar)
+
+            except (KeyError, ValueError, TypeError) as e:
+                log.error(
+                    "Failed to process data for queue depth %s: %s. Skipping this data point.",
+                    queue_depth,
+                    e,
+                )
+                continue
+
+        # Validate we extracted at least some data
+        if data_collector.is_empty():
+            raise ValueError("No valid data points could be extracted from dataset")
+
+        # Determine error bar cap size
+        cap_size = ERROR_BAR_CAP_SIZE if (plot_error_bars and not resource_plotting_enabled) else 0
+
+        return PlotDataResult(
+            x_data=data_collector.x_data,
+            error_bars=data_collector.error_bars,
+            cap_size=cap_size,
+            plot_resource_usage=resource_plotting_enabled,
+            x_label=x_label or "Unknown",  # Fallback if no label was set
+        )
+
+    def _render_plots(
+        self,
+        io_plotter: IOPlotter,
+        cpu_plotter: CPUPlotter,
+        plot_result: PlotDataResult,
+    ) -> None:
+        """Render the IO and optional CPU plots."""
+        io_plotter.plot_with_error_bars(
+            x_data=plot_result.x_data, error_data=plot_result.error_bars, cap_size=plot_result.cap_size
+        )
+
+        if plot_result.plot_resource_usage:
+            cpu_plotter.plot(x_data=plot_result.x_data)
+
+    def _add_single_file_data_with_optional_errorbars(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         file_data: CommonFormatDataType,
         main_axes: Axes,
@@ -161,60 +441,31 @@ class CommonFormatPlotter(ABC):
         label: Optional[str] = None,
     ) -> None:
         """
-        Add the data from a single file to a plot. Include error bars. Each point
-        in the plot is the latency vs IOPs or bandwidth for a given queue depth.
+        Add data from a single file to the plot with optional error bars and resource usage.
 
-        The plot will have red error bars with a blue plot line
+        Each point represents latency vs throughput (IOPS or bandwidth) for a given queue depth.
+        Error bars are displayed in red with a blue plot line when enabled.
+
+        Args:
+            file_data: Performance data in common format
+            main_axes: Matplotlib axes object for plotting
+            plot_error_bars: Whether to include standard deviation error bars
+            plot_resource_usage: Whether to include CPU usage on secondary axis
+            label: Custom label for the IO plot line (defaults to "IO Details")
         """
-        io_plot_label: str = label if label else "IO Details"
+        # Initialize plotters
+        io_plotter, cpu_plotter = self._initialize_plotters(main_axes, label)
 
-        cpu_plotter: CPUPlotter = CPUPlotter(main_axis=main_axes)  # io_axis)
-        io_plotter: IOPlotter = IOPlotter(main_axis=main_axes)  # io_axis)
-        io_plotter.y_label = "Latency (ms)"
-        io_plotter.plot_label = io_plot_label
+        # Sort and prepare data
+        sorted_plot_data = self._sort_plot_data(file_data)
 
-        sorted_plot_data: PlotDataType = self._sort_plot_data(file_data)
+        # Extract plot data with validation
+        plot_result = self._extract_plot_data(
+            sorted_plot_data, main_axes, io_plotter, cpu_plotter, plot_error_bars, plot_resource_usage
+        )
 
-        x_data: list[float] = []
-        error_bars: list[float] = []
-        capsize: int = 0
-
-        for _, data in sorted_plot_data.items():
-            # for blocksize less than 64K we want to use the bandwidth to plot the graphs,
-            # otherwise we should use iops.
-            blocksize: int = int(int(data["blocksize"]) / 1024)
-            if blocksize >= 64:
-                # convert bytes to Mb, not Mib, so use 1000s rather than 1024
-                x_data.append(float(data["bandwidth_bytes"]) / (1000 * 1000))
-                main_axes.set_xlabel("Bandwidth (MB/s)")  # pyright: ignore[reportUnknownMemberType]
-            else:
-                x_data.append(float(data["iops"]))
-                main_axes.set_xlabel("IOps")  # pyright: ignore[reportUnknownMemberType]
-                # The stored values are in ns, we want to convert to ms
-
-            io_plotter.add_y_data(data["latency"])
-
-            # If we don't have CPU data in the intermediate files, then there's
-            # no point in trying to plot a CPU line
-            if data.get("cpu", None) is None and plot_resource_usage:
-                log.warning("Unable to plot CPU usage as the CPU data does not exist")
-                plot_resource_usage = False
-
-            if plot_resource_usage:
-                cpu_plotter.add_y_data(data.get("cpu", ""))
-                plot_error_bars = False
-
-            if plot_error_bars:
-                error_bars.append(float(data["std_deviation"]) / (1000 * 1000))
-                capsize = 3
-            else:
-                error_bars.append(0)
-                capsize = 0
-
-        io_plotter.plot_with_error_bars(x_data=x_data, error_data=error_bars, cap_size=capsize)
-
-        if plot_resource_usage:
-            cpu_plotter.plot(x_data=x_data)
+        # Render plots
+        self._render_plots(io_plotter, cpu_plotter, plot_result)
 
     def _save_plot(self, file_path: str) -> None:
         """

--- a/post_processing/plotter/file_comparison_plotter.py
+++ b/post_processing/plotter/file_comparison_plotter.py
@@ -15,7 +15,7 @@ from matplotlib.figure import Figure
 from post_processing.common import (
     DATA_FILE_EXTENSION_WITH_DOT,
     PLOT_FILE_EXTENSION_WITH_DOT,
-    get_blocksize_percentage_operation_from_file_name,
+    get_blocksize_percentage_operation_numjobs_from_file_name,
     read_intermediate_file,
 )
 from post_processing.plotter.common_format_plotter import CommonFormatPlotter
@@ -47,7 +47,7 @@ class FileComparisonPlotter(CommonFormatPlotter):
             index: int = self._comparison_files.index(file_path)
             file_data: CommonFormatDataType = read_intermediate_file(f"{file_path}")
 
-            operation_details: tuple[str, str, str] = get_blocksize_percentage_operation_from_file_name(
+            operation_details: tuple[str, str, str, str] = get_blocksize_percentage_operation_numjobs_from_file_name(
                 file_name=file_path.stem
             )
 

--- a/post_processing/plotter/io_plotter.py
+++ b/post_processing/plotter/io_plotter.py
@@ -22,7 +22,7 @@ class IOPlotter(AxisPlotter):
     def add_y_data(self, data_value: str) -> None:
         """
         Add a point of IO latency data for this plot.
-        
+
         Args:
             data_value: A single latency value in nanoseconds as a string.
                        Will be converted to milliseconds internally.
@@ -38,13 +38,14 @@ class IOPlotter(AxisPlotter):
     def plot_with_error_bars(self, x_data: list[float], error_data: list[float], cap_size: int) -> None:
         """
         Plot IO data with error bars on the main axes.
-        
+
         Args:
             x_data: The data for the x-axis (throughput values)
             error_data: The error bar data (standard deviations in milliseconds)
             cap_size: The size of the error bar caps in points. Use 0 for no caps.
         """
         io_axis = self._main_axes
+        io_axis.set_ylabel(self.y_label)
         # io_axis.tick_params(axis="y")  # pyright: ignore[reportUnknownMemberType]
         io_axis.errorbar(  # pyright: ignore[reportUnknownMemberType]
             x_data, self._y_data, yerr=error_data, fmt="+-", capsize=cap_size, ecolor="red", label=self._label

--- a/post_processing/plotter/plot_data_collector.py
+++ b/post_processing/plotter/plot_data_collector.py
@@ -1,0 +1,23 @@
+"""
+Class for collecting and managing plot data points.
+"""
+
+
+class PlotDataCollector:
+    """Collects and manages plot data points."""
+
+    def __init__(self) -> None:
+        self.x_data: list[float] = []
+        self.error_bars: list[float] = []
+
+    def add_point(self, x_value: float, error_bar: float) -> None:
+        """Add a data point to the collection."""
+        self.x_data.append(x_value)
+        self.error_bars.append(error_bar)
+
+    def is_empty(self) -> bool:
+        """Check if no data points have been collected."""
+        return len(self.x_data) == 0
+
+
+# Made with Bob

--- a/post_processing/plotter/plot_data_results.py
+++ b/post_processing/plotter/plot_data_results.py
@@ -1,0 +1,33 @@
+"""
+Data structures for storing plot data results.
+
+Contains dataclasses for:
+- DataPointResult: Result from processing a single data point
+- PlotDataResult: Structured result from plot data extraction
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class DataPointResult:
+    """Result from processing a single data point."""
+
+    x_value: float
+    x_label: str
+    error_bar: float
+    resource_available: bool
+
+
+@dataclass
+class PlotDataResult:
+    """Structured result from plot data extraction."""
+
+    x_data: list[float]
+    error_bars: list[float]
+    cap_size: int
+    plot_resource_usage: bool
+    x_label: str
+
+
+# Made with Bob

--- a/post_processing/post_processing_types.py
+++ b/post_processing/post_processing_types.py
@@ -44,8 +44,9 @@ IodepthDataType = dict[str, str]
 CommonFormatDataType = dict[str, Union[str, IodepthDataType]]
 
 # Common formatter internal data types
-InternalBlocksizeDataType = dict[str, CommonFormatDataType]
-InternalFormattedOutputType = dict[str, InternalBlocksizeDataType]
+InternalBlocksizeDataType = dict[str, dict[str, Union[str, IodepthDataType]]]
+InternalNumJobsDataType = dict[str, InternalBlocksizeDataType]
+InternalFormattedOutputType = dict[str, InternalNumJobsDataType]
 
 # Plotter types
 PlotDataType = dict[str, dict[str, str]]

--- a/post_processing/report.py
+++ b/post_processing/report.py
@@ -81,7 +81,7 @@ class Report:
     def generate(self, throw_exception: bool = False) -> None:
         """
         Do all the steps necessary to create the report file.
-        
+
         Args:
             throw_exception: If True, re-raises exceptions after logging them.
                            If False, exceptions are caught and logged but not re-raised.

--- a/post_processing/reports/comparison_report_generator.py
+++ b/post_processing/reports/comparison_report_generator.py
@@ -21,7 +21,7 @@ from post_processing.common import (
     PLOT_FILE_EXTENSION_WITH_DOT,
     TITLE_CONVERSION,
     calculate_percent_difference_to_baseline,
-    get_blocksize_percentage_operation_from_file_name,
+    get_blocksize_percentage_operation_numjobs_from_file_name,
     get_date_time_string,
     get_latency_throughput_from_file,
     strip_confidential_data_from_yaml,
@@ -58,7 +58,8 @@ class ComparisonReportGenerator(ReportGenerator):
             # The comparison plot files have a different name format:
             #     Comparison_<blocksize>_<percent>_<operation>
             # so we need o split the Comparison_ from the front before calling the common method
-            (blocksize, percent, operation) = get_blocksize_percentage_operation_from_file_name(
+            # TODO: CH do we need numjobs here?
+            (blocksize, percent, operation, _) = get_blocksize_percentage_operation_numjobs_from_file_name(
                 image_file.stem[len("Comparison_") :]
             )
             title: str = f"{blocksize} {percent} {operation}"
@@ -227,7 +228,10 @@ class ComparisonReportGenerator(ReportGenerator):
         Generate the data for all the rows in the table
         """
         for file_name, file_paths in self._data_files.items():
-            (blocksize, percentage, operation) = get_blocksize_percentage_operation_from_file_name(file_name)
+            (blocksize, percentage, operation, number_of_jobs) = (
+                get_blocksize_percentage_operation_numjobs_from_file_name(file_name)
+            )
+            #TODO: CH need numjobs here somehow
             data_string: str = f"|[{blocksize}"
             if percentage:
                 data_string += f"_{percentage}"

--- a/post_processing/reports/comparison_report_generator.py
+++ b/post_processing/reports/comparison_report_generator.py
@@ -46,49 +46,52 @@ class ComparisonReportGenerator(ReportGenerator):
         title: str = f"Comparitive Performance Report for {' vs '.join(self._build_strings)}"
         return title
 
-    def _add_plots(self) -> None:
+    def _add_plots(self) -> None:  # pylint: disable=[too-many-locals]
         self._report.new_header(level=1, title="Response Curves")
         empty_table_header: list[str] = ["", ""]
-        image_tables: dict[str, list[str]] = {}
 
-        for _, operation in TITLE_CONVERSION.items():
-            image_tables[operation] = empty_table_header.copy()
+        for number_of_jobs in self._get_all_number_of_jobs_values():
+            self._report.new_header(level=2, title=f"Number of Jobs {number_of_jobs}")
+            image_tables: dict[str, list[str]] = {}
 
-        for image_file in self._plot_files:
-            # The comparison plot files have a different name format:
-            #     Comparison_<blocksize>_<percent>_<operation>
-            # so we need o split the Comparison_ from the front before calling the common method
-            # TODO: CH do we need numjobs here?
-            (blocksize, percent, operation, _) = get_blocksize_percentage_operation_numjobs_from_file_name(
-                image_file.stem[len("Comparison_") :]
-            )
-            title: str = f"{blocksize} {percent} {operation}"
+            for _, operation in TITLE_CONVERSION.items():
+                image_tables[operation] = empty_table_header.copy()
 
-            image_line: str = self._report.new_inline_image(
-                text=title, path=f"{self._plots_directory.parts[-1]}/{image_file.parts[-1]}"
-            )
-            anchor: str = f'<a name="{image_file.stem[len("Comparison_") :].replace("_", "-")}"></a>'
+            for image_file in self._plot_files:
+                # The comparison plot files have a different name format:
+                #     Comparison_<blocksize>_<percent>_<operation>_<numjobs>
+                # so we need to split the Comparison_ from the front before calling the common method
+                (blocksize, percent, operation, numjobs) = get_blocksize_percentage_operation_numjobs_from_file_name(
+                    image_file.stem[len("Comparison_") :]
+                )
+                if numjobs == number_of_jobs:
+                    title: str = f"{blocksize} {percent} {operation}"
 
-            image_line = f"{anchor}{image_line}"
+                    image_line: str = self._report.new_inline_image(
+                        text=title, path=f"{self._plots_directory.parts[-1]}/{image_file.parts[-1]}"
+                    )
+                    anchor: str = f'<a name="{image_file.stem[len("Comparison_") :].replace("_", "-")}"></a>'
 
-            image_tables[operation].append(image_line)
+                    image_line = f"{anchor}{image_line}"
 
-        # Create the correct sections and add a table for each section to the report
+                    image_tables[operation].append(image_line)
 
-        for section, data in image_tables.items():
-            # We don't want to display a section if it doesn't contain any plots
-            if len(data) > len(empty_table_header):
-                self._report.new_header(level=2, title=section)
-                table_images = data
+            # Create the correct sections and add a table for each section to the report
 
-                # We need to calculate the number of rows, but new_table() requires the
-                # exact number of items to fill the table, so we may need to add a dummy
-                # entry at the end
-                number_of_rows: int = len(table_images) // 2
-                if len(table_images) % 2 > 0:
-                    number_of_rows += 1
-                    table_images.append("")
-                self._report.new_table(columns=2, rows=number_of_rows, text=table_images, text_align="center")
+            for section, data in image_tables.items():
+                # We don't want to display a section if it doesn't contain any plots
+                if len(data) > len(empty_table_header):
+                    self._report.new_header(level=3, title=section)
+                    table_images = data
+
+                    # We need to calculate the number of rows, but new_table() requires the
+                    # exact number of items to fill the table, so we may need to add a dummy
+                    # entry at the end
+                    number_of_rows: int = len(table_images) // 2
+                    if len(table_images) % 2 > 0:
+                        number_of_rows += 1
+                        table_images.append("")
+                    self._report.new_table(columns=2, rows=number_of_rows, text=table_images, text_align="center")
 
     def _add_summary_table(self) -> None:
         self._report.new_header(level=1, title=f"Comparison summary for {' vs '.join(self._build_strings)}")
@@ -209,8 +212,8 @@ class ComparisonReportGenerator(ReportGenerator):
         Generate the header lines for the table
         """
         # The first directory is always the baseline, so we want to get it out of the way first
-        table_header: str = f"{self._data_directories.pop(0).parts[-2]}|"
-        table_justfication_string: str = "| :--- | ---: |"
+        table_header: str = f"numjobs|{self._data_directories.pop(0).parts[-2]}|"
+        table_justfication_string: str = "| :--- | ---: | ---: |"
 
         if len(self._data_directories) < 2:
             for directory in self._data_directories:
@@ -223,7 +226,7 @@ class ComparisonReportGenerator(ReportGenerator):
 
         return (table_header, table_justfication_string)
 
-    def _generate_table_rows(self, data_tables: dict[str, list[str]]) -> None:
+    def _generate_table_rows(self, data_tables: dict[str, list[str]]) -> None:  # pylint: disable=[too-many-locals]
         """
         Generate the data for all the rows in the table
         """
@@ -231,12 +234,14 @@ class ComparisonReportGenerator(ReportGenerator):
             (blocksize, percentage, operation, number_of_jobs) = (
                 get_blocksize_percentage_operation_numjobs_from_file_name(file_name)
             )
-            #TODO: CH need numjobs here somehow
+
             data_string: str = f"|[{blocksize}"
             if percentage:
                 data_string += f"_{percentage}"
 
             data_string += f"](#{file_name.replace('_', '-')})|"
+
+            data_string += f"{number_of_jobs}|"
 
             (baseline_max_throughput, baseline_latency_ms) = get_latency_throughput_from_file(file_paths.pop(0))
 

--- a/post_processing/reports/report_generator.py
+++ b/post_processing/reports/report_generator.py
@@ -19,6 +19,7 @@ from post_processing.common import (
     DATA_FILE_EXTENSION_WITH_DOT,
     PLOT_FILE_EXTENSION_WITH_DOT,
     find_common_data_file_names,
+    get_blocksize_percentage_operation_numjobs_from_file_name,
     get_date_time_string,
 )
 
@@ -38,7 +39,7 @@ class ReportGenerator(ABC):
     # tex header file location
     BASE_HEADER_FILE_PATH: str = "include/performance_report.tex"
 
-    def __init__(
+    def __init__(  # pylint: disable=[too-many-arguments, too-many-positional-arguments]
         self,
         archive_directories: list[str],
         output_directory: str,
@@ -161,12 +162,18 @@ class ReportGenerator(ABC):
             | <name>        | <numjobs>      | <iops_or_bw>       |    <latency_ms>|
 
         for a comparison report for 2 runs the format is:
-            | <operation_type> | <baseline_workload_name>       | <workload_name>       | %change throughput>  | %change latency   |
-            | <blocksize>      | <baseline_througput>@<latency> | <througput>@<latency> | <%change_throughput> | <%change_latency> |
+        | <operation_type> | <baseline_workload_name>       | <workload_name>
+        | %change throughput>  | %change latency   |
+
+        | <blocksize>      | <baseline_througput>@<latency> | <througput>@<latency>
+        | <%change_throughput> | <%change_latency> |
 
         for a comparison report for more than 2 runs the format is:
-            | <operation_type> | <baseline_workload_name> | <workload_1_name>     | %change   | <workload_2_name>     | %change   |
-            | <blocksize>      | <througput>@<latency>    | <througput>@<latency> | <%change> | <througput>@<latency> | <%change> |
+        | <operation_type> | <baseline_workload_name> | <workload_1_name>     | %change
+        | <workload_2_name>     | %change   |
+
+        | <blocksize>      | <througput>@<latency>    | <througput>@<latency> | <%change>
+        | <througput>@<latency> | <%change> |
         """
 
     @abstractmethod
@@ -315,3 +322,23 @@ class ReportGenerator(ABC):
 
         unique_directory_name: str = f"{base_directory_name}.{date_string}"
         return unique_directory_name
+
+    def _get_all_number_of_jobs_values(self) -> list[str]:
+        """
+        Get all the possible number_of_jobs values for this set of data.
+        Works for both simple and comparison plot file naming conventions.
+
+        Simple format: <blocksize>_<percent>_<operation>_<numjobs>.svg
+        Comparison format: Comparison_<blocksize>_<percent>_<operation>_<numjobs>.svg
+        """
+        numbers_of_jobs: set[str] = set()
+        for image_file in self._plot_files:
+            # Handle both naming conventions by stripping "Comparison_" prefix if present
+            stem = image_file.stem
+            if stem.startswith("Comparison_"):
+                stem = stem[len("Comparison_") :]
+
+            (_, _, _, number_of_jobs) = get_blocksize_percentage_operation_numjobs_from_file_name(stem)
+            numbers_of_jobs.add(number_of_jobs)
+
+        return sorted(numbers_of_jobs)

--- a/post_processing/reports/report_generator.py
+++ b/post_processing/reports/report_generator.py
@@ -157,11 +157,16 @@ class ReportGenerator(ABC):
 
         For a simple report this ill be of the format:
 
-        | workload_name | Maximum Throughput |    Latency (ms)|
-        | <name>        |       <iops_or_bw> |    <latency_ms>|
+            | workload_name | Number of Jobs | Maximum Throughput |    Latency (ms)|
+            | <name>        | <numjobs>      | <iops_or_bw>       |    <latency_ms>|
 
-        for a comparison report the format is:
-        TODO: fill this in
+        for a comparison report for 2 runs the format is:
+            | <operation_type> | <baseline_workload_name>       | <workload_name>       | %change throughput>  | %change latency   |
+            | <blocksize>      | <baseline_througput>@<latency> | <througput>@<latency> | <%change_throughput> | <%change_latency> |
+
+        for a comparison report for more than 2 runs the format is:
+            | <operation_type> | <baseline_workload_name> | <workload_1_name>     | %change   | <workload_2_name>     | %change   |
+            | <blocksize>      | <througput>@<latency>    | <througput>@<latency> | <%change> | <througput>@<latency> | <%change> |
         """
 
     @abstractmethod
@@ -222,7 +227,13 @@ class ReportGenerator(ABC):
         producing the summary table
         """
         unique_file_names: list[str] = find_common_data_file_names(self._data_directories)
-        sorted_data_file_names: list[str] = sorted(unique_file_names, key=lambda a: int(a.split("_")[0][:-1]))
+        sorted_data_file_names: list[str] = sorted(
+            unique_file_names,
+            key=lambda file_name: (
+                int(file_name.split("_")[0]),
+                int(file_name.split("_")[1]),
+            ),
+        )
 
         sorted_data_files: dict[str, list[Path]] = {}
         for file_name in sorted_data_file_names:

--- a/post_processing/reports/simple_report_generator.py
+++ b/post_processing/reports/simple_report_generator.py
@@ -50,7 +50,7 @@ class SimpleReportGenerator(ReportGenerator):
         output_file_name: str = f"performance_report_{datetime_string}.{self.MARKDOWN_FILE_EXTENSION}"
         return output_file_name
 
-    def _add_summary_table(self) -> None:
+    def _add_summary_table(self) -> None:  # pylint: disable=[too-many-locals]
         self._report.new_header(level=1, title=f"Summary of results for {''.join(self._build_strings)}")
 
         # We cannot use the mdutils table object here as it can only justify
@@ -97,7 +97,7 @@ class SimpleReportGenerator(ReportGenerator):
             for line in operation_data:
                 self._report.new_line(text=line)
 
-    def _add_plots(self) -> None:
+    def _add_plots(self) -> None:  # pylint: disable=[too-many-locals]
         self._report.new_header(level=1, title="Response Curves")
 
         empty_table_header: list[str] = ["", ""]
@@ -188,14 +188,3 @@ class SimpleReportGenerator(ReportGenerator):
         # This should only ever return a single path as each archive directory
         # should only ever contain a single cbt_config.yaml file
         return yaml_file_path
-
-    def _get_all_number_of_jobs_values(self) -> list[str]:
-        """
-        Get all the possible number_of_jobs values for this set of data
-        """
-        numbers_of_jobs: set[str] = set()
-        for image_file in self._plot_files:
-            (_, _, _, number_of_jobs) = get_blocksize_percentage_operation_numjobs_from_file_name(image_file.stem)
-            numbers_of_jobs.add(number_of_jobs)
-
-        return sorted(numbers_of_jobs)

--- a/post_processing/reports/simple_report_generator.py
+++ b/post_processing/reports/simple_report_generator.py
@@ -20,7 +20,7 @@ from typing import Optional
 from post_processing.common import (
     PLOT_FILE_EXTENSION_WITH_DOT,
     TITLE_CONVERSION,
-    get_blocksize_percentage_operation_from_file_name,
+    get_blocksize_percentage_operation_numjobs_from_file_name,
     get_latency_throughput_from_file,
     get_resource_details_from_file,
     strip_confidential_data_from_yaml,
@@ -60,8 +60,8 @@ class SimpleReportGenerator(ReportGenerator):
 
         log.info("Generating summary table")
 
-        headers: str = "|Workload Name|Maximum Throughput|Latency (ms)|"
-        alignment: str = "| :--- | ---: | ---: |"
+        headers: str = "|Workload Name|Number of Jobs|Maximum Throughput|Latency (ms)|"
+        alignment: str = "| :--- | :---: | ---: | ---: |"
 
         if self._plot_resources:
             alignment += " ---: |"
@@ -76,15 +76,19 @@ class SimpleReportGenerator(ReportGenerator):
 
         for _, file_data in self._data_files.items():
             for file_path in file_data:
-                # for file_name in self._data_files.keys():
-                #    for file_path in self._data_files[file_name]:
                 log.debug("Looking at file %s", file_path)
                 (max_throughput, latency_ms) = get_latency_throughput_from_file(file_path)
                 (cpu_usage, _) = get_resource_details_from_file(file_path)
                 # Eventually we will return the memory usage here, but for the first pass we'll just grab CPU
 
-                (_, _, operation) = get_blocksize_percentage_operation_from_file_name(file_path.stem)
-                data: str = f"|[{file_path.stem}](#{file_path.stem.replace('_', '-')})|{max_throughput}|{latency_ms}|{cpu_usage}|"
+                (blocksize, percent, operation, number_of_jobs) = (
+                    get_blocksize_percentage_operation_numjobs_from_file_name(file_path.stem)
+                )
+                workload_name: str = f"{blocksize} {percent} {operation}"
+                data: str = (
+                    f"|[{workload_name}](#{file_path.stem.replace('_', '-')})|"
+                    + f"{number_of_jobs}|{max_throughput}|{latency_ms}|{cpu_usage}|"
+                )
 
                 data_tables[operation].append(data)
 
@@ -95,42 +99,49 @@ class SimpleReportGenerator(ReportGenerator):
 
     def _add_plots(self) -> None:
         self._report.new_header(level=1, title="Response Curves")
+
         empty_table_header: list[str] = ["", ""]
-        image_tables: dict[str, list[str]] = {}
+        image_tables: dict[str, dict[str, list[str]]] = {}
 
-        for _, operation in TITLE_CONVERSION.items():
-            image_tables[operation] = empty_table_header.copy()
+        for number_of_jobs in self._get_all_number_of_jobs_values():
+            self._report.new_header(level=2, title=f"Number of Jobs {number_of_jobs}")
+            image_tables[number_of_jobs] = {}
+            for _, operation in TITLE_CONVERSION.items():
+                image_tables[number_of_jobs][operation] = empty_table_header.copy()
 
-        for image_file in self._plot_files:
-            (blocksize, percent, operation) = get_blocksize_percentage_operation_from_file_name(image_file.stem)
-            title: str = f"{blocksize}K {percent} {operation}"
+            for image_file in self._plot_files:
+                (blocksize, percent, operation, numjobs) = get_blocksize_percentage_operation_numjobs_from_file_name(
+                    image_file.stem
+                )
+                if numjobs == number_of_jobs:
+                    title: str = f"{blocksize} {percent} {operation}"
 
-            image_line: str = self._report.new_inline_image(
-                text=title, path=f"{self._plots_directory.parts[-1]}/{image_file.parts[-1]}"
-            )
-            anchor: str = f'<a name="{image_file.stem.replace("_", "-")}"></a>'
+                    image_line: str = self._report.new_inline_image(
+                        text=title, path=f"{self._plots_directory.parts[-1]}/{image_file.parts[-1]}"
+                    )
+                    anchor: str = f'<a name="{image_file.stem.replace("_", "-")}"></a>'
 
-            image_line = f"{anchor}{image_line}"
+                    image_line = f"{anchor}{image_line}"
 
-            image_tables[operation].append(image_line)
+                    image_tables[number_of_jobs][operation].append(image_line)
 
-        # Create the correct sections and add a table for each section to the report
+            # Create the correct sections and add a table for each section to the report
 
-        # for section in image_tables.keys():
-        for section_name, section_data in image_tables.items():
-            # We don't want to display a section if it doesn't contain any plots
-            if len(section_data) > len(empty_table_header):
-                self._report.new_header(level=2, title=section_name)
-                table_images = section_data
+            # for section in image_tables.keys():
+            for section_name, section_data in image_tables[number_of_jobs].items():
+                # We don't want to display a section if it doesn't contain any plots
+                if len(section_data) > len(empty_table_header):
+                    self._report.new_header(level=3, title=section_name)
+                    table_images = section_data
 
-                # We need to calculate the number of rows, but new_table() requires the
-                # exact number of items to fill the table, so we may need to add a dummy
-                # entry at the end
-                number_of_rows: int = len(table_images) // 2
-                if len(table_images) % 2 > 0:
-                    number_of_rows += 1
-                    table_images.append("")
-                self._report.new_table(columns=2, rows=number_of_rows, text=table_images, text_align="center")
+                    # We need to calculate the number of rows, but new_table() requires the
+                    # exact number of items to fill the table, so we may need to add a dummy
+                    # entry at the end
+                    number_of_rows: int = len(table_images) // 2
+                    if len(table_images) % 2 > 0:
+                        number_of_rows += 1
+                        table_images.append("")
+                    self._report.new_table(columns=2, rows=number_of_rows, text=table_images, text_align="center")
 
     def _add_configuration_yaml_files(self) -> None:
         self._report.new_header(level=1, title="Configuration yaml")
@@ -177,3 +188,14 @@ class SimpleReportGenerator(ReportGenerator):
         # This should only ever return a single path as each archive directory
         # should only ever contain a single cbt_config.yaml file
         return yaml_file_path
+
+    def _get_all_number_of_jobs_values(self) -> list[str]:
+        """
+        Get all the possible number_of_jobs values for this set of data
+        """
+        numbers_of_jobs: set[str] = set()
+        for image_file in self._plot_files:
+            (_, _, _, number_of_jobs) = get_blocksize_percentage_operation_numjobs_from_file_name(image_file.stem)
+            numbers_of_jobs.add(number_of_jobs)
+
+        return sorted(numbers_of_jobs)

--- a/post_processing/run_results/benchmarks/benchmark_result.py
+++ b/post_processing/run_results/benchmarks/benchmark_result.py
@@ -16,7 +16,7 @@ from post_processing.post_processing_types import IodepthDataType, JobsDataType
 log: Logger = getLogger("formatter")
 
 
-class BenchmarkResult(ABC):
+class BenchmarkResult(ABC):  # pylint: disable=[too-many-instance-attributes]
     """
     This is the top level class for a benchmark run result. As each
     benchmark tool produces different output results we will need a
@@ -70,10 +70,16 @@ class BenchmarkResult(ABC):
 
     @property
     def blocksize(self) -> str:
+        """
+        Getter for blocksize
+        """
         return get_blocksize(f"{self._data['global options']['bs']}")
 
     @property
     def operation(self) -> str:
+        """
+        Getter for the operation (read, write, rw etc)
+        """
         operation: str = f"{self._data['global options']['rw']}"
         if self._global_options.get("percentage_reads", None):
             operation = (
@@ -84,18 +90,30 @@ class BenchmarkResult(ABC):
 
     @property
     def global_options(self) -> dict[str, str]:
+        """
+        Getter for the global options from this run
+        """
         return self._global_options
 
     @property
     def iodepth(self) -> str:
+        """
+        Getter for iodepth value
+        """
         return self._iodepth
 
     @property
     def io_details(self) -> IodepthDataType:
+        """
+        Getter for the I/O details
+        """
         return self._io_details
 
     @property
     def number_of_jobs(self) -> str:
+        """
+        Getter for number of jobs
+        """
         return self._number_of_jobs
 
     def _read_results_from_file(self) -> dict[str, Any]:

--- a/post_processing/run_results/benchmarks/benchmark_result.py
+++ b/post_processing/run_results/benchmarks/benchmark_result.py
@@ -28,6 +28,7 @@ class BenchmarkResult(ABC):
         self._data: dict[str, Any] = self._read_results_from_file()
         if not self._data:
             raise ValueError(f"File {file_path} is empty")
+        self._number_of_jobs: str = ""
 
         self._global_options: dict[str, str] = self._get_global_options(self._data["global options"])
         self._iodepth = self._get_iodepth(f"{self._data['global options']['iodepth']}")
@@ -92,6 +93,10 @@ class BenchmarkResult(ABC):
     @property
     def io_details(self) -> IodepthDataType:
         return self._io_details
+
+    @property
+    def number_of_jobs(self) -> str:
+        return self._number_of_jobs
 
     def _read_results_from_file(self) -> dict[str, Any]:
         """

--- a/post_processing/run_results/benchmarks/fio.py
+++ b/post_processing/run_results/benchmarks/fio.py
@@ -33,6 +33,7 @@ class FIO(BenchmarkResult):
             "runtime_seconds": f"{fio_global_options['runtime']}",
             "blocksize": blocksize,
         }
+        self._number_of_jobs = f"{fio_global_options['numjobs']}"
 
         # if rwmixread exists in the output then so does rwmixwrite
         if fio_global_options.get("rwmixread", None):

--- a/post_processing/run_results/rbdfio.py
+++ b/post_processing/run_results/rbdfio.py
@@ -23,7 +23,7 @@ log: Logger = getLogger(name="formatter")
 class RBDFIO(RunResult):
     """
     Processes RBD FIO benchmark results and converts them to the common intermediate format.
-    
+
     This class handles reading FIO JSON output files from RBD (RADOS Block Device)
     benchmark runs and aggregating results across multiple volumes.
     """
@@ -35,10 +35,10 @@ class RBDFIO(RunResult):
     def _find_files_for_testrun(self, file_name_root: str) -> list[Path]:
         """
         Find all result files for a particular test run matching the file name pattern.
-        
+
         Args:
             file_name_root: The base filename to search for (e.g., "json_output")
-        
+
         Returns:
             List of Path objects for files matching the pattern <file_name_root>.<digit>
         """
@@ -57,11 +57,11 @@ class RBDFIO(RunResult):
         """
         Aggregate IO statistics from multiple volumes by summing values and computing
         weighted averages for latency and standard deviation.
-        
+
         Args:
             existing_values: Previously aggregated IO statistics
             new_values: New IO statistics to add to the aggregate
-        
+
         Returns:
             Combined IO statistics with properly weighted latency and standard deviation
         """

--- a/post_processing/run_results/resources/fio_resource.py
+++ b/post_processing/run_results/resources/fio_resource.py
@@ -14,7 +14,7 @@ log: Logger = getLogger("formatter")
 class FIOResource(ResourceResult):
     """
     Processes resource usage statistics from FIO benchmark output.
-    
+
     FIO includes CPU usage statistics in its JSON output, which this class
     extracts and formats for inclusion in the common intermediate format.
     """
@@ -26,13 +26,13 @@ class FIOResource(ResourceResult):
     def _get_resource_output_file_from_file_path(self, file_path: Path) -> Path:
         """
         Get the path to the resource usage file.
-        
+
         For FIO, resource usage details are stored in the same file as the
         benchmark results, so this simply returns the input path.
-        
+
         Args:
             file_path: Path to the FIO output file
-        
+
         Returns:
             The same path, as FIO stores resource data in the benchmark output file
         """
@@ -41,10 +41,10 @@ class FIOResource(ResourceResult):
     def _parse(self, data: dict[str, Any]) -> None:
         """
         Extract CPU and memory usage from FIO output data.
-        
+
         Combines system CPU and user CPU percentages to get total CPU usage.
         Memory usage is currently not extracted from FIO output.
-        
+
         Args:
             data: Dictionary containing parsed FIO JSON output
         """

--- a/post_processing/run_results/resources/resource_result.py
+++ b/post_processing/run_results/resources/resource_result.py
@@ -34,7 +34,7 @@ class ResourceResult(ABC):
     def source(self) -> str:
         """
         Get the source identifier for the resource monitoring tool.
-        
+
         Returns:
             A string identifier for the resource monitoring source (e.g., "fio", "collectl")
         """
@@ -55,12 +55,18 @@ class ResourceResult(ABC):
 
     @property
     def cpu(self) -> str:
+        """
+        getter for the CPU value
+        """
         if not self._has_been_parsed:
             self._parse(self._read_results_from_file())
         return self._cpu
 
     @property
     def memory(self) -> str:
+        """
+        getter for the memory value
+        """
         if not self._has_been_parsed:
             self._parse(self._read_results_from_file())
         return self._memory

--- a/post_processing/run_results/run_result.py
+++ b/post_processing/run_results/run_result.py
@@ -12,6 +12,7 @@ from post_processing.common import file_is_empty, file_is_precondition
 from post_processing.post_processing_types import (
     InternalBlocksizeDataType,
     InternalFormattedOutputType,
+    InternalNumJobsDataType,
     IodepthDataType,
 )
 
@@ -58,7 +59,7 @@ class RunResult(ABC):
     def type(self) -> str:
         """
         Returns the benchmark type.
-        
+
         Returns:
             The benchmark type identifier (e.g., "rbdfio", "fio")
         """
@@ -107,11 +108,11 @@ class RunResult(ABC):
     def _convert_file(self, file_path: Path) -> None:
         """
         Convert an individual benchmark result file to the common intermediate format.
-        
+
         This method reads the benchmark output file, extracts IO and resource usage
         statistics, and stores them in the internal data structure organized by
         operation type, blocksize, and IO depth.
-        
+
         Args:
             file_path: Path to the benchmark result file to process
         """
@@ -123,21 +124,24 @@ class RunResult(ABC):
         iodepth = io.iodepth
         blocksize: str = io.blocksize
         operation: str = io.operation
+        number_of_jobs: str = io.number_of_jobs
         global_details: dict[str, str] = io.global_options
 
         blocksize_details: InternalBlocksizeDataType = {blocksize: {}}
         iodepth_details: dict[str, dict[str, str]] = {iodepth: global_details}
+        numjobs_details: InternalNumJobsDataType = {number_of_jobs: blocksize_details}
 
         io_details: IodepthDataType = {}
 
         if self._processed_data.get(operation, None):
-            if self._processed_data[operation].get(blocksize, None):
-                if self._processed_data[operation][blocksize].get(iodepth, None):
-                    # we already have data here, so use it
-                    log.debug("We have details for iodepth %s so using them", iodepth)
-                    io_details = self._sum_io_details(
-                        self._processed_data[operation][blocksize][iodepth], io.io_details
-                    )
+            if self._processed_data[operation].get(number_of_jobs, None):
+                if self._processed_data[operation][number_of_jobs].get(blocksize, None):
+                    if self._processed_data[operation][number_of_jobs][blocksize].get(iodepth, None):
+                        # we already have data here, so use it
+                        log.debug("We have details for iodepth %s so using them", iodepth)
+                        io_details = self._sum_io_details(
+                            self._processed_data[operation][number_of_jobs][blocksize][iodepth], io.io_details
+                        )
 
         if not io_details:
             io_details = io.io_details
@@ -145,11 +149,15 @@ class RunResult(ABC):
         iodepth_details[iodepth].update(io_details)
         iodepth_details[iodepth].update(resource.get())
         blocksize_details[blocksize].update(iodepth_details)
+        numjobs_details[number_of_jobs].update(blocksize_details)
 
         if self._processed_data.get(operation, None):
-            if self._processed_data[operation].get(blocksize, None):
-                self._processed_data[operation][blocksize].update(iodepth_details)
+            if self._processed_data[operation].get(number_of_jobs, None):
+                if self._processed_data[operation][number_of_jobs].get(blocksize, None):
+                    self._processed_data[operation][number_of_jobs][blocksize].update(iodepth_details)
+                else:
+                    self._processed_data[operation][number_of_jobs].update(blocksize_details)
             else:
-                self._processed_data[operation].update(blocksize_details)
+                self._processed_data[operation].update(numjobs_details)
         else:
-            self._processed_data.update({operation: blocksize_details})
+            self._processed_data.update({operation: numjobs_details})

--- a/post_processing/run_results/run_result_factory.py
+++ b/post_processing/run_results/run_result_factory.py
@@ -1,0 +1,70 @@
+"""
+Factory for creating the appropriate RunResult subclass based on benchmark type.
+
+This module provides a factory method that determines which RunResult implementation
+to use based on the directory name, which should contain the benchmark type identifier.
+"""
+
+from logging import Logger, getLogger
+from pathlib import Path
+
+from post_processing.run_results.rbdfio import RBDFIO
+from post_processing.run_results.run_result import RunResult
+
+log: Logger = getLogger(name="formatter")
+
+
+# Map benchmark types to their RunResult classes
+# Currently only RBDFIO is implemented, but this can be extended
+BENCHMARK_TYPE_MAP: dict[str, type[RunResult]] = {
+    "rbdfio": RBDFIO,
+    "librbdfio": RBDFIO,  # LibrbdFio uses same result format as RbdFio
+    "kvmrbdfio": RBDFIO,  # KvmRbdFio uses same result format as RbdFio
+    "rawfio": RBDFIO,  # RawFio uses same result format as RbdFio
+    # Add more mappings as new RunResult subclasses are implemented
+    # 'radosbench': RadosBench,
+    # 'cosbench': CosBench,
+    # 'hsbench': HsBench,
+    # 'getput': GetPut,
+    # etc.
+}
+
+
+def get_run_result_from_directory_name(directory: Path, file_name_root: str) -> RunResult:
+    """
+    Create the appropriate RunResult subclass based on the directory name.
+
+    The directory name should contain the benchmark type name (e.g., 'rbdfio',
+    'librbdfio', 'kvmrbdfio', 'rawfio', 'radosbench', etc.) which corresponds
+    to the benchmark class name.
+
+    Args:
+        directory: Path to the directory containing benchmark results
+        file_name_root: Root name of the result files to process
+
+    Returns:
+        An instance of the appropriate RunResult subclass
+
+    Note:
+        If the benchmark type cannot be determined from the directory name,
+        a NotImplementedError will be raised
+    """
+    directory_str: str = ""
+    # We need to look at the directory that is inside the directory we are passed.
+    # For example, if we are passed /tmp/results/id-1234/precondition, we need to look at
+    # /tmp/results/id-1234/precondition/rbdfio to determine the benchmark type.
+    for entry in directory.iterdir():
+        if entry.is_dir():
+            directory_str = str(entry).lower()
+            break
+
+    # Try to find a matching benchmark type in the directory path
+    for benchmark_type, result_class in BENCHMARK_TYPE_MAP.items():
+        if benchmark_type in directory_str:
+            log.debug("Creating %s result processor for directory %s", result_class.__name__, directory)
+            return result_class(directory=directory, file_name_root=file_name_root)
+
+    raise NotImplementedError(f"Could not determine benchmark type from directory {directory}, ")
+
+
+# Made with Bob

--- a/tests/test_common_format_plotter.py
+++ b/tests/test_common_format_plotter.py
@@ -1,0 +1,723 @@
+"""
+Unit tests for the post_processing/plotter common_format_plotter module
+"""
+
+# pyright: strict, reportPrivateUsage=false
+#
+# We are OK to ignore private use in unit tests as the whole point of the tests
+# is to validate the functions contained in the module
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from matplotlib.axes import Axes
+
+from post_processing.plotter.common_format_plotter import (
+    BLOCKSIZE_THRESHOLD_KB,
+    BYTES_TO_MB_DIVISOR,
+    ERROR_BAR_CAP_SIZE,
+    KB_CONVERSION_FACTOR,
+    NANOSECONDS_TO_MS_DIVISOR,
+    CommonFormatPlotter,
+)
+from post_processing.plotter.cpu_plotter import CPUPlotter
+from post_processing.plotter.io_plotter import IOPlotter
+from post_processing.plotter.plot_data_results import PlotDataResult
+
+
+class ConcreteCommonFormatPlotter(CommonFormatPlotter):
+    """Concrete implementation for testing abstract base class"""
+
+    def draw_and_save(self) -> None:
+        """Dummy implementation"""
+        pass
+
+    def _generate_output_file_name(self, files: list) -> str:  # type: ignore[type-arg]
+        """Dummy implementation"""
+        return "test.svg"
+
+
+class TestCommonFormatPlotterConstants(unittest.TestCase):
+    """Test cases for module-level constants"""
+
+    def test_blocksize_threshold_kb(self) -> None:
+        """Test BLOCKSIZE_THRESHOLD_KB constant"""
+        self.assertEqual(BLOCKSIZE_THRESHOLD_KB, 64)
+
+    def test_bytes_to_mb_divisor(self) -> None:
+        """Test BYTES_TO_MB_DIVISOR constant"""
+        self.assertEqual(BYTES_TO_MB_DIVISOR, 1024 * 1024)
+
+    def test_nanoseconds_to_ms_divisor(self) -> None:
+        """Test NANOSECONDS_TO_MS_DIVISOR constant"""
+        self.assertEqual(NANOSECONDS_TO_MS_DIVISOR, 1_000_000)
+
+    def test_error_bar_cap_size(self) -> None:
+        """Test ERROR_BAR_CAP_SIZE constant"""
+        self.assertEqual(ERROR_BAR_CAP_SIZE, 3)
+
+    def test_kb_conversion_factor(self) -> None:
+        """Test KB_CONVERSION_FACTOR constant"""
+        self.assertEqual(KB_CONVERSION_FACTOR, 1024)
+
+
+class TestCommonFormatPlotterHelperMethods(unittest.TestCase):
+    """Test cases for CommonFormatPlotter helper methods"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        mock_plotter = MagicMock()
+        self.plotter = ConcreteCommonFormatPlotter(mock_plotter)
+
+    def test_calculate_blocksize_kb_small(self) -> None:
+        """Test _calculate_blocksize_kb with small blocksize"""
+        result = self.plotter._calculate_blocksize_kb("4096")
+        self.assertEqual(result, 4)
+
+    def test_calculate_blocksize_kb_medium(self) -> None:
+        """Test _calculate_blocksize_kb with medium blocksize"""
+        result = self.plotter._calculate_blocksize_kb("65536")
+        self.assertEqual(result, 64)
+
+    def test_calculate_blocksize_kb_large(self) -> None:
+        """Test _calculate_blocksize_kb with large blocksize"""
+        result = self.plotter._calculate_blocksize_kb("1048576")
+        self.assertEqual(result, 1024)
+
+    def test_should_use_bandwidth_below_threshold(self) -> None:
+        """Test _should_use_bandwidth returns False for blocksize below threshold"""
+        result = self.plotter._should_use_bandwidth(32)
+        self.assertFalse(result)
+
+    def test_should_use_bandwidth_at_threshold(self) -> None:
+        """Test _should_use_bandwidth returns True for blocksize at threshold"""
+        result = self.plotter._should_use_bandwidth(64)
+        self.assertTrue(result)
+
+    def test_should_use_bandwidth_above_threshold(self) -> None:
+        """Test _should_use_bandwidth returns True for blocksize above threshold"""
+        result = self.plotter._should_use_bandwidth(128)
+        self.assertTrue(result)
+
+    def test_convert_bandwidth_to_mb(self) -> None:
+        """Test _convert_bandwidth_to_mb conversion"""
+        # 100 MB in bytes = 100 * 1024 * 1024 = 104857600
+        result = self.plotter._convert_bandwidth_to_mb("104857600")
+        self.assertAlmostEqual(result, 100.0, places=2)
+
+    def test_convert_bandwidth_to_mb_fractional(self) -> None:
+        """Test _convert_bandwidth_to_mb with fractional result"""
+        # 1.5 MB in bytes = 1.5 * 1024 * 1024 = 1572864
+        result = self.plotter._convert_bandwidth_to_mb("1572864")
+        self.assertAlmostEqual(result, 1.5, places=2)
+
+    def test_convert_std_dev_to_ms(self) -> None:
+        """Test _convert_std_dev_to_ms conversion"""
+        # 5 ms in nanoseconds = 5 * 1000000 = 5000000
+        result = self.plotter._convert_std_dev_to_ms("5000000")
+        self.assertAlmostEqual(result, 5.0, places=2)
+
+    def test_convert_std_dev_to_ms_fractional(self) -> None:
+        """Test _convert_std_dev_to_ms with fractional result"""
+        # 2.5 ms in nanoseconds = 2.5 * 1000000 = 2500000
+        result = self.plotter._convert_std_dev_to_ms("2500000")
+        self.assertAlmostEqual(result, 2.5, places=2)
+
+    def test_extract_x_axis_data_small_blocksize(self) -> None:
+        """Test _extract_x_axis_data with small blocksize (uses IOPS)"""
+        data = {
+            "blocksize": "4096",  # 4KB
+            "bandwidth_bytes": "1000000",
+            "iops": "250.5",
+        }
+        x_value, x_label = self.plotter._extract_x_axis_data(data)
+        self.assertAlmostEqual(x_value, 250.5, places=2)
+        self.assertEqual(x_label, "IOps")
+
+    def test_extract_x_axis_data_large_blocksize(self) -> None:
+        """Test _extract_x_axis_data with large blocksize (uses bandwidth)"""
+        data = {
+            "blocksize": "131072",  # 128KB
+            "bandwidth_bytes": "104857600",  # 100 MB
+            "iops": "800",
+        }
+        x_value, x_label = self.plotter._extract_x_axis_data(data)
+        self.assertAlmostEqual(x_value, 100.0, places=2)
+        self.assertEqual(x_label, "Bandwidth (MB/s)")
+
+    def test_extract_x_axis_data_threshold_blocksize(self) -> None:
+        """Test _extract_x_axis_data at threshold blocksize (uses bandwidth)"""
+        data = {
+            "blocksize": "65536",  # 64KB (at threshold)
+            "bandwidth_bytes": "52428800",  # 50 MB
+            "iops": "800",
+        }
+        x_value, x_label = self.plotter._extract_x_axis_data(data)
+        self.assertAlmostEqual(x_value, 50.0, places=2)
+        self.assertEqual(x_label, "Bandwidth (MB/s)")
+
+    @patch("post_processing.plotter.common_format_plotter.log")
+    def test_validate_cpu_data_availability_with_cpu_data(self, mock_log: MagicMock) -> None:
+        """Test _validate_cpu_data_availability when CPU data exists"""
+        data = {"cpu": "45.5"}
+        result = self.plotter._validate_cpu_data_availability(data, True)
+        self.assertTrue(result)
+        mock_log.warning.assert_not_called()
+
+    @patch("post_processing.plotter.common_format_plotter.log")
+    def test_validate_cpu_data_availability_without_cpu_data(self, mock_log: MagicMock) -> None:
+        """Test _validate_cpu_data_availability when CPU data is missing"""
+        data = {"latency": "5000000"}
+        result = self.plotter._validate_cpu_data_availability(data, True)
+        self.assertFalse(result)
+        mock_log.warning.assert_called_once()
+        self.assertIn("CPU data not found", mock_log.warning.call_args[0][0])
+
+    @patch("post_processing.plotter.common_format_plotter.log")
+    def test_validate_cpu_data_availability_not_requested(self, mock_log: MagicMock) -> None:
+        """Test _validate_cpu_data_availability when resource plotting not requested"""
+        data = {"latency": "5000000"}
+        result = self.plotter._validate_cpu_data_availability(data, False)
+        self.assertFalse(result)
+        mock_log.warning.assert_not_called()
+
+    @patch("post_processing.plotter.common_format_plotter.CPUPlotter")
+    @patch("post_processing.plotter.common_format_plotter.IOPlotter")
+    def test_initialize_plotters_with_label(
+        self, mock_io_plotter_class: MagicMock, mock_cpu_plotter_class: MagicMock
+    ) -> None:
+        """Test _initialize_plotters with custom label"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+        mock_io_plotter_class.return_value = mock_io_plotter
+        mock_cpu_plotter_class.return_value = mock_cpu_plotter
+
+        io_plotter, cpu_plotter = self.plotter._initialize_plotters(mock_axes, "Custom Label")
+
+        self.assertEqual(io_plotter, mock_io_plotter)
+        self.assertEqual(cpu_plotter, mock_cpu_plotter)
+        self.assertEqual(io_plotter.y_label, "Latency (ms)")
+        self.assertEqual(io_plotter.plot_label, "Custom Label")
+
+    @patch("post_processing.plotter.common_format_plotter.CPUPlotter")
+    @patch("post_processing.plotter.common_format_plotter.IOPlotter")
+    def test_initialize_plotters_without_label(
+        self, mock_io_plotter_class: MagicMock, mock_cpu_plotter_class: MagicMock
+    ) -> None:
+        """Test _initialize_plotters with default label"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+        mock_io_plotter_class.return_value = mock_io_plotter
+        mock_cpu_plotter_class.return_value = mock_cpu_plotter
+
+        io_plotter, _ = self.plotter._initialize_plotters(mock_axes, None)
+
+        self.assertEqual(io_plotter.plot_label, "IO Details")
+
+    def test_extract_plot_data_with_error_bars(self) -> None:
+        """Test _extract_plot_data with error bars enabled"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        sorted_plot_data = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "250",
+                "latency": "5000000",
+                "std_deviation": "500000",
+            },
+            "2": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "2000000",
+                "iops": "500",
+                "latency": "4000000",
+                "std_deviation": "400000",
+            },
+        }
+
+        result = self.plotter._extract_plot_data(
+            sorted_plot_data, mock_axes, mock_io_plotter, mock_cpu_plotter, True, False
+        )
+
+        self.assertIsInstance(result, PlotDataResult)
+        self.assertEqual(len(result.x_data), 2)
+        self.assertEqual(len(result.error_bars), 2)
+        self.assertEqual(result.cap_size, ERROR_BAR_CAP_SIZE)
+        self.assertFalse(result.plot_resource_usage)
+        # Verify error bars are converted from ns to ms
+        self.assertAlmostEqual(result.error_bars[0], 0.5, places=2)
+        self.assertAlmostEqual(result.error_bars[1], 0.4, places=2)
+
+    def test_extract_plot_data_with_cpu_usage(self) -> None:
+        """Test _extract_plot_data with CPU usage enabled"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        sorted_plot_data = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "250",
+                "latency": "5000000",
+                "std_deviation": "500000",
+                "cpu": "45.5",
+            },
+        }
+
+        result = self.plotter._extract_plot_data(
+            sorted_plot_data, mock_axes, mock_io_plotter, mock_cpu_plotter, True, True
+        )
+
+        self.assertIsInstance(result, PlotDataResult)
+        self.assertTrue(result.plot_resource_usage)
+        self.assertEqual(result.cap_size, 0)  # No error bars when CPU is plotted
+        mock_cpu_plotter.add_y_data.assert_called_once_with("45.5")
+
+    def test_extract_plot_data_large_blocksize_uses_bandwidth(self) -> None:
+        """Test _extract_plot_data uses bandwidth for large blocksizes"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        sorted_plot_data = {
+            "1": {
+                "blocksize": "131072",  # 128KB
+                "bandwidth_bytes": "104857600",  # 100 MB
+                "iops": "800",
+                "latency": "5000000",
+                "std_deviation": "500000",
+            },
+        }
+
+        result = self.plotter._extract_plot_data(
+            sorted_plot_data, mock_axes, mock_io_plotter, mock_cpu_plotter, False, False
+        )
+
+        self.assertIsInstance(result, PlotDataResult)
+        # Should use bandwidth (100 MB)
+        self.assertAlmostEqual(result.x_data[0], 100.0, places=2)
+        mock_axes.set_xlabel.assert_called_once_with("Bandwidth (MB/s)")
+
+    def test_render_plots_with_error_bars(self) -> None:
+        """Test _render_plots with error bars"""
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        plot_result = PlotDataResult(
+            x_data=[100.0, 200.0],
+            error_bars=[0.5, 0.6],
+            cap_size=ERROR_BAR_CAP_SIZE,
+            plot_resource_usage=False,
+            x_label="IOps",
+        )
+
+        self.plotter._render_plots(mock_io_plotter, mock_cpu_plotter, plot_result)
+
+        mock_io_plotter.plot_with_error_bars.assert_called_once_with(
+            x_data=[100.0, 200.0], error_data=[0.5, 0.6], cap_size=ERROR_BAR_CAP_SIZE
+        )
+        mock_cpu_plotter.plot.assert_not_called()
+
+    def test_render_plots_with_cpu_usage(self) -> None:
+        """Test _render_plots with CPU usage"""
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        plot_result = PlotDataResult(
+            x_data=[100.0, 200.0], error_bars=[0.0, 0.0], cap_size=0, plot_resource_usage=True, x_label="IOps"
+        )
+
+        self.plotter._render_plots(mock_io_plotter, mock_cpu_plotter, plot_result)
+
+        mock_io_plotter.plot_with_error_bars.assert_called_once()
+        mock_cpu_plotter.plot.assert_called_once_with(x_data=[100.0, 200.0])
+
+    def test_calculate_error_bar_with_error_bars_enabled(self) -> None:
+        """Test _calculate_error_bar when error bars are enabled"""
+        data = {"std_deviation": "1000000"}  # 1ms in nanoseconds
+        result = self.plotter._calculate_error_bar(data, True, False)
+        self.assertAlmostEqual(result, 1.0, places=2)
+
+    def test_calculate_error_bar_with_error_bars_disabled(self) -> None:
+        """Test _calculate_error_bar when error bars are disabled"""
+        data = {"std_deviation": "1000000"}
+        result = self.plotter._calculate_error_bar(data, False, False)
+        self.assertEqual(result, 0.0)
+
+    def test_calculate_error_bar_with_resource_plotting(self) -> None:
+        """Test _calculate_error_bar when resource plotting is enabled"""
+        data = {"std_deviation": "1000000"}
+        result = self.plotter._calculate_error_bar(data, True, True)
+        self.assertEqual(result, 0.0)
+
+    def test_calculate_error_bar_missing_std_deviation(self) -> None:
+        """Test _calculate_error_bar with missing std_deviation field"""
+        data: dict[str, str] = {}
+        result = self.plotter._calculate_error_bar(data, True, False)
+        self.assertEqual(result, 0.0)
+
+    def test_extract_plot_data_empty_dataset(self) -> None:
+        """Test _extract_plot_data raises ValueError for empty dataset"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        with self.assertRaises(ValueError) as context:
+            self.plotter._extract_plot_data({}, mock_axes, mock_io_plotter, mock_cpu_plotter, False, False)
+        self.assertIn("empty dataset", str(context.exception))
+
+    def test_extract_plot_data_all_missing_latency_field(self) -> None:
+        """Test _extract_plot_data raises ValueError when all data points are invalid"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        sorted_plot_data = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "250",
+                # Missing "latency" field
+                "std_deviation": "500000",
+            },
+        }
+
+        with self.assertRaises(ValueError) as context:
+            self.plotter._extract_plot_data(
+                sorted_plot_data, mock_axes, mock_io_plotter, mock_cpu_plotter, False, False
+            )
+        self.assertIn("No valid data points", str(context.exception))
+
+    def test_extract_plot_data_partial_failure(self) -> None:
+        """Test _extract_plot_data continues processing after individual failures"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        sorted_plot_data = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "250",
+                # Missing "latency" field - should fail
+                "std_deviation": "500000",
+            },
+            "2": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "2000000",
+                "iops": "500",
+                "latency": "4000000",
+                "std_deviation": "400000",
+            },
+        }
+
+        result = self.plotter._extract_plot_data(
+            sorted_plot_data, mock_axes, mock_io_plotter, mock_cpu_plotter, False, False
+        )
+
+        # Should have extracted data from the second entry only
+        self.assertEqual(len(result.x_data), 1)
+        self.assertAlmostEqual(result.x_data[0], 500.0, places=2)
+
+    def test_extract_plot_data_x_label_fallback(self) -> None:
+        """Test _extract_plot_data provides fallback x_label"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        sorted_plot_data = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "250",
+                "latency": "5000000",
+                "std_deviation": "500000",
+            },
+        }
+
+        result = self.plotter._extract_plot_data(
+            sorted_plot_data, mock_axes, mock_io_plotter, mock_cpu_plotter, False, False
+        )
+
+        # Should have a valid x_label (not "Unknown" since data is valid)
+        self.assertIn(result.x_label, ["IOps", "Bandwidth (MB/s)"])
+
+    def test_extract_plot_data_invalid_latency_value(self) -> None:
+        """Test _extract_plot_data handles invalid latency values"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        sorted_plot_data = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "250",
+                "latency": "invalid",  # Invalid value
+                "std_deviation": "500000",
+            },
+            "2": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "2000000",
+                "iops": "500",
+                "latency": "4000000",
+                "std_deviation": "400000",
+            },
+        }
+
+        # Should skip invalid entry and process valid one
+        result = self.plotter._extract_plot_data(
+            sorted_plot_data, mock_axes, mock_io_plotter, mock_cpu_plotter, False, False
+        )
+
+        # Should have extracted data from the second entry only
+        self.assertEqual(len(result.x_data), 1)
+        self.assertAlmostEqual(result.x_data[0], 500.0, places=2)
+
+    @patch("post_processing.plotter.common_format_plotter.log")
+    def test_extract_plot_data_invalid_cpu_value(self, mock_log: MagicMock) -> None:
+        """Test _extract_plot_data handles invalid CPU values"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        sorted_plot_data = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "250",
+                "latency": "5000000",
+                "cpu": "invalid",  # Invalid CPU value
+            },
+            "2": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "2000000",
+                "iops": "500",
+                "latency": "4000000",
+                "cpu": "50.5",
+            },
+        }
+
+        result = self.plotter._extract_plot_data(
+            sorted_plot_data, mock_axes, mock_io_plotter, mock_cpu_plotter, False, True
+        )
+
+        # Should log warning about invalid CPU value
+        mock_log.warning.assert_called()
+        # Check for either the specific invalid CPU warning or the general CPU data not found warning
+        warning_message = str(mock_log.warning.call_args)
+        self.assertTrue(
+            "Invalid CPU value" in warning_message or "CPU data not found" in warning_message
+        )
+
+        # Should still process valid data
+        self.assertEqual(len(result.x_data), 2)
+
+    @patch("post_processing.plotter.common_format_plotter.log")
+    def test_extract_plot_data_missing_cpu_disables_resource_plotting(self, mock_log: MagicMock) -> None:
+        """Test that missing CPU data disables resource plotting with warning"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+
+        sorted_plot_data = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "250",
+                "latency": "5000000",
+                # Missing CPU data
+            },
+        }
+
+        result = self.plotter._extract_plot_data(
+            sorted_plot_data, mock_axes, mock_io_plotter, mock_cpu_plotter, False, True
+        )
+
+        # Should log warning about missing CPU data
+        mock_log.warning.assert_called()
+        warning_message = mock_log.warning.call_args[0][0]
+        self.assertIn("Unable to plot CPU usage", warning_message)
+        self.assertIn("CPU data not found", warning_message)
+
+        # Resource plotting should be disabled
+        self.assertFalse(result.plot_resource_usage)
+
+
+class TestCommonFormatPlotterTitleGeneration(unittest.TestCase):
+    """Test cases for title generation methods"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        mock_plotter = MagicMock()
+        self.plotter = ConcreteCommonFormatPlotter(mock_plotter)
+
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    def test_construct_title_from_list_single_blocksize(self, mock_get_details: MagicMock) -> None:
+        """Test title generation when all files have same blocksize"""
+        from pathlib import Path
+
+        mock_get_details.side_effect = [
+            ("4096", "100", "read", "1"),
+            ("4096", "50", "write", "1"),
+        ]
+
+        files = [Path("4096_100_read_1.json"), Path("4096_50_write_1.json")]
+        title = self.plotter._construct_title_from_list_of_file_names(files)
+
+        self.assertEqual(title, "4096 blocksize comparison")
+
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    def test_construct_title_from_list_single_operation_and_percentage(self, mock_get_details: MagicMock) -> None:
+        """Test title generation when operation and percentage are same"""
+        from pathlib import Path
+
+        mock_get_details.side_effect = [
+            ("4096", "100", "read", "1"),
+            ("8192", "100", "read", "1"),
+        ]
+
+        files = [Path("4096_100_read_1.json"), Path("8192_100_read_1.json")]
+        title = self.plotter._construct_title_from_list_of_file_names(files)
+
+        self.assertEqual(title, "100 read comparison")
+
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    def test_construct_title_from_list_single_operation(self, mock_get_details: MagicMock) -> None:
+        """Test title generation when only operation is same"""
+        from pathlib import Path
+
+        mock_get_details.side_effect = [
+            ("4096", "100", "read", "1"),
+            ("8192", "50", "read", "1"),
+        ]
+
+        files = [Path("4096_100_read_1.json"), Path("8192_50_read_1.json")]
+        title = self.plotter._construct_title_from_list_of_file_names(files)
+
+        self.assertEqual(title, "read comparison")
+
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    def test_construct_title_from_list_no_common_elements(self, mock_get_details: MagicMock) -> None:
+        """Test title generation when no common elements"""
+        from pathlib import Path
+
+        mock_get_details.side_effect = [
+            ("4096", "100", "read", "1"),
+            ("8192", "50", "write", "1"),
+        ]
+
+        files = [Path("4096_100_read_1.json"), Path("8192_50_write_1.json")]
+        title = self.plotter._construct_title_from_list_of_file_names(files)
+
+        self.assertIn("4096 100 read", title)
+        self.assertIn("Vs", title)
+        self.assertIn("8192 50 write", title)
+
+    def test_add_title_single_file(self) -> None:
+        """Test _add_title with single file"""
+        from pathlib import Path
+
+        with patch.object(self.plotter, "_construct_title_from_file_name", return_value="Test Title") as mock_construct:
+            self.plotter._add_title([Path("test.json")])
+            mock_construct.assert_called_once_with("test.json")
+            self.plotter._plotter.title.assert_called_once_with("Test Title")
+
+    def test_add_title_multiple_files(self) -> None:
+        """Test _add_title with multiple files"""
+        from pathlib import Path
+
+        files = [Path("test1.json"), Path("test2.json")]
+        with patch.object(
+            self.plotter, "_construct_title_from_list_of_file_names", return_value="Comparison Title"
+        ) as mock_construct:
+            self.plotter._add_title(files)
+            mock_construct.assert_called_once_with(files)
+            self.plotter._plotter.title.assert_called_once_with("Comparison Title")
+
+
+class TestCommonFormatPlotterAxisSettings(unittest.TestCase):
+    """Test cases for axis setting methods"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        mock_plotter = MagicMock()
+        self.plotter = ConcreteCommonFormatPlotter(mock_plotter)
+
+    def test_set_axis_with_maximum_values(self) -> None:
+        """Test _set_axis with explicit maximum values"""
+        self.plotter._set_axis(maximum_values=(100, 200))
+
+        self.plotter._plotter.xlim.assert_called_once_with(0, 100)
+        self.plotter._plotter.ylim.assert_called_once_with(0, 200)
+
+    def test_set_axis_without_maximum_values(self) -> None:
+        """Test _set_axis with auto-scaling (None)"""
+        self.plotter._set_axis(maximum_values=None)
+
+        self.plotter._plotter.xlim.assert_called_once_with(0, None)
+        self.plotter._plotter.ylim.assert_called_once_with(0, None)
+
+
+class TestCommonFormatPlotterIntegration(unittest.TestCase):
+    """Integration tests for the refactored method"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        mock_plotter = MagicMock()
+        self.plotter = ConcreteCommonFormatPlotter(mock_plotter)
+
+    @patch("post_processing.plotter.common_format_plotter.CPUPlotter")
+    @patch("post_processing.plotter.common_format_plotter.IOPlotter")
+    def test_add_single_file_data_complete_flow(
+        self, mock_io_plotter_class: MagicMock, mock_cpu_plotter_class: MagicMock
+    ) -> None:
+        """Test complete flow of _add_single_file_data_with_optional_errorbars"""
+        mock_axes = MagicMock(spec=Axes)
+        mock_io_plotter = MagicMock(spec=IOPlotter)
+        mock_cpu_plotter = MagicMock(spec=CPUPlotter)
+        mock_io_plotter_class.return_value = mock_io_plotter
+        mock_cpu_plotter_class.return_value = mock_cpu_plotter
+
+        file_data = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "250",
+                "latency": "5000000",
+                "std_deviation": "500000",
+            },
+            "2": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "2000000",
+                "iops": "500",
+                "latency": "4000000",
+                "std_deviation": "400000",
+            },
+        }
+
+        self.plotter._add_single_file_data_with_optional_errorbars(
+            file_data=file_data,  # type: ignore[arg-type]
+            main_axes=mock_axes,
+            plot_error_bars=True,
+            plot_resource_usage=False,
+            label="Test",
+        )
+
+        # Verify plotters were initialized
+        mock_io_plotter_class.assert_called_once()
+        mock_cpu_plotter_class.assert_called_once()
+
+        # Verify data was added
+        self.assertEqual(mock_io_plotter.add_y_data.call_count, 2)
+
+        # Verify plot was rendered
+        mock_io_plotter.plot_with_error_bars.assert_called_once()
+
+
+# Made with Bob

--- a/tests/test_comparison_report_generator.py
+++ b/tests/test_comparison_report_generator.py
@@ -133,6 +133,8 @@ class TestComparisonReportGenerator(unittest.TestCase):
 
         header, justification = generator._generate_table_headers()
 
+        # Should include numjobs column
+        self.assertIn("numjobs", header)
         # Should include baseline directory name
         self.assertIn("baseline", header)
         # Should include comparison directory name
@@ -141,9 +143,9 @@ class TestComparisonReportGenerator(unittest.TestCase):
         self.assertIn("%change", header)
         
         # Test justification string for two directories
-        # Format: | :--- | ---: | ---: | ---: | ---: |
-        # (left-aligned first column, right-aligned for baseline, comparison, %change throughput, %change latency)
-        self.assertEqual(justification, "| :--- | ---: | ---: | ---: | ---: |")
+        # Format: | :--- | ---: | ---: | ---: | ---: | ---: |
+        # (left-aligned operation, right-aligned numjobs, baseline, comparison, %change throughput, %change latency)
+        self.assertEqual(justification, "| :--- | ---: | ---: | ---: | ---: | ---: |")
 
     def test_generate_table_headers_multiple_directories(self) -> None:
         """Test generating table headers for more than two directories"""
@@ -162,15 +164,17 @@ class TestComparisonReportGenerator(unittest.TestCase):
 
         header, justification = generator._generate_table_headers()
 
+        # Should include numjobs column
+        self.assertIn("numjobs", header)
         # Should have all directory names
         self.assertIn("baseline", header)
         self.assertIn("comparison", header)
         self.assertIn("comparison2", header)
         
         # Test justification string for multiple directories (3+ total)
-        # Format: | :--- | ---: | ---: | ---: | ---: | ---: |
-        # (left-aligned first column, right-aligned for baseline, then comparison + %change for each comparison dir)
-        self.assertEqual(justification, "| :--- | ---: | ---: | ---: | ---: | ---: |")
+        # Format: | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
+        # (left-aligned operation, right-aligned numjobs, baseline, then comparison + %change for each comparison dir)
+        self.assertEqual(justification, "| :--- | ---: | ---: | ---: | ---: | ---: | ---: |")
 
     @patch("subprocess.check_output")
     def test_yaml_file_has_more_than_20_differences_true(self, mock_check_output: MagicMock) -> None:

--- a/tests/test_comparison_report_generator.py
+++ b/tests/test_comparison_report_generator.py
@@ -34,8 +34,9 @@ class TestComparisonReportGenerator(unittest.TestCase):
         self.vis2.mkdir(parents=True)
 
         # Create matching data files in both
-        (self.vis1 / "4096_read.json").touch()
-        (self.vis2 / "4096_read.json").touch()
+        # Format: {blocksize}_{numjobs}_{operation}.json
+        (self.vis1 / "4096_1_read.json").touch()
+        (self.vis2 / "4096_1_read.json").touch()
 
     def tearDown(self) -> None:
         """Clean up test fixtures"""
@@ -86,8 +87,9 @@ class TestComparisonReportGenerator(unittest.TestCase):
     def test_find_and_sort_file_paths_multiple_directories(self) -> None:
         """Test finding files across multiple directories"""
         # Create additional files
-        (self.vis1 / "8192_write.json").touch()
-        (self.vis2 / "8192_write.json").touch()
+        # Format: {blocksize}_{numjobs}_{operation}.json
+        (self.vis1 / "8192_1_write.json").touch()
+        (self.vis2 / "8192_1_write.json").touch()
 
         output_dir = f"{self.temp_dir}/output"
 
@@ -148,7 +150,8 @@ class TestComparisonReportGenerator(unittest.TestCase):
         archive3 = Path(self.temp_dir) / "comparison2"
         vis3 = archive3 / "visualisation"
         vis3.mkdir(parents=True)
-        (vis3 / "4096_read.json").touch()
+        # Format: {blocksize}_{numjobs}_{operation}.json
+        (vis3 / "4096_1_read.json").touch()
 
         output_dir = f"{self.temp_dir}/output"
 

--- a/tests/test_directory_comparison_plotter.py
+++ b/tests/test_directory_comparison_plotter.py
@@ -1,0 +1,300 @@
+"""
+Unit tests for the DirectoryComparisonPlotter class
+"""
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from post_processing.plotter.directory_comparison_plotter import DirectoryComparisonPlotter
+
+
+class TestDirectoryComparisonPlotter(unittest.TestCase):
+    """Test suite for DirectoryComparisonPlotter class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.output_dir = Path(self.temp_dir) / "output"
+        self.output_dir.mkdir(parents=True)
+
+        # Create test directory structures
+        self.dir1 = Path(self.temp_dir) / "test1"
+        self.dir2 = Path(self.temp_dir) / "test2"
+        self.vis_dir1 = self.dir1 / "visualisation"
+        self.vis_dir2 = self.dir2 / "visualisation"
+        self.vis_dir1.mkdir(parents=True)
+        self.vis_dir2.mkdir(parents=True)
+
+        # Create common test data files
+        self.test_file1 = self.vis_dir1 / "4096_100_read_1.json"
+        self.test_file2 = self.vis_dir2 / "4096_100_read_1.json"
+        self.test_file1.touch()
+        self.test_file2.touch()
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_initialization(self) -> None:
+        """Test DirectoryComparisonPlotter initialization"""
+        directories = [str(self.dir1), str(self.dir2)]
+        plotter = DirectoryComparisonPlotter(output_directory=str(self.output_dir), directories=directories)
+
+        assert plotter._output_directory == str(self.output_dir)
+        assert len(plotter._comparison_directories) == 2
+        assert plotter._comparison_directories[0] == self.vis_dir1
+        assert plotter._comparison_directories[1] == self.vis_dir2
+
+    def test_generate_output_file_name(self) -> None:
+        """Test generating output file name"""
+        directories = [str(self.dir1), str(self.dir2)]
+        plotter = DirectoryComparisonPlotter(output_directory=str(self.output_dir), directories=directories)
+
+        test_file = Path("4096_100_read_1.json")
+        output_name = plotter._generate_output_file_name([test_file])
+
+        expected = f"{self.output_dir}/Comparison_4096_100_read_1.svg"
+        assert output_name == expected
+
+    @patch("post_processing.plotter.directory_comparison_plotter.find_common_data_file_names")
+    @patch("post_processing.plotter.directory_comparison_plotter.read_intermediate_file")
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("matplotlib.pyplot.subplots")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.close")
+    def test_draw_and_save_single_common_file(
+        self,
+        mock_close: MagicMock,
+        mock_savefig: MagicMock,
+        mock_subplots: MagicMock,
+        mock_get_details: MagicMock,
+        mock_read_file: MagicMock,
+        mock_find_common: MagicMock,
+    ) -> None:
+        """Test draw_and_save with single common file"""
+        directories = [str(self.dir1), str(self.dir2)]
+        plotter = DirectoryComparisonPlotter(output_directory=str(self.output_dir), directories=directories)
+
+        # Mock common file names
+        mock_find_common.return_value = ["4096_100_read_1.json"]
+
+        # Mock file name parsing
+        mock_get_details.return_value = ("4096", "100", "read", "1")
+
+        # Mock file data
+        mock_read_file.return_value = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "100",
+                "latency": "5000000",
+                "std_deviation": "500000",
+            },
+            "maximum_iops": "100",
+        }
+
+        # Mock matplotlib
+        mock_figure = MagicMock()
+        mock_axes = MagicMock()
+        mock_subplots.return_value = (mock_figure, mock_axes)
+
+        plotter.draw_and_save()
+
+        # Should find common files
+        mock_find_common.assert_called_once()
+
+        # Should read file from both directories
+        assert mock_read_file.call_count == 2
+
+        # Should create subplots once (one plot for the common file)
+        mock_subplots.assert_called_once()
+
+        # Should save the plot once
+        mock_savefig.assert_called_once()
+
+        # Should close the plot
+        assert mock_close.call_count >= 1
+
+    @patch("post_processing.plotter.directory_comparison_plotter.find_common_data_file_names")
+    @patch("post_processing.plotter.directory_comparison_plotter.read_intermediate_file")
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("matplotlib.pyplot.subplots")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.close")
+    def test_draw_and_save_multiple_common_files(
+        self,
+        mock_close: MagicMock,
+        mock_savefig: MagicMock,
+        mock_subplots: MagicMock,
+        mock_get_details: MagicMock,
+        mock_read_file: MagicMock,
+        mock_find_common: MagicMock,
+    ) -> None:
+        """Test draw_and_save with multiple common files"""
+        directories = [str(self.dir1), str(self.dir2)]
+        plotter = DirectoryComparisonPlotter(output_directory=str(self.output_dir), directories=directories)
+
+        # Mock multiple common file names
+        mock_find_common.return_value = ["4096_100_read_1.json", "8192_100_write_1.json"]
+
+        # Mock file name parsing
+        mock_get_details.return_value = ("4096", "100", "read", "1")
+
+        # Mock file data
+        mock_read_file.return_value = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "100",
+                "latency": "5000000",
+            },
+        }
+
+        # Mock matplotlib
+        mock_figure = MagicMock()
+        mock_axes = MagicMock()
+        mock_subplots.return_value = (mock_figure, mock_axes)
+
+        plotter.draw_and_save()
+
+        # Should read file from both directories for each common file (2 files * 2 dirs = 4 reads)
+        assert mock_read_file.call_count == 4
+
+        # Should create subplots twice (one for each common file)
+        assert mock_subplots.call_count == 2
+
+        # Should save the plot twice
+        assert mock_savefig.call_count == 2
+
+    @patch("post_processing.plotter.directory_comparison_plotter.find_common_data_file_names")
+    @patch("post_processing.plotter.directory_comparison_plotter.read_intermediate_file")
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("matplotlib.pyplot.subplots")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.close")
+    def test_draw_and_save_no_error_bars(
+        self,
+        mock_close: MagicMock,
+        mock_savefig: MagicMock,
+        mock_subplots: MagicMock,
+        mock_get_details: MagicMock,
+        mock_read_file: MagicMock,
+        mock_find_common: MagicMock,
+    ) -> None:
+        """Test that error bars are not plotted in comparison mode"""
+        directories = [str(self.dir1), str(self.dir2)]
+        plotter = DirectoryComparisonPlotter(output_directory=str(self.output_dir), directories=directories)
+
+        # Mock common file names
+        mock_find_common.return_value = ["4096_100_read_1.json"]
+
+        # Mock file name parsing
+        mock_get_details.return_value = ("4096", "100", "read", "1")
+
+        # Mock file data with std_deviation
+        mock_read_file.return_value = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "100",
+                "latency": "5000000",
+                "std_deviation": "500000",
+            },
+        }
+
+        # Mock matplotlib
+        mock_figure = MagicMock()
+        mock_axes = MagicMock()
+        mock_subplots.return_value = (mock_figure, mock_axes)
+
+        plotter.draw_and_save()
+
+        # Verify that the plotter completed successfully
+        # (plot is called on a twinx axis, not the main axes directly)
+        mock_savefig.assert_called_once()
+
+    @patch("post_processing.plotter.directory_comparison_plotter.find_common_data_file_names")
+    @patch("post_processing.plotter.directory_comparison_plotter.read_intermediate_file")
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("matplotlib.pyplot.subplots")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.close")
+    def test_draw_and_save_adds_legend(
+        self,
+        mock_close: MagicMock,
+        mock_savefig: MagicMock,
+        mock_subplots: MagicMock,
+        mock_get_details: MagicMock,
+        mock_read_file: MagicMock,
+        mock_find_common: MagicMock,
+    ) -> None:
+        """Test that legend is added to the plot"""
+        directories = [str(self.dir1), str(self.dir2)]
+        plotter = DirectoryComparisonPlotter(output_directory=str(self.output_dir), directories=directories)
+
+        # Mock common file names
+        mock_find_common.return_value = ["4096_100_read_1.json"]
+
+        # Mock file name parsing
+        mock_get_details.return_value = ("4096", "100", "read", "1")
+
+        # Mock file data
+        mock_read_file.return_value = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "100",
+                "latency": "5000000",
+            },
+        }
+
+        # Mock matplotlib
+        mock_figure = MagicMock()
+        mock_axes = MagicMock()
+        mock_subplots.return_value = (mock_figure, mock_axes)
+
+        plotter.draw_and_save()
+
+        # Verify legend was added
+        mock_figure.legend.assert_called_once()
+
+    @patch("post_processing.plotter.directory_comparison_plotter.find_common_data_file_names")
+    def test_draw_and_save_no_common_files(
+        self,
+        mock_find_common: MagicMock,
+    ) -> None:
+        """Test draw_and_save when no common files exist"""
+        directories = [str(self.dir1), str(self.dir2)]
+        plotter = DirectoryComparisonPlotter(output_directory=str(self.output_dir), directories=directories)
+
+        # Mock no common file names
+        mock_find_common.return_value = []
+
+        # Should not raise an error, just do nothing
+        plotter.draw_and_save()
+
+        # Should find common files
+        mock_find_common.assert_called_once()
+
+    def test_uses_directory_name_as_label(self) -> None:
+        """Test that directory names are used as labels in the plot"""
+        # Create directories with meaningful names
+        baseline_dir = Path(self.temp_dir) / "baseline"
+        optimized_dir = Path(self.temp_dir) / "optimized"
+        baseline_vis = baseline_dir / "visualisation"
+        optimized_vis = optimized_dir / "visualisation"
+        baseline_vis.mkdir(parents=True)
+        optimized_vis.mkdir(parents=True)
+
+        directories = [str(baseline_dir), str(optimized_dir)]
+        plotter = DirectoryComparisonPlotter(output_directory=str(self.output_dir), directories=directories)
+
+        # Verify the comparison directories are set correctly
+        assert plotter._comparison_directories[0] == baseline_vis
+        assert plotter._comparison_directories[1] == optimized_vis
+
+
+# Made with Bob

--- a/tests/test_file_comparison_plotter.py
+++ b/tests/test_file_comparison_plotter.py
@@ -1,0 +1,273 @@
+"""
+Unit tests for the FileComparisonPlotter class
+"""
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from post_processing.plotter.file_comparison_plotter import FileComparisonPlotter
+
+
+class TestFileComparisonPlotter(unittest.TestCase):
+    """Test suite for FileComparisonPlotter class"""
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.output_dir = Path(self.temp_dir) / "output"
+        self.output_dir.mkdir(parents=True)
+
+        # Create test data files
+        self.test_file1 = Path(self.temp_dir) / "4096_100_read_1.json"
+        self.test_file2 = Path(self.temp_dir) / "4096_100_write_1.json"
+        self.test_file1.touch()
+        self.test_file2.touch()
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_initialization(self) -> None:
+        """Test FileComparisonPlotter initialization"""
+        files = [str(self.test_file1), str(self.test_file2)]
+        plotter = FileComparisonPlotter(output_directory=str(self.output_dir), files=files)
+
+        assert plotter._output_directory == str(self.output_dir)
+        assert len(plotter._comparison_files) == 2
+        assert plotter._comparison_files[0] == self.test_file1
+        assert plotter._comparison_files[1] == self.test_file2
+        assert plotter._labels is None
+
+    def test_set_labels(self) -> None:
+        """Test setting custom labels for plot lines"""
+        files = [str(self.test_file1), str(self.test_file2)]
+        plotter = FileComparisonPlotter(output_directory=str(self.output_dir), files=files)
+
+        labels = ["Test 1", "Test 2"]
+        plotter.set_labels(labels)
+
+        assert plotter._labels == labels
+
+    def test_generate_output_file_name_single_file(self) -> None:
+        """Test generating output file name with single file"""
+        files = [str(self.test_file1)]
+        plotter = FileComparisonPlotter(output_directory=str(self.output_dir), files=files)
+
+        output_name = plotter._generate_output_file_name([self.test_file1])
+
+        expected = f"{self.output_dir}/Comparison_4096_100_read_1.svg"
+        assert output_name == expected
+
+    def test_generate_output_file_name_multiple_files(self) -> None:
+        """Test generating output file name with multiple files"""
+        files = [str(self.test_file1), str(self.test_file2)]
+        plotter = FileComparisonPlotter(output_directory=str(self.output_dir), files=files)
+
+        output_name = plotter._generate_output_file_name([self.test_file1, self.test_file2])
+
+        expected = f"{self.output_dir}/Comparison_4096_100_read_1_4096_100_write_1.svg"
+        assert output_name == expected
+
+    @patch("post_processing.plotter.file_comparison_plotter.read_intermediate_file")
+    @patch("post_processing.plotter.file_comparison_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("matplotlib.pyplot.subplots")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.close")
+    def test_draw_and_save_without_labels(
+        self,
+        mock_close: MagicMock,
+        mock_savefig: MagicMock,
+        mock_subplots: MagicMock,
+        mock_get_details_common: MagicMock,
+        mock_get_details: MagicMock,
+        mock_read_file: MagicMock,
+    ) -> None:
+        """Test draw_and_save method without custom labels"""
+        files = [str(self.test_file1), str(self.test_file2)]
+        plotter = FileComparisonPlotter(output_directory=str(self.output_dir), files=files)
+
+        # Mock file name parsing (both locations where it's called)
+        mock_get_details.return_value = ("4096", "100", "read", "1")
+        mock_get_details_common.return_value = ("4096", "100", "read", "1")
+
+        # Mock file data
+        mock_read_file.return_value = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "100",
+                "latency": "5000000",
+                "std_deviation": "500000",
+            },
+            "maximum_iops": "100",
+        }
+
+        # Mock matplotlib
+        mock_figure = MagicMock()
+        mock_axes = MagicMock()
+        mock_subplots.return_value = (mock_figure, mock_axes)
+
+        plotter.draw_and_save()
+
+        # Should read both files
+        assert mock_read_file.call_count == 2
+
+        # Should create subplots once
+        mock_subplots.assert_called_once()
+
+        # Should save the plot once
+        mock_savefig.assert_called_once()
+
+        # Should close the plot
+        assert mock_close.call_count >= 1
+
+    @patch("post_processing.plotter.file_comparison_plotter.read_intermediate_file")
+    @patch("post_processing.plotter.file_comparison_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("matplotlib.pyplot.subplots")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.close")
+    def test_draw_and_save_with_labels(
+        self,
+        mock_close: MagicMock,
+        mock_savefig: MagicMock,
+        mock_subplots: MagicMock,
+        mock_get_details_common: MagicMock,
+        mock_get_details: MagicMock,
+        mock_read_file: MagicMock,
+    ) -> None:
+        """Test draw_and_save method with custom labels"""
+        files = [str(self.test_file1), str(self.test_file2)]
+        plotter = FileComparisonPlotter(output_directory=str(self.output_dir), files=files)
+
+        # Set custom labels
+        labels = ["Baseline", "Optimized"]
+        plotter.set_labels(labels)
+
+        # Mock file name parsing (both locations where it's called)
+        mock_get_details.return_value = ("4096", "100", "read", "1")
+        mock_get_details_common.return_value = ("4096", "100", "read", "1")
+
+        # Mock file data
+        mock_read_file.return_value = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "100",
+                "latency": "5000000",
+                "std_deviation": "500000",
+            },
+            "maximum_iops": "100",
+        }
+
+        # Mock matplotlib
+        mock_figure = MagicMock()
+        mock_axes = MagicMock()
+        mock_subplots.return_value = (mock_figure, mock_axes)
+
+        plotter.draw_and_save()
+
+        # Should read both files
+        assert mock_read_file.call_count == 2
+
+        # Should create subplots once
+        mock_subplots.assert_called_once()
+
+        # Should save the plot once
+        mock_savefig.assert_called_once()
+
+    @patch("post_processing.plotter.file_comparison_plotter.read_intermediate_file")
+    @patch("post_processing.plotter.file_comparison_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("matplotlib.pyplot.subplots")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.close")
+    def test_draw_and_save_no_error_bars(
+        self,
+        mock_close: MagicMock,
+        mock_savefig: MagicMock,
+        mock_subplots: MagicMock,
+        mock_get_details_common: MagicMock,
+        mock_get_details: MagicMock,
+        mock_read_file: MagicMock,
+    ) -> None:
+        """Test that error bars are not plotted in comparison mode"""
+        files = [str(self.test_file1)]
+        plotter = FileComparisonPlotter(output_directory=str(self.output_dir), files=files)
+
+        # Mock file name parsing (both locations where it's called)
+        mock_get_details.return_value = ("4096", "100", "read", "1")
+        mock_get_details_common.return_value = ("4096", "100", "read", "1")
+
+        # Mock file data with std_deviation
+        mock_read_file.return_value = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "100",
+                "latency": "5000000",
+                "std_deviation": "500000",
+            },
+            "maximum_iops": "100",
+        }
+
+        # Mock matplotlib
+        mock_figure = MagicMock()
+        mock_axes = MagicMock()
+        mock_subplots.return_value = (mock_figure, mock_axes)
+
+        plotter.draw_and_save()
+
+        # Verify that the plotter completed successfully
+        # (plot is called on a twinx axis, not the main axes directly)
+        mock_savefig.assert_called_once()
+
+    @patch("post_processing.plotter.file_comparison_plotter.read_intermediate_file")
+    @patch("post_processing.plotter.file_comparison_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("post_processing.plotter.common_format_plotter.get_blocksize_percentage_operation_numjobs_from_file_name")
+    @patch("matplotlib.pyplot.subplots")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.close")
+    def test_draw_and_save_adds_legend(
+        self,
+        mock_close: MagicMock,
+        mock_savefig: MagicMock,
+        mock_subplots: MagicMock,
+        mock_get_details_common: MagicMock,
+        mock_get_details: MagicMock,
+        mock_read_file: MagicMock,
+    ) -> None:
+        """Test that legend is added to the plot"""
+        files = [str(self.test_file1), str(self.test_file2)]
+        plotter = FileComparisonPlotter(output_directory=str(self.output_dir), files=files)
+
+        # Mock file name parsing (both locations where it's called)
+        mock_get_details.return_value = ("4096", "100", "read", "1")
+        mock_get_details_common.return_value = ("4096", "100", "read", "1")
+
+        # Mock file data
+        mock_read_file.return_value = {
+            "1": {
+                "blocksize": "4096",
+                "bandwidth_bytes": "1000000",
+                "iops": "100",
+                "latency": "5000000",
+            },
+        }
+
+        # Mock matplotlib
+        mock_figure = MagicMock()
+        mock_axes = MagicMock()
+        mock_subplots.return_value = (mock_figure, mock_axes)
+
+        plotter.draw_and_save()
+
+        # Verify legend was added
+        mock_figure.legend.assert_called_once()
+
+
+# Made with Bob

--- a/tests/test_memory_plotter.py
+++ b/tests/test_memory_plotter.py
@@ -1,0 +1,111 @@
+"""
+Unit tests for the MemoryPlotter class
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from post_processing.plotter.memory_plotter import (
+    MEMORY_PLOT_DEFAULT_COLOUR,
+    MEMORY_PLOT_LABEL,
+    MEMORY_Y_LABEL,
+    MemoryPlotter,
+)
+
+
+class TestMemoryPlotter:
+    """Test suite for MemoryPlotter class"""
+
+    def test_initialization(self) -> None:
+        """Test that MemoryPlotter initializes correctly"""
+        mock_axes = MagicMock()
+        plotter = MemoryPlotter(main_axis=mock_axes)
+
+        assert plotter._main_axes == mock_axes
+        assert plotter._y_data == []
+        assert plotter._label == ""
+        assert plotter._y_label == ""
+
+    def test_memory_constants(self) -> None:
+        """Test that memory constants are defined correctly"""
+        assert MEMORY_PLOT_DEFAULT_COLOUR == "#4b006e"
+        assert MEMORY_Y_LABEL == "Memory use (Mb)"
+        assert MEMORY_PLOT_LABEL == "Memory use"
+
+    def test_add_y_data(self) -> None:
+        """Test adding memory data points"""
+        mock_axes = MagicMock()
+        plotter = MemoryPlotter(main_axis=mock_axes)
+
+        plotter.add_y_data("100.5")
+        plotter.add_y_data("200.75")
+        plotter.add_y_data("150.25")
+
+        assert plotter._y_data == [100.5, 200.75, 150.25]
+
+    def test_add_y_data_converts_string_to_float(self) -> None:
+        """Test that add_y_data converts string values to float"""
+        mock_axes = MagicMock()
+        plotter = MemoryPlotter(main_axis=mock_axes)
+
+        plotter.add_y_data("42")
+        assert plotter._y_data == [42.0]
+        assert isinstance(plotter._y_data[0], float)
+
+    def test_plot(self) -> None:
+        """Test plotting memory data"""
+        mock_main_axes = MagicMock()
+        mock_memory_axes = MagicMock()
+        mock_main_axes.twinx.return_value = mock_memory_axes
+
+        plotter = MemoryPlotter(main_axis=mock_main_axes)
+        plotter.add_y_data("100")
+        plotter.add_y_data("200")
+
+        x_data: list[float] = [1.0, 2.0]
+        plotter.plot(x_data=x_data)
+
+        # Verify twinx was called to create secondary axis
+        mock_main_axes.twinx.assert_called_once()
+
+        # Verify labels were set
+        assert plotter._label == MEMORY_PLOT_LABEL
+        assert plotter._y_label == MEMORY_Y_LABEL
+
+        # Verify plot was called on the memory axis
+        mock_memory_axes.plot.assert_called_once()
+
+    def test_plot_with_custom_colour_ignored(self) -> None:
+        """Test that custom colour parameter is ignored and default is used"""
+        mock_main_axes = MagicMock()
+        mock_memory_axes = MagicMock()
+        mock_main_axes.twinx.return_value = mock_memory_axes
+
+        plotter = MemoryPlotter(main_axis=mock_main_axes)
+        plotter.add_y_data("100")
+
+        x_data: list[float] = [1.0]
+        # Pass a custom colour, but it should be ignored
+        plotter.plot(x_data=x_data, colour="#FF0000")
+
+        # Verify the default colour is used
+        call_args = mock_memory_axes.plot.call_args
+        assert MEMORY_PLOT_DEFAULT_COLOUR in str(call_args)
+
+    def test_plot_sets_y_label_on_axis(self) -> None:
+        """Test that plot sets the y-axis label"""
+        mock_main_axes = MagicMock()
+        mock_memory_axes = MagicMock()
+        mock_main_axes.twinx.return_value = mock_memory_axes
+
+        plotter = MemoryPlotter(main_axis=mock_main_axes)
+        plotter.add_y_data("100")
+
+        x_data: list[float] = [1.0]
+        plotter.plot(x_data=x_data)
+
+        # Verify set_ylabel was called with correct label
+        mock_memory_axes.set_ylabel.assert_called_once_with(MEMORY_Y_LABEL)
+
+# Made with Bob

--- a/tests/test_post_processing_common.py
+++ b/tests/test_post_processing_common.py
@@ -15,7 +15,7 @@ from post_processing.common import (
     file_is_precondition,
     find_common_data_file_names,
     get_blocksize,
-    get_blocksize_percentage_operation_from_file_name,
+    get_blocksize_percentage_operation_numjobs_from_file_name,
     get_date_time_string,
     get_latency_throughput_from_file,
     get_resource_details_from_file,
@@ -31,25 +31,32 @@ class TestCommonFunctions(unittest.TestCase):
     """Test cases for common.py utility functions"""
 
     def test_get_blocksize_percentage_operation_from_file_name_simple(self) -> None:
-        """Test parsing simple filename format: BLOCKSIZE_OPERATION"""
-        blocksize, read_percent, operation = get_blocksize_percentage_operation_from_file_name("4096_read")
+        """Test parsing simple filename format: BLOCKSIZE_NUMJOBS_OPERATION"""
+        blocksize, read_percent, operation, number_of_jobs = get_blocksize_percentage_operation_numjobs_from_file_name("4096_1_read")
         self.assertEqual(blocksize, "4K")
         self.assertEqual(read_percent, "")
         self.assertEqual(operation, "Sequential Read")
+        self.assertEqual(number_of_jobs, "1")
 
     def test_get_blocksize_percentage_operation_from_file_name_with_percentage(self) -> None:
-        """Test parsing filename with read/write percentage: BLOCKSIZE_READ_WRITE_OPERATION"""
-        blocksize, read_percent, operation = get_blocksize_percentage_operation_from_file_name("4096_70_30_randrw")
+        """Test parsing filename with read/write percentage: BLOCKSIZE_NUMJOBS_READ_WRITE_OPERATION"""
+        blocksize, read_percent, operation, number_of_jobs = get_blocksize_percentage_operation_numjobs_from_file_name(
+            "4096_1_70_30_randrw"
+        )
         self.assertEqual(blocksize, "4K")
         self.assertEqual(read_percent, "70/30 ")
         self.assertEqual(operation, "Random Read/Write")
+        self.assertEqual(number_of_jobs, "1")
 
     def test_get_blocksize_percentage_operation_from_file_name_randwrite(self) -> None:
         """Test parsing randwrite operation"""
-        blocksize, read_percent, operation = get_blocksize_percentage_operation_from_file_name("8192_randwrite")
+        blocksize, read_percent, operation, number_of_jobs = get_blocksize_percentage_operation_numjobs_from_file_name(
+            "8192_2_randwrite"
+        )
         self.assertEqual(blocksize, "8K")
         self.assertEqual(read_percent, "")
         self.assertEqual(operation, "Random Write")
+        self.assertEqual(number_of_jobs, "2")
 
     def test_read_intermediate_file_success(self) -> None:
         """Test successfully reading an intermediate JSON file"""

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -27,8 +27,9 @@ class TestReportGenerator(unittest.TestCase):
         self.vis_dir.mkdir(parents=True)
 
         # Create some test data files
-        (self.vis_dir / "4096_read.json").touch()
-        (self.vis_dir / "8192_write.json").touch()
+        # Format: {blocksize}_{numjobs}_{operation}.json
+        (self.vis_dir / "4096_1_read.json").touch()
+        (self.vis_dir / "8192_1_write.json").touch()
 
     def tearDown(self) -> None:
         """Clean up test fixtures"""
@@ -85,7 +86,8 @@ class TestReportGenerator(unittest.TestCase):
         archive_with_underscores = Path(self.temp_dir) / "test_archive_name"
         vis_dir = archive_with_underscores / "visualisation"
         vis_dir.mkdir(parents=True)
-        (vis_dir / "4096_read.json").touch()
+        # Format: {blocksize}_{numjobs}_{operation}.json
+        (vis_dir / "4096_1_read.json").touch()
 
         output_dir = f"{self.temp_dir}/output"
 
@@ -106,16 +108,17 @@ class TestReportGenerator(unittest.TestCase):
             output_directory=output_dir,
         )
 
-        files = generator._find_files_with_filename("4096_read")
+        files = generator._find_files_with_filename("4096_1_read")
 
         self.assertEqual(len(files), 1)
-        self.assertTrue(str(files[0]).endswith("4096_read.json"))
+        self.assertTrue(str(files[0]).endswith("4096_1_read.json"))
 
     def test_sort_list_of_paths(self) -> None:
         """Test sorting paths by numeric blocksize"""
         # Create files with different blocksizes
-        (self.vis_dir / "16384_read.json").touch()
-        (self.vis_dir / "1024_read.json").touch()
+        # Format: {blocksize}_{numjobs}_{operation}.json
+        (self.vis_dir / "16384_1_read.json").touch()
+        (self.vis_dir / "1024_1_read.json").touch()
 
         output_dir = f"{self.temp_dir}/output"
 
@@ -128,8 +131,8 @@ class TestReportGenerator(unittest.TestCase):
         sorted_paths = generator._sort_list_of_paths(paths, index=0)
 
         # Should be sorted by blocksize: 1024, 4096, 8192, 16384
-        self.assertTrue(str(sorted_paths[0]).endswith("1024_read.json"))
-        self.assertTrue(str(sorted_paths[-1]).endswith("16384_read.json"))
+        self.assertTrue(str(sorted_paths[0]).endswith("1024_1_read.json"))
+        self.assertTrue(str(sorted_paths[-1]).endswith("16384_1_read.json"))
 
     def test_generate_plot_directory_name(self) -> None:
         """Test generating unique plot directory name"""

--- a/tests/test_simple_report_generator.py
+++ b/tests/test_simple_report_generator.py
@@ -27,7 +27,8 @@ class TestSimpleReportGenerator(unittest.TestCase):
         self.vis_dir.mkdir(parents=True)
 
         # Create test data files
-        (self.vis_dir / "4096_read.json").touch()
+        # Format: {blocksize}_{numjobs}_{operation}.json
+        (self.vis_dir / "4096_1_read.json").touch()
 
     def tearDown(self) -> None:
         """Clean up test fixtures"""
@@ -85,8 +86,9 @@ class TestSimpleReportGenerator(unittest.TestCase):
     def test_find_and_sort_file_paths(self) -> None:
         """Test finding and sorting file paths"""
         # Create multiple files
-        (self.vis_dir / "8192_write.json").touch()
-        (self.vis_dir / "16384_read.json").touch()
+        # Format: {blocksize}_{numjobs}_{operation}.json
+        (self.vis_dir / "8192_1_write.json").touch()
+        (self.vis_dir / "16384_1_read.json").touch()
 
         output_dir = f"{self.temp_dir}/output"
 
@@ -99,7 +101,7 @@ class TestSimpleReportGenerator(unittest.TestCase):
 
         self.assertEqual(len(paths), 3)
         # Should be sorted by blocksize
-        self.assertTrue(str(paths[0]).endswith("4096_read.json"))
+        self.assertTrue(str(paths[0]).endswith("4096_1_read.json"))
 
 
 # Made with Bob


### PR DESCRIPTION
Previously the post_processing modules could handle multiple iodepth values, but only a single value for numjobs.

This update adds support for multiply numjobs values for both a simple report (a single run) or a comparison report of 2 or  more runs. For data that has already been post-processed the intermediate files will need to be re-generated using the --force-refresh option to either create_performance_report.py or create_comparison_performance_report.py

### AI Use

IBM Bob was used to generate some new unit tests for this code, and to help re-factor the existing code to make it more readable. All code was human-checked.

# Testing

Several test reports were generated with multiple numjobs values. The [comparison report](https://github.com/user-attachments/files/27161888/comparitive_performance_report_260428_085745.pdf) uses the same dataset, to compare to itself, hence the single line on the plots. This was done to test the format and sections within the report, rather than to test data plotting as we already know this works from previous testing.

For the simple report a run with [multiple numjobs values](https://github.com/user-attachments/files/27161924/performance_report_260427_113328.pdf), and a report with a [single numjobs value](https://github.com/user-attachments/files/27164746/performance_report_260428_124221.pdf) were tested.

## Unit Tests

Finally the unit tests were run:

```
============================================================================ slowest 5 durations ============================================================================
0.11s call     tests/test_directory_comparison_plotter.py::TestDirectoryComparisonPlotter::test_draw_and_save_adds_legend
0.03s call     tests/test_report.py::TestReport::test_generate_with_intermediate_file_creation
0.01s call     tests/test_simple_plotter.py::TestSimplePlotter::test_draw_and_save_multiple_files
0.01s setup    tests/test_bm_rbdfio.py::TestBenchmarkrbdfio::test_valid__base_archive_directory
0.01s setup    tests/test_bm_cephtestrados.py::TestBenchmarkcephtestrados::test_valid__base_archive_directory
================================================================ 615 passed, 3 skipped, 21 warnings in 1.02s ================================================================
```

The warnings are all to do with functions in the environment that will be deprecated in future releases, and nothing to do with the code under test

```
============================================================================= warnings summary ==============================================================================
ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:64
  /home/harriscr/cbt/ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:64: DeprecationWarning: 'oneOf' deprecated - use 'one_of'
    prop = Group((name + Suppress("=") + comma_separated(value)) | oneOf(_CONSTANTS))

ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:85
ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:85
ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:85
ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:85
ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:85
ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:85
  /home/harriscr/cbt/ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:85: DeprecationWarning: 'parseString' deprecated - use 'parse_string'
    parse = parser.parseString(pattern)

ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:89
ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:89
ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:89
ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:89
ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:89
ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:89
  /home/harriscr/cbt/ceph.venv/lib64/python3.9/site-packages/matplotlib/_fontconfig_pattern.py:89: DeprecationWarning: 'resetCache' deprecated - use 'reset_cache'
    parser.resetCache()

ceph.venv/lib64/python3.9/site-packages/matplotlib/_mathtext.py:45
  /home/harriscr/cbt/ceph.venv/lib64/python3.9/site-packages/matplotlib/_mathtext.py:45: DeprecationWarning: 'enablePackrat' deprecated - use 'enable_packrat'
    ParserElement.enablePackrat()

tests/test_directory_comparison_plotter.py::TestDirectoryComparisonPlotter::test_draw_and_save_adds_legend
tests/test_directory_comparison_plotter.py::TestDirectoryComparisonPlotter::test_draw_and_save_adds_legend
tests/test_directory_comparison_plotter.py::TestDirectoryComparisonPlotter::test_draw_and_save_adds_legend
tests/test_directory_comparison_plotter.py::TestDirectoryComparisonPlotter::test_draw_and_save_adds_legend
tests/test_directory_comparison_plotter.py::TestDirectoryComparisonPlotter::test_draw_and_save_adds_legend
tests/test_directory_comparison_plotter.py::TestDirectoryComparisonPlotter::test_draw_and_save_adds_legend
tests/test_directory_comparison_plotter.py::TestDirectoryComparisonPlotter::test_draw_and_save_adds_legend
  /home/harriscr/cbt/ceph.venv/lib64/python3.9/site-packages/matplotlib/backends/_backend_tk.py:754: DeprecationWarning: 'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)
    return Image.fromarray(image_data, mode="RGBA")

```
