### PR TITLE
Error handling: Report YAML pars errors and continue if error setting

### DIFF
--- a/common.py
+++ b/common.py
@@ -172,7 +172,9 @@ def get_localnode(nodes):
         return None
     return getLocalhost(nodes_list[0])
 
-def sh(local_node, command, continue_if_error=True):
+def sh(local_node, command, continue_if_error=None):
+    if continue_if_error is None:
+        continue_if_error = settings.common.get("pdsh_continue_on_error", True)
     return CheckedPopenLocal(local_node, join_nostr(command),
                              continue_if_error=continue_if_error, shell=True)
 

--- a/example/example-client_endpoints.yaml
+++ b/example/example-client_endpoints.yaml
@@ -1,3 +1,7 @@
+common:
+  # Control whether pdsh continues on error (default: true)
+  # Set to false to fail immediately if any host fails
+  pdsh_continue_on_error: true
 cluster:
   user: 'perf'
   head: "incerta01"

--- a/example/example-report_generation.yaml
+++ b/example/example-report_generation.yaml
@@ -1,3 +1,8 @@
+common:
+  # Control whether pdsh continues on error (default: true)
+  # Set to false to fail immediately if any host fails
+  pdsh_continue_on_error: true
+
 cluster:
   user: 'perf'
   head: "incerta01"

--- a/settings.py
+++ b/settings.py
@@ -5,6 +5,8 @@ import os
 import socket
 import logging
 
+from yaml.scanner import ScannerError
+
 
 logger = logging.getLogger("cbt")
 
@@ -33,6 +35,8 @@ def initialize(ctx):
     try:
         with open(ctx.config_file) as f:
             config = yaml.safe_load(f)
+    except ScannerError as s:
+        raise argparse.ArgumentTypeError(f"Malformed YAML file was used. Error was:\n {s.problem} in file {s.problem_mark.name}")
     except IOError as e:
         raise argparse.ArgumentTypeError(str(e))
 


### PR DESCRIPTION
This PR addresses 2 weaknesses in CBT error handling:
1. When there is a malformed CBT yaml, CBT will exit without any helpful error message as to where the error in the file is.
2. There is no configuration setting to chaneg the value for continue-if-error when calling the underlying PDSH methods.

for 1. the YAML parsing exception is caught and reported to the user which allows them to see exactly where the error in their file is and fix it before trying again.

The problem for 2 was found when the FIO process running during a test was crashing, or never starting. The only way that we could figure out what went wrong was by oddities in the response curves from the benchmark run and them nonitoring the individual processes on the system as the benchmark was running via CBT. It would be better to have a setting to stop on error to allow quicker and more efficient debugging of issues like this. The pdsh helper methods aready support this, but there was no way to change the behaviour. A setting has been added to the common section of the yaml. 2 of the example files have been updated to show this new setting as well. There is potentially more that can be done in this area in the future, but this addresses our current pain-point.

An example output for a malformed yaml:
```
Traceback (most recent call last):
  File "cbt/./cbt.py", line 100, in <module>
    exit(main(sys.argv))
         ~~~~^^^^^^^^^^
  File "cbt/./cbt.py", line 45, in main
    settings.initialize(ctx)
    ~~~~~~~~~~~~~~~~~~~^^^^^
  File "cbt/settings.py", line 37, in initialize
    config = yaml.safe_load(f)
  File "/usr/lib64/python3.14/site-packages/yaml/__init__.py", line 125, in safe_load
    return load(stream, SafeLoader)
  File "/usr/lib64/python3.14/site-packages/yaml/__init__.py", line 81, in load
    return loader.get_single_data()
           ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.14/site-packages/yaml/constructor.py", line 49, in get_single_data
    node = self.get_single_node()
  File "/usr/lib64/python3.14/site-packages/yaml/composer.py", line 39, in get_single_node
    if not self.check_event(StreamEndEvent):
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/site-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
                         ~~~~~~~~~~^^
  File "/usr/lib64/python3.14/site-packages/yaml/parser.py", line 171, in parse_document_start
    raise ParserError(None, None,
    ...<2 lines>...
            self.peek_token().start_mark)
yaml.parser.ParserError: expected '<document start>', but found '<block mapping start>'
  in "malformed.yaml", line 31, column 1
```